### PR TITLE
Reintroduce Vesting Payment

### DIFF
--- a/src/modules/MetadataManager.sol
+++ b/src/modules/MetadataManager.sol
@@ -34,7 +34,7 @@ contract MetadataManager is IMetadataManager, Module {
         IProposal proposal_,
         Metadata memory metadata,
         bytes memory configdata
-    ) external override (Module) initializer {
+    ) external override(Module) initializer {
         __Module_init(proposal_, metadata);
 
         (

--- a/src/modules/MilestoneManager.sol
+++ b/src/modules/MilestoneManager.sol
@@ -141,7 +141,7 @@ contract MilestoneManager is IMilestoneManager, Module, PaymentClient {
         IProposal proposal_,
         Metadata memory metadata,
         bytes memory /*configdata*/
-    ) external override (Module) initializer {
+    ) external override(Module) initializer {
         __Module_init(proposal_, metadata);
 
         // Set up empty list of milestones.
@@ -459,7 +459,7 @@ contract MilestoneManager is IMilestoneManager, Module, PaymentClient {
 
     function _ensureTokenBalance(uint amount)
         internal
-        override (PaymentClient)
+        override(PaymentClient)
     {
         uint balance = __Module_proposal.token().balanceOf(address(this));
 
@@ -484,7 +484,7 @@ contract MilestoneManager is IMilestoneManager, Module, PaymentClient {
 
     function _ensureTokenAllowance(IPaymentProcessor spender, uint amount)
         internal
-        override (PaymentClient)
+        override(PaymentClient)
     {
         IERC20 token = __Module_proposal.token();
         uint allowance = token.allowance(address(this), address(spender));
@@ -497,7 +497,7 @@ contract MilestoneManager is IMilestoneManager, Module, PaymentClient {
     function _isAuthorizedPaymentProcessor(IPaymentProcessor who)
         internal
         view
-        override (PaymentClient)
+        override(PaymentClient)
         returns (bool)
     {
         return __Module_proposal.paymentProcessor() == who;

--- a/src/modules/PaymentProcessor.sol
+++ b/src/modules/PaymentProcessor.sol
@@ -34,7 +34,7 @@ contract PaymentProcessor is Module, IPaymentProcessor {
         IProposal proposal_,
         Metadata memory metadata,
         bytes memory /*configdata*/
-    ) external override (Module) initializer {
+    ) external override(Module) initializer {
         __Module_init(proposal_, metadata);
     }
 

--- a/src/modules/VestingPaymentProcessor.sol
+++ b/src/modules/VestingPaymentProcessor.sol
@@ -112,15 +112,7 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
     ///         In OZ VestingWallet this method is named release().
     function claim(IPaymentClient client) external {
         if (vestings[msg.sender]._enabled) {
-            uint amount = releasable(msg.sender);
-            vestings[msg.sender]._released += amount;
-
-            // Cache token.
-            IERC20 token_ = token();
-
-            emit ERC20Released(address(token_), amount);
-
-            token_.safeTransferFrom(address(client), msg.sender, amount);
+            _claim(client, msg.sender);
         }
     }
 
@@ -132,7 +124,7 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
         (orders, totalAmount) = client.collectPaymentOrders();
 
         // Cache token.
-        IERC20 token_ = token();
+        //IERC20 token_ = token();
 
         // Generate Vesting Payments for all orders
         address _recipient;
@@ -145,88 +137,23 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
             _start = orders[i].createdAt;
             _duration = (orders[i].dueTo - _start);
 
-            addPayment(_recipient, _amount, _start, _duration);
-        }
-    }
+            //check if running payment order exists. If it does, remove it
+            if (start(_recipient) != 0) {
+                _removePayment(client, _recipient);
+            }
 
-    /// @notice Adds a new payment containing the details of the monetary flow
-    ///         depending on the module.
-    /// @param _contributor Contributor's address.
-    /// @param _salary Salary contributor will receive per epoch.
-    /// @param _start Start vesting timestamp.
-    /// @param _duration Vesting duration timestamp.
-    function addPayment(
-        address _contributor,
-        uint _salary,
-        uint _start,
-        uint _duration
-    )
-        internal
-        validSalary(_salary)
-        validStart(_start)
-        validDuration(_start, _duration)
-    {
-        if (!validAddress(_contributor)) {
-            revert Module__PaymentManager__InvalidContributor();
-        }
-
-        // @todo Nejc: Verify there's enough tokens in proposal for the payment.
-        // @todo Nejc: before adding payment make sure contributor is wListed.
-
-        if (
-            block.timestamp
-                < (vestings[_contributor]._start + vestings[_contributor]._duration)
-        ) {
-            //there is a running payment, update
-            
-            //@todo releasable() stays the same, we distribute the remaining amounts over the new schedule (bigger one of the end dates)
-
-            vestings[_contributor]._salary += _salary;
-
-            uint newEndDate = _start + _duration;
-
-            vestings[_contributor]._duration = newEndDate;
-
-            emit PaymentUpdated(_contributor, _salary, newEndDate);
-        } else if (
-            (block.timestamp
-                > (vestings[_contributor]._start + vestings[_contributor]._duration)) && 
-                (releasable(_contributor) != 0)
-                
-            ) {
-            //there's a finished unclaimed payment, add them to the new one as claimable
-
-            //actually this should be merged with the one above
-        } else {
-            //there's no payment, create new one
-
-            vestings[_contributor] =
-                VestingWallet(_salary, 0, _start, _duration, true);
-
-            emit PaymentAdded(_contributor, _salary, _start, _duration);
+            _addPayment(_recipient, _amount, _start, _duration);
         }
     }
 
     /// @notice Deletes a contributors payment and refunds non-released tokens
     ///         to proposal owner.
     /// @param contributor Contributor's address.
-    function removePayment(address contributor)
+    function removePayment(IPaymentClient client, address contributor)
         external
-        onlyAuthorized // only proposal owner
+        onlyAuthorized
     {
-        // @noto Nejc: withdraw tokens that were not withdrawn yet.
-        uint unclaimedAmount = vestedAmount(uint(block.timestamp), contributor)
-            - released(contributor);
-        if (unclaimedAmount > 0) {
-            delete vestings[contributor];
-
-            // Cache token.
-            IERC20 token_ = token();
-
-            token_.safeTransfer(msg.sender, unclaimedAmount);
-
-            emit PaymentRemoved(contributor);
-        }
+        _removePayment(client, contributor);
     }
 
     /// @notice Disable a payment of a contributor.
@@ -288,7 +215,7 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
         view
         returns (uint)
     {
-        return _vestingSchedule(vestings[contributor]._salary, timestamp);
+        return _vestingSchedule(contributor, timestamp);
     }
 
     /// @notice Getter for the amount of releasable tokens.
@@ -304,24 +231,90 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
     //--------------------------------------------------------------------------
     // Internal Functions
 
+    function _removePayment(IPaymentClient client, address contributor)
+        internal
+    {
+        //we send the funds the contributor has a right to.
+        _claim(client, contributor);
+
+        // outstanding vested funds are sent back to the proposal
+        uint unclaimedAmount = vestedAmount(uint(block.timestamp), contributor)
+            - released(contributor);
+
+        delete vestings[contributor];
+
+        if (unclaimedAmount > 0) {
+            // Cache token.
+            //IERC20 token_ = token();
+
+            //@todo: send the outstanding funds from the MilestoneManager back into proposal. Right now it just stays locked in the MilestoneManager, with nobody able to claim it. The funds should ideally return in the same way funds go back when a Milestone is cancelled.
+        }
+
+        emit PaymentRemoved(contributor);
+    }
+
+    /// @notice Adds a new payment containing the details of the monetary flow
+    ///         depending on the module.
+    /// @param _contributor Contributor's address.
+    /// @param _salary Salary contributor will receive per epoch.
+    /// @param _start Start vesting timestamp.
+    /// @param _duration Vesting duration timestamp.
+    function _addPayment(
+        address _contributor,
+        uint _salary,
+        uint _start,
+        uint _duration
+    )
+        internal
+        validSalary(_salary)
+        validStart(_start)
+        validDuration(_start, _duration)
+    {
+        if (!validAddress(_contributor)) {
+            revert Module__PaymentManager__InvalidContributor();
+        }
+
+        // @todo Nejc: Verify there's enough tokens in proposal for the payment.
+        // @todo Nejc: before adding payment make sure contributor is wListed.
+
+        vestings[_contributor] =
+            VestingWallet(_salary, 0, _start, _duration, true);
+
+        emit PaymentAdded(_contributor, _salary, _start, _duration);
+    }
+
+    function _claim(IPaymentClient client, address beneficiary) internal {
+        uint amount = releasable(beneficiary);
+        vestings[beneficiary]._released += amount;
+
+        // Cache token.
+        IERC20 token_ = token();
+
+        emit ERC20Released(address(token_), amount);
+
+        token_.safeTransferFrom(address(client), beneficiary, amount);
+    }
+
     /// @notice Virtual implementation of the vesting formula.
     ///         Returns the amount vested, as a function of time,
     ///         for an asset given its total historical allocation.
-    /// @param totalAllocation Contributor's allocated vesting amount.
+    /// @param contributor The contributor to check on.
     /// @param timestamp Current block.timestamp
-    function _vestingSchedule(uint totalAllocation, uint timestamp)
+    function _vestingSchedule(address contributor, uint timestamp)
         internal
         view
         virtual
         returns (uint)
     {
-        if (timestamp < start(msg.sender)) {
+        uint totalAllocation = vestings[contributor]._salary;
+
+        if (timestamp < start(contributor)) {
             return 0;
-        } else if (timestamp > start(msg.sender) + duration(msg.sender)) {
+        } else if (timestamp > start(contributor) + duration(contributor)) {
             return totalAllocation;
         } else {
-            return (totalAllocation * (timestamp - start(msg.sender)))
-                / duration(msg.sender);
+            return (totalAllocation * (timestamp - start(contributor)))
+                / duration(contributor);
         }
     }
 

--- a/src/modules/VestingPaymentProcessor.sol
+++ b/src/modules/VestingPaymentProcessor.sol
@@ -104,7 +104,7 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
         IProposal proposal_,
         Metadata memory metadata,
         bytes memory /*configdata*/
-    ) external override (Module) initializer {
+    ) external override(Module) initializer {
         __Module_init(proposal_, metadata);
     }
 

--- a/src/modules/VestingPaymentProcessor.sol
+++ b/src/modules/VestingPaymentProcessor.sol
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+// Internal Dependencies
+import {
+    IPaymentProcessor,
+    IPaymentClient
+} from "src/modules/IPaymentProcessor.sol";
+import {Types} from "src/common/Types.sol";
+import {Module} from "src/modules/base/Module.sol";
+import {ERC20} from "@oz/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
+
+// Interfaces
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {IProposal} from "src/proposal/IProposal.sol";
+
+/**
+ * @title Payment processor module implementation #2: Linear vesting curve.
+ *
+ * @dev The payment module handles the money flow to the contributors
+ * (e.g. how many tokens are sent to which contributor at what time).
+ *
+ * @author byterocket
+ */
+
+contract VestingPaymentProcessor is Module, IPaymentProcessor {
+    using SafeERC20 for IERC20;
+
+    //--------------------------------------------------------------------------
+    // Storage
+
+    struct VestingWallet {
+        uint _salary;
+        uint _released;
+        uint _start;
+        uint _duration;
+        bool _enabled;
+    }
+
+    // contributor => Payment
+    mapping(address => VestingWallet) private vestings;
+
+    //--------------------------------------------------------------------------
+    // Events
+
+    event PaymentAdded(address contributor, uint salary, uint start, uint end);
+    event PaymentRemoved(address contributor);
+    event PaymentPaused(address contributor);
+    event PaymentContinued(address contributor);
+    event PaymentUpdated(address contributor, uint newSalary, uint newEndDate);
+    event ERC20Released(address indexed token, uint amount);
+
+    //--------------------------------------------------------------------------
+    // Errors
+
+    /// @notice salary cannot be 0.
+    error Module__PaymentManager__InvalidSalary();
+
+    /// @notice should start in future, cant be more than 10e18.
+    error Module__PaymentManager__InvalidStart();
+
+    /// @notice duration cant overflow, cant be 0.
+    error Module__PaymentManager__InvalidDuration();
+
+    /// @notice invalid token address
+    error Module__PaymentManager__InvalidToken();
+
+    /// @notice invalid proposal address
+    error Module__PaymentManager__InvalidProposal();
+
+    /// @notice invalid contributor address
+    error Module__PaymentManager__InvalidContributor();
+
+    //--------------------------------------------------------------------------
+    // Modifiers
+
+    modifier validSalary(uint _salary) {
+        if (_salary == 0) {
+            revert Module__PaymentManager__InvalidSalary();
+        }
+        _;
+    }
+
+    modifier validStart(uint _start) {
+        if (_start < block.timestamp || _start >= type(uint).max) {
+            revert Module__PaymentManager__InvalidStart();
+        }
+        _;
+    }
+
+    modifier validDuration(uint _start, uint _duration) {
+        if (_start + _duration <= _start || _duration == 0) {
+            revert Module__PaymentManager__InvalidDuration();
+        }
+        _;
+    }
+
+    //--------------------------------------------------------------------------
+    // External Functions
+
+    /// @inheritdoc Module
+    function init(
+        IProposal proposal_,
+        Metadata memory metadata,
+        bytes memory /*configdata*/
+    ) external override (Module) initializer {
+        __Module_init(proposal_, metadata);
+    }
+
+    /// @notice Release the releasable tokens.
+    ///         In OZ VestingWallet this method is named release().
+    function claim(IPaymentClient client) external {
+        if (vestings[msg.sender]._enabled) {
+            uint amount = releasable();
+            vestings[msg.sender]._released += amount;
+
+            // Cache token.
+            IERC20 token_ = token();
+
+            emit ERC20Released(address(token_), amount);
+
+            token_.safeTransferFrom(address(client), msg.sender, amount);
+        }
+    }
+
+    /// @inheritdoc IPaymentProcessor
+    function processPayments(IPaymentClient client) external {
+        // Collect outstanding orders and their total token amount.
+        IPaymentClient.PaymentOrder[] memory orders;
+        uint totalAmount;
+        (orders, totalAmount) = client.collectPaymentOrders();
+
+        // Cache token.
+        IERC20 token_ = token();
+
+        // Generate Vesting Payments for all orders
+        address _recipient;
+        uint _amount;
+        uint _start;
+        uint _duration;
+        for (uint i; i < orders.length; i++) {
+            _recipient = orders[i].recipient;
+            _amount = orders[i].amount;
+            _start = orders[i].createdAt;
+            _duration = (orders[i].dueTo - _start);
+
+            addPayment(_recipient, _amount, _start, _duration);
+        }
+    }
+
+    /// @notice Adds a new payment containing the details of the monetary flow
+    ///         depending on the module.
+    /// @param _contributor Contributor's address.
+    /// @param _salary Salary contributor will receive per epoch.
+    /// @param _start Start vesting timestamp.
+    /// @param _duration Vesting duration timestamp.
+    function addPayment(
+        address _contributor,
+        uint _salary,
+        uint _start,
+        uint _duration
+    )
+        internal
+        validSalary(_salary)
+        validStart(_start)
+        validDuration(_start, _duration)
+    {
+        if (!validAddress(_contributor)) {
+            revert Module__PaymentManager__InvalidContributor();
+        }
+
+        // @todo Nejc: Verify there's enough tokens in proposal for the payment.
+        // @todo Nejc: before adding payment make sure contributor is wListed.
+
+        //@todo Nuggan: Update VestingWallet if there's a running payment already (just add amt + duration)
+
+        if (
+            block.timestamp
+                < (vestings[_contributor]._start + vestings[_contributor]._duration)
+        ) {
+            //there is a running payment, update
+
+            vestings[_contributor]._salary += _salary;
+
+            uint newEndDate = _start + _duration;
+
+            vestings[_contributor]._duration = newEndDate;
+
+            emit PaymentUpdated(_contributor, _salary, newEndDate);
+        } else {
+            //either there's no payment or it finished, create new one
+
+            vestings[_contributor] =
+                VestingWallet(_salary, 0, _start, _duration, true);
+
+            emit PaymentAdded(_contributor, _salary, _start, _duration);
+        }
+    }
+
+    /// @notice Deletes a contributors payment and refunds non-released tokens
+    ///         to proposal owner.
+    /// @param contributor Contributor's address.
+    function removePayment(address contributor)
+        external
+        onlyAuthorized // only proposal owner
+    {
+        // @noto Nejc: withdraw tokens that were not withdrawn yet.
+        uint unclaimedAmount = vestedAmount(uint(block.timestamp), contributor)
+            - released(contributor);
+        if (unclaimedAmount > 0) {
+            delete vestings[contributor];
+
+            // Cache token.
+            IERC20 token_ = token();
+
+            token_.safeTransfer(msg.sender, unclaimedAmount);
+
+            emit PaymentRemoved(contributor);
+        }
+    }
+
+    /// @notice Disable a payment of a contributor.
+    /// @param contributor Contributor's address.
+    function pausePayment(address contributor)
+        external
+        onlyAuthorized // only proposal owner
+    {
+        if (vestings[contributor]._enabled) {
+            vestings[contributor]._enabled = false;
+            emit PaymentPaused(contributor);
+        }
+    }
+
+    /// @notice Continue contributors paused payment.
+    ///         Tokens from paused period will be immediately claimable.
+    /// @param contributor Contributor's address.
+    function continuePayment(address contributor)
+        external
+        onlyAuthorized // only proposal owner
+    {
+        if (!vestings[contributor]._enabled) {
+            vestings[contributor]._enabled = true;
+            emit PaymentContinued(contributor);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public Functions
+
+    /// @notice Returns true if contributors vesting is enabled.
+    /// @param contributor Contributor's address.
+    function enabled(address contributor) public view returns (bool) {
+        return vestings[contributor]._enabled;
+    }
+
+    /// @notice Getter for the start timestamp.
+    /// @param contributor Contributor's address.
+    function start(address contributor) public view returns (uint) {
+        return vestings[contributor]._start;
+    }
+
+    /// @notice Getter for the vesting duration.
+    /// @param contributor Contributor's address.
+    function duration(address contributor) public view returns (uint) {
+        return vestings[contributor]._duration;
+    }
+
+    /// @notice Getter for the amount of eth already released
+    /// @param contributor Contributor's address.
+    function released(address contributor) public view returns (uint) {
+        return vestings[contributor]._released;
+    }
+
+    /// @notice Calculates the amount of tokens that has already vested.
+    /// @param contributor Contributor's address.
+    function vestedAmount(uint timestamp, address contributor)
+        public
+        view
+        returns (uint)
+    {
+        return _vestingSchedule(vestings[contributor]._salary, timestamp);
+    }
+
+    /// @notice Getter for the amount of releasable tokens.
+    function releasable() public view returns (uint) {
+        return vestedAmount(uint(block.timestamp), msg.sender)
+            - released(msg.sender);
+    }
+
+    function token() public view returns (IERC20) {
+        return this.proposal().token();
+    }
+
+    //--------------------------------------------------------------------------
+    // Internal Functions
+
+    /// @notice Virtual implementation of the vesting formula.
+    ///         Returns the amount vested, as a function of time,
+    ///         for an asset given its total historical allocation.
+    /// @param totalAllocation Contributor's allocated vesting amount.
+    /// @param timestamp Current block.timestamp
+    function _vestingSchedule(uint totalAllocation, uint timestamp)
+        internal
+        view
+        virtual
+        returns (uint)
+    {
+        if (timestamp < start(msg.sender)) {
+            return 0;
+        } else if (timestamp > start(msg.sender) + duration(msg.sender)) {
+            return totalAllocation;
+        } else {
+            return (totalAllocation * (timestamp - start(msg.sender)))
+                / duration(msg.sender);
+        }
+    }
+
+    /// @notice validate address input.
+    /// @param addr Address to validate.
+    /// @return True if address is valid.
+    function validAddress(address addr) internal view returns (bool) {
+        if (addr == address(0) || addr == msg.sender || addr == address(this)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/modules/VestingPaymentProcessor.sol
+++ b/src/modules/VestingPaymentProcessor.sol
@@ -70,6 +70,9 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
     /// @notice invalid contributor address
     error Module__PaymentManager__InvalidContributor();
 
+    /// @notice insufficient tokens in the client to do payments
+    error Module__PaymentManager__InsufficientTokenBalanceInClient();
+
     //--------------------------------------------------------------------------
     // Modifiers
 
@@ -124,6 +127,10 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
         (orders, totalAmount) = client.collectPaymentOrders();
 
         // @todo would we want to hardcode a check here that Balance(client) >= totalAmount ? in our case, collectPaymentOrders() does it already, but you maybe other clients won't...
+
+        if (token().balanceOf(address(client)) < totalAmount) {
+            revert Module__PaymentManager__InsufficientTokenBalanceInClient();
+        }
 
         // Generate Vesting Payments for all orders
         address _recipient;

--- a/src/modules/VestingPaymentProcessor.sol
+++ b/src/modules/VestingPaymentProcessor.sol
@@ -159,8 +159,8 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
         }
     }
 
-    /// @notice Deletes a contributors payment and refunds non-released tokens
-    ///         to proposal owner.
+    /// @notice Deletes a contributors payment and leaves non-released tokens
+    ///         in the PaymentClient.
     /// @param contributor Contributor's address.
     function removePayment(IPaymentClient client, address contributor)
         external
@@ -168,6 +168,8 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
     {
         _removePayment(client, contributor);
     }
+
+    // @todo see issue 
 
     /// @notice Disable a payment of a contributor.
     /// @param contributor Contributor's address.

--- a/src/modules/VestingPaymentProcessor.sol
+++ b/src/modules/VestingPaymentProcessor.sol
@@ -169,7 +169,7 @@ contract VestingPaymentProcessor is Module, IPaymentProcessor {
         _removePayment(client, contributor);
     }
 
-    // @todo see issue 
+    // @todo see issue
 
     /// @notice Disable a payment of a contributor.
     /// @param contributor Contributor's address.

--- a/src/modules/base/Module.sol
+++ b/src/modules/base/Module.sol
@@ -161,12 +161,12 @@ abstract contract Module is IModule, ProposalStorage, PausableUpgradeable {
     // API functions for authenticated users.
 
     /// @inheritdoc IModule
-    function pause() external override (IModule) onlyAuthorizedOrOwner {
+    function pause() external override(IModule) onlyAuthorizedOrOwner {
         _pause();
     }
 
     /// @inheritdoc IModule
-    function unpause() external override (IModule) onlyAuthorizedOrOwner {
+    function unpause() external override(IModule) onlyAuthorizedOrOwner {
         _unpause();
     }
 

--- a/src/modules/governance/SingleVoteGovernor.sol
+++ b/src/modules/governance/SingleVoteGovernor.sol
@@ -147,7 +147,7 @@ contract SingleVoteGovernor is ISingleVoteGovernor, Module {
     function isAuthorized(address who)
         public
         view
-        override (IAuthorizer)
+        override(IAuthorizer)
         returns (bool)
     {
         // Note that only the governance itself is authorized.

--- a/src/modules/mixins/PaymentClient.sol
+++ b/src/modules/mixins/PaymentClient.sol
@@ -192,6 +192,11 @@ abstract contract PaymentClient is IPaymentClient, ContextUpgradeable {
             IPaymentProcessor(_msgSender()), _outstandingTokenAmount
         );
 
+        //Ensure that the Client will have sufficient funds.
+        // Note that function is implemented in downstream contract.
+        // Note that while we also control when adding a payment order, more complex payment systems with f.ex. deferred payments may not guarantee that having enough balance available when adding the order means it'll have enough balance when the order is processed.
+        _ensureTokenBalance(_outstandingTokenAmount);
+
         // Create a copy of all orders to return.
         PaymentOrder[] memory copy = new PaymentOrder[](_orders.length);
         for (uint i; i < _orders.length; i++) {

--- a/src/proposal/Proposal.sol
+++ b/src/proposal/Proposal.sol
@@ -78,13 +78,13 @@ contract Proposal is
     IERC20 private _receiptToken;
 
     /// @inheritdoc IProposal
-    uint public override (IProposal) proposalId;
+    uint public override(IProposal) proposalId;
 
     /// @inheritdoc IProposal
-    IAuthorizer public override (IProposal) authorizer;
+    IAuthorizer public override(IProposal) authorizer;
 
     /// @inheritdoc IProposal
-    IPaymentProcessor public override (IProposal) paymentProcessor;
+    IPaymentProcessor public override(IProposal) paymentProcessor;
 
     //--------------------------------------------------------------------------
     // Initializer
@@ -101,7 +101,7 @@ contract Proposal is
         address[] calldata modules,
         IAuthorizer authorizer_,
         IPaymentProcessor paymentProcessor_
-    ) external override (IProposal) initializer {
+    ) external override(IProposal) initializer {
         // Initialize upstream contracts.
         __Ownable_init();
         __ModuleManager_init(modules);
@@ -135,7 +135,7 @@ contract Proposal is
     function __ModuleManager_isAuthorized(address who)
         internal
         view
-        override (ModuleManager)
+        override(ModuleManager)
         returns (bool)
     {
         return authorizer.isAuthorized(who);
@@ -146,7 +146,7 @@ contract Proposal is
     function __ContributorManager_isAuthorized(address who)
         internal
         view
-        override (ContributorManager)
+        override(ContributorManager)
         returns (bool)
     {
         return authorizer.isAuthorized(who) || who == owner();
@@ -179,14 +179,14 @@ contract Proposal is
     function token()
         public
         view
-        override (FundingManager, IProposal)
+        override(FundingManager, IProposal)
         returns (IERC20)
     {
         return _token;
     }
 
     /// @inheritdoc IProposal
-    function receiptToken() public view override (IProposal) returns (IERC20) {
+    function receiptToken() public view override(IProposal) returns (IERC20) {
         return _receiptToken;
     }
 
@@ -198,7 +198,7 @@ contract Proposal is
     function owner()
         public
         view
-        override (OwnableUpgradeable, IProposal)
+        override(OwnableUpgradeable, IProposal)
         returns (address)
     {
         return super.owner();

--- a/src/proposal/base/FundingManager.sol
+++ b/src/proposal/base/FundingManager.sol
@@ -62,7 +62,7 @@ abstract contract FundingManager is
     function _supplyTarget()
         internal
         view
-        override (ElasticReceiptTokenUpgradeable)
+        override(ElasticReceiptTokenUpgradeable)
         returns (uint)
     {
         return token().balanceOf(address(this));

--- a/src/proposal/base/ModuleManager.sol
+++ b/src/proposal/base/ModuleManager.sol
@@ -160,7 +160,7 @@ abstract contract ModuleManager is
     function isModule(address module)
         public
         view
-        override (IModuleManager)
+        override(IModuleManager)
         returns (bool)
     {
         return module != _SENTINEL && _modules[module] != address(0);
@@ -236,12 +236,7 @@ abstract contract ModuleManager is
         address to,
         bytes memory data,
         Types.Operation operation
-    )
-        public
-        override (IModuleManager)
-        onlyModule
-        returns (bool, bytes memory)
-    {
+    ) public override(IModuleManager) onlyModule returns (bool, bytes memory) {
         bool ok;
         bytes memory returnData;
 

--- a/test/modules/MetadataManager.t.sol
+++ b/test/modules/MetadataManager.t.sol
@@ -80,7 +80,7 @@ contract MetadataManagerTest is ModuleTest {
     // Test: Initialization
 
     //This function also tests all the getters
-    function testInit() public override (ModuleTest) {
+    function testInit() public override(ModuleTest) {
         //-----------------------
         // OWNER_METADATA
 
@@ -97,7 +97,7 @@ contract MetadataManagerTest is ModuleTest {
         assertMetadataManagerTeamMetadataEqualTo(TEAM_METADATA);
     }
 
-    function testReinitFails() public override (ModuleTest) {
+    function testReinitFails() public override(ModuleTest) {
         vm.expectRevert(OZErrors.Initializable__AlreadyInitialized);
         metadataManager.init(_proposal, _METADATA, bytes(""));
     }

--- a/test/modules/MilestoneManager.t.sol
+++ b/test/modules/MilestoneManager.t.sol
@@ -69,7 +69,7 @@ contract MilestoneManagerTest is ModuleTest {
     //--------------------------------------------------------------------------
     // Test: Initialization
 
-    function testInit() public override (ModuleTest) {
+    function testInit() public override(ModuleTest) {
         // SENTINEL milestone does not exist.
         assertTrue(!milestoneManager.isExistingMilestoneId(_SENTINEL));
 
@@ -84,7 +84,7 @@ contract MilestoneManagerTest is ModuleTest {
         assertEq(milestones.length, 0);
     }
 
-    function testReinitFails() public override (ModuleTest) {
+    function testReinitFails() public override(ModuleTest) {
         vm.expectRevert(OZErrors.Initializable__AlreadyInitialized);
         milestoneManager.init(_proposal, _METADATA, bytes(""));
     }

--- a/test/modules/PaymentProcessor.t.sol
+++ b/test/modules/PaymentProcessor.t.sol
@@ -40,11 +40,11 @@ contract PaymentProcessorTest is ModuleTest {
     //--------------------------------------------------------------------------
     // Test: Initialization
 
-    function testInit() public override (ModuleTest) {
+    function testInit() public override(ModuleTest) {
         assertEq(address(paymentProcessor.token()), address(_token));
     }
 
-    function testReinitFails() public override (ModuleTest) {
+    function testReinitFails() public override(ModuleTest) {
         vm.expectRevert(OZErrors.Initializable__AlreadyInitialized);
         paymentProcessor.init(_proposal, _METADATA, bytes(""));
     }

--- a/test/modules/VestingPaymentProcessor.t.sol
+++ b/test/modules/VestingPaymentProcessor.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.13;
+
+// External Libraries
+import {Clones} from "@oz/proxy/Clones.sol";
+
+import {ModuleTest, IModule, IProposal} from "test/modules/ModuleTest.sol";
+
+// SuT
+import {
+    VestingPaymentProcessor,
+    IPaymentProcessor
+} from "src/modules/VestingPaymentProcessor.sol";
+
+// Mocks
+import {PaymentClientMock} from
+    "test/utils/mocks/modules/mixins/PaymentClientMock.sol";
+
+// Errors
+import {OZErrors} from "test/utils/errors/OZErrors.sol";
+
+contract VestingPaymentProcessorTest is ModuleTest {
+    // SuT
+    VestingPaymentProcessor paymentProcessor;
+
+    // Mocks
+    PaymentClientMock paymentClient = new PaymentClientMock(_token);
+
+    function setUp() public {
+        address impl = address(new VestingPaymentProcessor());
+        paymentProcessor = VestingPaymentProcessor(Clones.clone(impl));
+
+        _setUpProposal(paymentProcessor);
+
+        paymentProcessor.init(_proposal, _METADATA, bytes(""));
+
+        paymentClient.setIsAuthorized(address(paymentProcessor), true);
+    }
+
+    //--------------------------------------------------------------------------
+    // Test: Initialization
+
+    function testInit() public override (ModuleTest) {
+        assertEq(address(paymentProcessor.token()), address(_token));
+    }
+
+    function testReinitFails() public override (ModuleTest) {
+        vm.expectRevert(OZErrors.Initializable__AlreadyInitialized);
+        paymentProcessor.init(_proposal, _METADATA, bytes(""));
+    }
+
+    //--------------------------------------------------------------------------
+    // Test: Payment Processing
+
+    function testProcessPayments(
+        address[] memory recipients,
+        uint128[] memory amounts
+    ) public {
+        vm.assume(recipients.length <= amounts.length);
+        assumeValidRecipients(recipients);
+        assumeValidAmounts(amounts);
+
+        for (uint i; i < recipients.length; i++) {
+            address recipient = recipients[i];
+            uint amount = uint(amounts[i]);
+
+            // Add payment order to client.
+            paymentClient.addPaymentOrder(
+                recipient, amount, (block.timestamp + 100)
+            );
+
+            // Call processPayments.
+            paymentProcessor.processPayments(paymentClient);
+
+            vm.warp(block.timestamp + 101);
+            vm.prank(address(recipient));
+            paymentProcessor.claim(paymentClient);
+
+            // Check correct balances.
+            assertEq(_token.balanceOf(address(recipient)), amount);
+            assertEq(_token.balanceOf(address(paymentClient)), 0);
+
+            // Invariant: Payment processor does not hold funds.
+            assertEq(_token.balanceOf(address(paymentProcessor)), 0);
+        }
+    }
+
+    function testUpdatePayments(address recipient, uint amount) public {
+        // @todo
+    }
+
+    mapping(address => bool) recipientCache;
+
+    function assumeValidRecipients(address[] memory addrs) public {
+        for (uint i; i < addrs.length; i++) {
+            assumeValidRecipient(addrs[i]);
+
+            // Assume contributor address unique.
+            vm.assume(!recipientCache[addrs[i]]);
+
+            // Add contributor address to cache.
+            recipientCache[addrs[i]] = true;
+        }
+    }
+
+    function assumeValidRecipient(address a) public {
+        address[] memory invalids = createInvalidRecipients();
+
+        for (uint i; i < invalids.length; i++) {
+            vm.assume(a != invalids[i]);
+        }
+    }
+
+    function createInvalidRecipients() public view returns (address[] memory) {
+        address[] memory invalids = new address[](5);
+
+        invalids[0] = address(0);
+        invalids[1] = address(_proposal);
+        invalids[2] = address(paymentProcessor);
+        invalids[3] = address(paymentClient);
+        invalids[4] = address(this);
+
+        return invalids;
+    }
+
+    function assumeValidAmounts(uint128[] memory amounts) public {
+        for (uint i; i < amounts.length; i++) {
+            vm.assume(amounts[i] != 0);
+        }
+    }
+}

--- a/test/modules/VestingPaymentProcessor.t.sol
+++ b/test/modules/VestingPaymentProcessor.t.sol
@@ -40,11 +40,11 @@ contract VestingPaymentProcessorTest is ModuleTest {
     //--------------------------------------------------------------------------
     // Test: Initialization
 
-    function testInit() public override (ModuleTest) {
+    function testInit() public override(ModuleTest) {
         assertEq(address(paymentProcessor.token()), address(_token));
     }
 
-    function testReinitFails() public override (ModuleTest) {
+    function testReinitFails() public override(ModuleTest) {
         vm.expectRevert(OZErrors.Initializable__AlreadyInitialized);
         paymentProcessor.init(_proposal, _METADATA, bytes(""));
     }

--- a/test/utils/mocks/AuthorizerMock.sol
+++ b/test/utils/mocks/AuthorizerMock.sol
@@ -25,7 +25,7 @@ contract AuthorizerMock is IAuthorizer, Module {
         IProposal proposal_,
         Metadata memory metadata,
         bytes memory configdata
-    ) public override (Module) initializer {
+    ) public override(Module) initializer {
         __Module_init(proposal_, metadata);
 
         // Read first authorized address from configdata.

--- a/test/utils/mocks/modules/base/ModuleMock.sol
+++ b/test/utils/mocks/modules/base/ModuleMock.sol
@@ -7,7 +7,7 @@ contract ModuleMock is Module {
     function init(IProposal proposal_, Metadata memory metadata, bytes memory)
         public
         virtual
-        override (Module)
+        override(Module)
         initializer
     {
         __Module_init(proposal_, metadata);

--- a/test/utils/mocks/modules/mixins/PaymentClientMock.sol
+++ b/test/utils/mocks/modules/mixins/PaymentClientMock.sol
@@ -60,13 +60,13 @@ contract PaymentClientMock is PaymentClient {
         internal
         override (PaymentClient)
     {
-        /*if (token.balanceOf(address(this)) >= amount) {
+        if (token.balanceOf(address(this)) >= amount) {
             return;
         } else {
             uint amtToMint = amount - token.balanceOf(address(this));
             token.mint(address(this), amtToMint);
-        }*/
-        token.mint(address(this), amount);
+        }
+
     }
 
     function _ensureTokenAllowance(IPaymentProcessor spender, uint amount)

--- a/test/utils/mocks/modules/mixins/PaymentClientMock.sol
+++ b/test/utils/mocks/modules/mixins/PaymentClientMock.sol
@@ -60,12 +60,13 @@ contract PaymentClientMock is PaymentClient {
         internal
         override (PaymentClient)
     {
-        if( token.balanceOf(address(this)) >= amount) {
+        /*if (token.balanceOf(address(this)) >= amount) {
             return;
         } else {
-        uint amtToMint = amount - token.balanceOf(address(this));
-        token.mint(address(this), amtToMint);
-        }
+            uint amtToMint = amount - token.balanceOf(address(this));
+            token.mint(address(this), amtToMint);
+        }*/
+        token.mint(address(this), amount);
     }
 
     function _ensureTokenAllowance(IPaymentProcessor spender, uint amount)

--- a/test/utils/mocks/modules/mixins/PaymentClientMock.sol
+++ b/test/utils/mocks/modules/mixins/PaymentClientMock.sol
@@ -60,7 +60,12 @@ contract PaymentClientMock is PaymentClient {
         internal
         override (PaymentClient)
     {
-        token.mint(address(this), amount);
+        if( token.balanceOf(address(this)) >= amount) {
+            return;
+        } else {
+        uint amtToMint = amount - token.balanceOf(address(this));
+        token.mint(address(this), amtToMint);
+        }
     }
 
     function _ensureTokenAllowance(IPaymentProcessor spender, uint amount)

--- a/test/utils/mocks/modules/mixins/PaymentClientMock.sol
+++ b/test/utils/mocks/modules/mixins/PaymentClientMock.sol
@@ -58,7 +58,7 @@ contract PaymentClientMock is PaymentClient {
 
     function _ensureTokenBalance(uint amount)
         internal
-        override (PaymentClient)
+        override(PaymentClient)
     {
         if (token.balanceOf(address(this)) >= amount) {
             return;
@@ -70,7 +70,7 @@ contract PaymentClientMock is PaymentClient {
 
     function _ensureTokenAllowance(IPaymentProcessor spender, uint amount)
         internal
-        override (PaymentClient)
+        override(PaymentClient)
     {
         token.approve(address(spender), amount);
     }
@@ -78,7 +78,7 @@ contract PaymentClientMock is PaymentClient {
     function _isAuthorizedPaymentProcessor(IPaymentProcessor)
         internal
         view
-        override (PaymentClient)
+        override(PaymentClient)
         returns (bool)
     {
         return authorized[msg.sender];

--- a/test/utils/mocks/modules/mixins/PaymentClientMock.sol
+++ b/test/utils/mocks/modules/mixins/PaymentClientMock.sol
@@ -66,7 +66,6 @@ contract PaymentClientMock is PaymentClient {
             uint amtToMint = amount - token.balanceOf(address(this));
             token.mint(address(this), amtToMint);
         }
-
     }
 
     function _ensureTokenAllowance(IPaymentProcessor spender, uint amount)

--- a/test/utils/mocks/proposal/base/ContributorManagerMock.sol
+++ b/test/utils/mocks/proposal/base/ContributorManagerMock.sol
@@ -34,7 +34,7 @@ contract ContributorManagerMock is ContributorManager {
     function __ContributorManager_isAuthorized(address who)
         internal
         view
-        override (ContributorManager)
+        override(ContributorManager)
         returns (bool)
     {
         return _authorized[who] || _allAuthorized;

--- a/test/utils/mocks/proposal/base/FundingManagerMock.sol
+++ b/test/utils/mocks/proposal/base/FundingManagerMock.sol
@@ -31,7 +31,7 @@ contract FundingManagerMock is FundingManager {
         __FundingManager_init(proposalId_, token_);
     }
 
-    function token() public view override (FundingManager) returns (IERC20) {
+    function token() public view override(FundingManager) returns (IERC20) {
         return _token;
     }
 }

--- a/test/utils/mocks/proposal/base/ModuleManagerMock.sol
+++ b/test/utils/mocks/proposal/base/ModuleManagerMock.sol
@@ -33,7 +33,7 @@ contract ModuleManagerMock is ModuleManager {
     function __ModuleManager_isAuthorized(address who)
         internal
         view
-        override (ModuleManager)
+        override(ModuleManager)
         returns (bool)
     {
         return _authorized[who] || _allAuthorized;


### PR DESCRIPTION
It seems that the Vesting Payment Processor got lost at some point. I've re-added it and updated it to the new Processor-Client structure. I've made some changes to the code, mainly:

- **releasable()**: now takes an address as argument to keep it in line with the other similar functions
- **_vestingSchedule()**: Now also takes an address as input, and doesn't default to msg.sender.
- **removePayment()**: When removing a running PaymentOrder, the amount that had already vested gets claimed for the contributor and sent to him. This way, they don't lose money they earned. Unvested funds now remain unassigned in the PaymentClient. See @todo on line 255
- **Overwriting a Payment**: In that line, adding a Payment to somebody who is already on a vesting schedule will remove their current payment first. They'll get the tokens that had vested up to that point and then continue with the new schedule.
	
Also, while writing the test I noticed some issues on 2 other contracts and made some changes:
-**PaymentClient**: Added an extra _ensureTokenBalance check when collecting payment orders. Technically we had been ensuring the sufficient balance everytime we added a new order, but the fact that the contract had enough funds THEN doesn't necessarily guarantee that we have enough funds NOW, if we do stuf like deferred payments etc.  
-**PaymentClientMock**: Now only mints the exact amount needed when calling "_ensureTokenBalance". It used to mint the whole amount irrespective of the current balance, generating excess funds.
	

Also apart from the couple todos in the code, one more general question:
Do we want to enable pausing of the payment? As it is, it would prevent a contributor from claiming what they have already earned, and actually cause a deadlock on removing them (since we cant call claim()). Also, we won't be pausing milestones for now, so I don't think we *need* it for anything. I have the feeling it only adds complexity? If we need to stop somebody form getting money, we can use removePayment()... 

Please review and share any comments!! :pray:
	
		
PS. I'm intrigued by this modifier: 
```
    modifier validDuration(uint _start, uint _duration) {
        if (_start + _duration <= _start || _duration == 0) {
            revert Module__PaymentManager__InvalidDuration();
        }
        _;
    }
```
Is this some kind of Solidity quirk? 🤓