### PR TITLE
Remove mentions of Sentinel from ModuleManager

### DIFF
--- a/src/proposal/base/ModuleManager.sol
+++ b/src/proposal/base/ModuleManager.sol
@@ -73,9 +73,6 @@ abstract contract ModuleManager is
     //--------------------------------------------------------------------------
     // Constants
 
-    /// @dev Marks the beginning and end of the _modules list.
-    address private constant _SENTINEL = address(0x1);
-
     /// @dev Marks the maximum amount of Modules a Proposal can have to avoid out-of-gas risk.
     uint8 private constant MAX_MODULE_AMOUNT = 128;
 
@@ -286,10 +283,7 @@ abstract contract ModuleManager is
     }
 
     function _ensureValidModule(address module) private view {
-        if (
-            module == address(0) || module == _SENTINEL
-                || module == address(this)
-        ) {
+        if (module == address(0) || module == address(this)) {
             revert Proposal__ModuleManager__InvalidModuleAddress();
         }
     }

--- a/test/proposal/base/ModuleManager.t.sol
+++ b/test/proposal/base/ModuleManager.t.sol
@@ -29,9 +29,6 @@ contract ModuleManagerTest is Test {
     uint MAX_MODULES = 128;
     address[] EMPTY_LIST = new address[](0);
 
-    // Constants copied from SuT.
-    address private constant _SENTINEL = address(0x1);
-
     // Events copied from SuT.
     event ModuleAdded(address indexed module);
     event ModuleRemoved(address indexed module);

--- a/test/proposal/helper/TypeSanityHelper.sol
+++ b/test/proposal/helper/TypeSanityHelper.sol
@@ -34,7 +34,6 @@ contract TypeSanityHelper is Test {
     // Types for Module
     // Contract: base/ModuleManager.sol
 
-    address private constant _SENTINEL_MODULE = address(0x1);
     uint8 private constant MAX_MODULES = 128;
 
     mapping(address => bool) moduleCache;
@@ -64,8 +63,7 @@ contract TypeSanityHelper is Test {
         address[] memory invalids = new address[](3);
 
         invalids[0] = address(0);
-        invalids[1] = _SENTINEL_MODULE;
-        invalids[2] = _self;
+        invalids[1] = _self;
 
         return invalids;
     }

--- a/test/utils/mocks/factories/ModuleFactoryMock.sol
+++ b/test/utils/mocks/factories/ModuleFactoryMock.sol
@@ -14,8 +14,7 @@ contract ModuleFactoryMock is IModuleFactory {
     IBeacon private _beacon;
 
     // Note to not start too low as, e.g., modules are not allowed to have
-    // address(0x1). For more info, see _SENTINEL constants in
-    // src/proposal/base.
+    // address(0x1).
     uint public addressCounter = 10;
 
     function createModule(IModule.Metadata memory, IProposal, bytes memory)


### PR DESCRIPTION
Some mentions where remaining in the code even though we use an array now