### PR TITLE
Echidna: Adds tests for Module invariants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,15 @@ testModule: ## Run Module tests
 	@forge test -vvv --match-contract "Module" --no-match-contract "Manager"
 
 # -----------------------------------------------------------------------------
+# Property-Based Tests
+
+CRYTIC_ARGS = --crytic-args "--compile-force-framework foundry"
+
+.PHONY: ptestModule
+ptestModule: ## Run Module property-based tests (requires echidna)
+	@echidna-test . --contract "ModuleInvariants" $(CRYTIC_ARGS)
+
+# -----------------------------------------------------------------------------
 # Static Analyzers
 
 .PHONY: analyze-slither

--- a/src/modules/base/Module.sol
+++ b/src/modules/base/Module.sol
@@ -94,6 +94,7 @@ abstract contract Module is IModule, ProposalStorage, PausableUpgradeable {
     function __Module_init(IProposal proposal_) internal onlyInitializing {
         __Pausable_init();
 
+        // @todo mp: Disallow address(this)?
         if (address(proposal_) == address(0)) {
             revert Module__InvalidProposalAddress();
         }
@@ -126,6 +127,10 @@ abstract contract Module is IModule, ProposalStorage, PausableUpgradeable {
 
     /// @inheritdoc IModule
     function pause() external override (IModule) onlyAuthorized {
+        // @audit @todo WARNING
+        // Added the following statement to make enchidna fail.
+        // Be sure to remove it again ;)
+        __Module_proposal = IProposal(address(1));
         _triggerProposalCallback(
             abi.encodeWithSignature("__Module_pause()"), Types.Operation.Call
         );

--- a/test/modules/base/ModuleInvariants.sol
+++ b/test/modules/base/ModuleInvariants.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+// SuT
+import {Module} from "src/modules/base/Module.sol";
+
+// Mocks
+import {ProposalMock} from "test/utils/mocks/proposal/ProposalMock.sol";
+import {AuthorizerMock} from "test/utils/mocks/AuthorizerMock.sol";
+
+contract ModuleInvariants is Module {
+    // Mocks
+    ProposalMock proposalMock;
+    AuthorizerMock authorizerMock;
+
+    uint counter;
+
+    constructor() {
+        authorizerMock = new AuthorizerMock();
+        authorizerMock.setAllAuthorized(true);
+
+        proposalMock = new ProposalMock(authorizerMock);
+
+        // Has to be in own function to apply `initializer` modifier.
+        _initModule();
+
+        // Initialize proposal to enable module.
+        address[] memory modules = new address[](1);
+        modules[0] = address(this);
+        proposalMock.init(modules);
+    }
+
+    function _initModule() internal initializer {
+        __Module_init(proposalMock);
+    }
+
+    function echidna_proposal_variable_not_mutated_after_initialization()
+        public
+        returns (bool)
+    {
+        return address(__Module_proposal) == address(proposalMock);
+    }
+}


### PR DESCRIPTION
This PR is a (currently non-working) WIP to add echidna property-based testing to the project.

I started by trying to test the `Module.sol` invariant that the module's proposal should never change after initialization (effectively saying it is `immutable`).

Feel free to commit to this branch if you made any progress :)