### PR TITLE
Add mandatory ERC20 PaymentToken to Proposal

### DIFF
--- a/src/factories/ProposalFactory.sol
+++ b/src/factories/ProposalFactory.sol
@@ -12,6 +12,8 @@ import {IProposal} from "src/interfaces/IProposal.sol";
 import {IModule} from "src/interfaces/IModule.sol";
 import {IModuleFactory} from "src/interfaces/IModuleFactory.sol";
 import {IProposalFactory} from "src/interfaces/IProposalFactory.sol";
+
+// External Interfaces
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 /**
@@ -57,7 +59,7 @@ contract ProposalFactory is IProposalFactory {
         IModule.Metadata memory paymentProcessorMetadata,
         bytes memory paymentProcessorConfigdata,
         // Payment token
-        address paymentToken,
+        IERC20 token,
         // Other module data
         IModule.Metadata[] memory moduleMetadatas,
         bytes[] memory moduleConfigdatas
@@ -97,7 +99,7 @@ contract ProposalFactory is IProposalFactory {
             modules,
             IAuthorizer(authorizer),
             IPaymentProcessor(paymentProcessor),
-            IERC20(paymentToken)
+            IERC20(token)
         );
 
         return clone;

--- a/src/interfaces/IProposal.sol
+++ b/src/interfaces/IProposal.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.0;
 
+// Internal Interfaces
 import {IAuthorizer} from "src/interfaces/IAuthorizer.sol";
 import {IPaymentProcessor} from "src/interfaces/IPaymentProcessor.sol";
 import {IModuleManager} from "src/interfaces/IModuleManager.sol";
+
+// External Interfaces
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 interface IProposal is IModuleManager {
@@ -20,7 +23,7 @@ interface IProposal is IModuleManager {
     error Proposal__InvalidPaymentProcessor();
 
     /// @notice Given {IERC20} instance invalid.
-    error Proposal__InvalidPaymentToken();
+    error Proposal__InvalidToken();
 
     /// @notice Execution of transaction failed.
     error Proposal__ExecuteTxFailed();
@@ -37,7 +40,7 @@ interface IProposal is IModuleManager {
         address[] calldata modules, // @todo mp: Change to IModules.
         IAuthorizer authorizer,
         IPaymentProcessor paymentProcessor,
-        IERC20 paymentToken
+        IERC20 token
     ) external;
 
     /// @notice Executes a call on target `target` with call data `data`.
@@ -57,7 +60,7 @@ interface IProposal is IModuleManager {
     function paymentProcessor() external view returns (IPaymentProcessor);
 
     /// @notice The {IERC20} token used for payouts.
-    function paymentToken() external view returns (IERC20);
+    function token() external view returns (IERC20);
 
     /// @notice The version of the proposal instance.
     function version() external pure returns (string memory);

--- a/src/interfaces/IProposalFactory.sol
+++ b/src/interfaces/IProposalFactory.sol
@@ -5,6 +5,9 @@ pragma solidity ^0.8.0;
 import {IProposal} from "src/interfaces/IProposal.sol";
 import {IModule} from "src/interfaces/IModule.sol";
 
+// External Interfaces
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+
 interface IProposalFactory {
     error ProposalFactory__ModuleDataLengthMismatch();
 
@@ -17,7 +20,7 @@ interface IProposalFactory {
         bytes memory authorizerConfigdata,
         IModule.Metadata memory paymentProcessorMetadata,
         bytes memory paymentProcessorConfigdata,
-        address paymentToken,
+        IERC20 token,
         IModule.Metadata[] memory moduleMetadatas,
         bytes[] memory moduleConfigdatas
     ) external returns (address);

--- a/src/modules/SimplePaymentClient.sol
+++ b/src/modules/SimplePaymentClient.sol
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+// External Dependencies
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 
 // Internal Dependencies
 import {Types} from "src/common/Types.sol";
 import {Module} from "src/modules/base/Module.sol";
 import {PaymentClient} from "src/modules/PaymentClient.sol";
+
+// External Interfces
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 contract SimplePaymentClient is PaymentClient, Module {
     using SafeERC20 for IERC20;
@@ -124,14 +127,12 @@ contract SimplePaymentClient is PaymentClient, Module {
         /// @question: Do we want to structure this function also with triggerProposalCallback etc ? It would basically force us to send the PaymentOrders[] around as bytes32  in the call returns and parse them again at the end...
 
         PaymentOrder[] memory processOrders = paymentOrders;
-        
+
         // Cache payment token.
-        IERC20 paymentToken = __Module_proposal.paymentToken();
+        IERC20 token = __Module_proposal.token();
 
         for (uint i; i < processOrders.length; i++) {
-            paymentToken.safeIncreaseAllowance(
-                _msgSender(), processOrders[i].amount
-            );
+            token.safeIncreaseAllowance(_msgSender(), processOrders[i].amount);
         }
 
         delete paymentOrders;

--- a/src/proposal/Proposal.sol
+++ b/src/proposal/Proposal.sol
@@ -13,6 +13,8 @@ import {ModuleManager} from "src/proposal/base/ModuleManager.sol";
 import {IProposal} from "src/interfaces/IProposal.sol";
 import {IPaymentProcessor} from "src/interfaces/IPaymentProcessor.sol";
 import {IAuthorizer} from "src/interfaces/IAuthorizer.sol";
+
+// External Interfaces
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 contract Proposal is IProposal, ModuleManager, PausableUpgradeable {
@@ -43,7 +45,7 @@ contract Proposal is IProposal, ModuleManager, PausableUpgradeable {
     /// @inheritdoc IProposal
     IPaymentProcessor public override (IProposal) paymentProcessor;
 
-    IERC20 public paymentToken;
+    IERC20 public token;
 
     //--------------------------------------------------------------------------
     // Initializer
@@ -54,14 +56,15 @@ contract Proposal is IProposal, ModuleManager, PausableUpgradeable {
     //    _disableInitializers();
     //}
 
+    /// @inheritdoc IProposal
     function init(
         uint proposalId,
         address[] calldata funders,
         address[] calldata modules,
         IAuthorizer authorizer_,
         IPaymentProcessor paymentProcessor_,
-        IERC20 paymentToken_
-    ) external initializer {
+        IERC20 token_
+    ) external override (IProposal) initializer {
         _proposalId = proposalId;
         _funders = funders;
 
@@ -80,10 +83,10 @@ contract Proposal is IProposal, ModuleManager, PausableUpgradeable {
         }
         paymentProcessor = paymentProcessor_;
 
-        if (address(paymentToken_) == address(0)) {
-            revert Proposal__InvalidPaymentToken();
+        if (address(token_) == address(0)) {
+            revert Proposal__InvalidToken();
         }
-        paymentToken = paymentToken_;
+        token = token_;
     }
 
     //--------------------------------------------------------------------------

--- a/test/factories/ProposalFactory.t.sol
+++ b/test/factories/ProposalFactory.t.sol
@@ -10,6 +10,8 @@ import {ProposalFactory} from "src/factories/ProposalFactory.sol";
 import {IProposalFactory} from "src/interfaces/IProposalFactory.sol";
 import {IModule} from "src/interfaces/IModule.sol";
 import {IProposal} from "src/interfaces/IProposal.sol";
+
+// External Interfaces
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 // Mocks
@@ -61,7 +63,7 @@ contract ProposalFactoryTest is Test {
         }
 
         // Create a mock payment Token
-        ERC20Mock paymentToken = new ERC20Mock("TestToken", "TST");
+        ERC20Mock token = new ERC20Mock("TestToken", "TST");
 
         // Deploy Proposal with id=1
         ProposalMock proposal = ProposalMock(
@@ -71,7 +73,7 @@ contract ProposalFactoryTest is Test {
                 authorizerConfigdata: bytes("Authorizer"),
                 paymentProcessorMetadata: IModule.Metadata(1, "PaymentProcessor"),
                 paymentProcessorConfigdata: bytes("PaymentProcessor"),
-                paymentToken: address(paymentToken),
+                token: token,
                 moduleMetadatas: metadatas,
                 moduleConfigdatas: configdatas
             })
@@ -86,7 +88,7 @@ contract ProposalFactoryTest is Test {
                 authorizerConfigdata: bytes("Authorizer"),
                 paymentProcessorMetadata: IModule.Metadata(1, "PaymentProcessor"),
                 paymentProcessorConfigdata: bytes("PaymentProcessor"),
-                paymentToken: address(paymentToken),
+                token: token,
                 moduleMetadatas: metadatas,
                 moduleConfigdatas: configdatas
             })
@@ -113,7 +115,7 @@ contract ProposalFactoryTest is Test {
         configdatas[modulesLen] = bytes("");
 
         // Create a mock payment Token
-        ERC20Mock paymentToken = new ERC20Mock("TestToken", "TST");
+        ERC20Mock token = new ERC20Mock("TestToken", "TST");
 
         vm.expectRevert(
             IProposalFactory.ProposalFactory__ModuleDataLengthMismatch.selector
@@ -124,7 +126,7 @@ contract ProposalFactoryTest is Test {
             authorizerConfigdata: bytes("Authorizer"),
             paymentProcessorMetadata: IModule.Metadata(1, "PaymentProcessor"),
             paymentProcessorConfigdata: bytes("PaymentProcessor"),
-            paymentToken: address(paymentToken),
+            token: token,
             moduleMetadatas: metadatas,
             moduleConfigdatas: configdatas
         });

--- a/test/proposal/Proposal.t.sol
+++ b/test/proposal/Proposal.t.sol
@@ -10,7 +10,10 @@ import {Proposal} from "src/proposal/Proposal.sol";
 import {IProposal} from "src/interfaces/IProposal.sol";
 import {IAuthorizer} from "src/interfaces/IAuthorizer.sol";
 import {IPaymentProcessor} from "src/interfaces/IPaymentProcessor.sol";
+
+// External Interfaces
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+
 // Helpers
 import {FuzzInputChecker} from "test/proposal/helper/FuzzInputChecker.sol";
 
@@ -29,12 +32,12 @@ contract ProposalTest is Test, FuzzInputChecker {
     // Mocks
     AuthorizerMock authorizer;
     PaymentProcessorMock paymentProcessor;
-    ERC20Mock paymentToken;
+    ERC20Mock token;
 
     function setUp() public {
         authorizer = new AuthorizerMock();
         paymentProcessor = new PaymentProcessorMock();
-        paymentToken = new ERC20Mock("TestToken", "TST");
+        token = new ERC20Mock("TestToken", "TST");
 
         proposal = new Proposal();
     }
@@ -57,12 +60,7 @@ contract ProposalTest is Test, FuzzInputChecker {
 
         // Initialize proposal.
         proposal.init(
-            proposalId,
-            funders,
-            modules,
-            authorizer,
-            paymentProcessor,
-            paymentToken
+            proposalId, funders, modules, authorizer, paymentProcessor, token
         );
 
         // Check that proposal's storage correctly initialized.
@@ -70,7 +68,7 @@ contract ProposalTest is Test, FuzzInputChecker {
         assertEq(
             address(proposal.paymentProcessor()), address(paymentProcessor)
         );
-        assertEq(address(proposal.paymentToken()), address(paymentToken));
+        assertEq(address(proposal.token()), address(token));
     }
 
     function testReinitFails(
@@ -88,22 +86,12 @@ contract ProposalTest is Test, FuzzInputChecker {
 
         // Initialize proposal.
         proposal.init(
-            proposalId,
-            funders,
-            modules,
-            authorizer,
-            paymentProcessor,
-            paymentToken
+            proposalId, funders, modules, authorizer, paymentProcessor, token
         );
 
         vm.expectRevert(OZErrors.Initializable__AlreadyInitialized);
         proposal.init(
-            proposalId,
-            funders,
-            modules,
-            authorizer,
-            paymentProcessor,
-            paymentToken
+            proposalId, funders, modules, authorizer, paymentProcessor, token
         );
     }
 
@@ -121,12 +109,7 @@ contract ProposalTest is Test, FuzzInputChecker {
 
         vm.expectRevert(IProposal.Proposal__InvalidAuthorizer.selector);
         proposal.init(
-            proposalId,
-            funders,
-            modules,
-            authorizer,
-            paymentProcessor,
-            paymentToken
+            proposalId, funders, modules, authorizer, paymentProcessor, token
         );
     }
 
@@ -144,12 +127,7 @@ contract ProposalTest is Test, FuzzInputChecker {
 
         vm.expectRevert(IProposal.Proposal__InvalidPaymentProcessor.selector);
         proposal.init(
-            proposalId,
-            funders,
-            modules,
-            authorizer,
-            paymentProcessor,
-            paymentToken
+            proposalId, funders, modules, authorizer, paymentProcessor, token
         );
     }
 
@@ -166,10 +144,7 @@ contract ProposalTest is Test, FuzzInputChecker {
         modules[modules.length - 1] = address(authorizer);
         modules[modules.length - 2] = address(paymentProcessor);
 
-        // Create invalid Token
-        //paymentToken = new PERC20Mock();
-
-        vm.expectRevert(IProposal.Proposal__InvalidPaymentToken.selector);
+        vm.expectRevert(IProposal.Proposal__InvalidToken.selector);
         proposal.init(
             proposalId,
             funders,

--- a/test/utils/mocks/proposal/ProposalMock.sol
+++ b/test/utils/mocks/proposal/ProposalMock.sol
@@ -4,18 +4,21 @@ pragma solidity ^0.8.0;
 // Mock Dependencies
 import {ModuleManagerMock} from "./base/ModuleManagerMock.sol";
 
+// External Dependencies
+import {Initializable} from "@oz-up/proxy/utils/Initializable.sol";
+
 // Internal Interfaces
 import {IProposal} from "src/interfaces/IProposal.sol";
 import {IPaymentProcessor} from "src/interfaces/IPaymentProcessor.sol";
 import {IAuthorizer} from "src/interfaces/IAuthorizer.sol";
-import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
-import {Initializable} from "@oz-up/proxy/utils/Initializable.sol";
+// External Interfaces
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 contract ProposalMock is IProposal, ModuleManagerMock {
     IAuthorizer public authorizer;
     IPaymentProcessor public paymentProcessor;
-    IERC20 public paymentToken;
+    IERC20 public token;
 
     uint public proposalId;
     address[] public funders;
@@ -32,14 +35,14 @@ contract ProposalMock is IProposal, ModuleManagerMock {
         address[] calldata modules_,
         IAuthorizer authorizer_,
         IPaymentProcessor paymentProcessor_,
-        IERC20 paymentToken_
+        IERC20 token_
     ) external {
         proposalId = proposalId_;
         funders = funders_;
         modules = modules_;
         authorizer = authorizer_;
         paymentProcessor = paymentProcessor_;
-        paymentToken = paymentToken_;
+        token = token_;
     }
 
     function executeTx(address target, bytes memory data)


### PR DESCRIPTION
Adds a mandatory ERC20 token for payouts to the proposal. 
Also uncomments some functions in SimplePaymentProcessor now that the referenced variables exist in the main Proposal contract.  