### PR TITLE
Fix: Formatting & Dev Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ To keep your fork in sync with the `upstream` repository, periodically fetch and
 git fetch upstream
 ```
 
-2.Merge the upstream dev branch into your local dev branch:
+2. Merge the upstream dev branch into your local dev branch:
 
 ```bash
 git checkout dev

--- a/src/templates/modules/IPP_Template_v1.sol
+++ b/src/templates/modules/IPP_Template_v1.sol
@@ -2,8 +2,7 @@
 pragma solidity ^0.8.0;
 
 // Internal
-
-// External
+import {IPaymentProcessor_v1} from "@pp/IPaymentProcessor_v1.sol";
 
 /**
  * @title   Inverter Template Payment Processor
@@ -33,7 +32,7 @@ pragma solidity ^0.8.0;
  *
  * @author  Inverter Network
  */
-interface IPP_Template_v1 {
+interface IPP_Template_v1 is IPaymentProcessor_v1 {
     //--------------------------------------------------------------------------
     // Structs
 

--- a/src/templates/modules/IPP_Template_v1.sol
+++ b/src/templates/modules/IPP_Template_v1.sol
@@ -1,10 +1,38 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.0;
 
-// Internal Dependencies
+// Internal
 
-// External Dependencies
+// External
 
+/**
+ * @title   Inverter Template Payment Processor
+ *
+ * @notice  Basic template payment processor used as base for developing new
+ *          payment processors.
+ *
+ * @dev     This contract is used to showcase a basic setup for a payment
+ *          processor. The contract showcases the following:
+ *          - Inherit from the Module_v1 contract to enable interaction with
+ *            the Inverter workflow.
+ *          - Use of the IPaymentProcessor_v1 interface to facilitate
+ *            interaction with a payment client.
+ *          - Implement custom interface which has all the public facing
+ *            functions, errors, events and structs.
+ *          - Pre-defined layout for all contract functions, modifiers, state
+ *            variables etc.
+ *          - Use of the ERC165Upgradeable contract to check for interface
+ *            support.
+ *
+ * @custom:security-contact security@inverter.network
+ *                          In case of any concerns or findings, please refer
+ *                          to our Security Policy at security.inverter.network
+ *                          or email us directly!
+ *
+ * @custom:version 1.0.0
+ *
+ * @author  Inverter Network
+ */
 interface IPP_Template_v1 {
     //--------------------------------------------------------------------------
     // Structs
@@ -13,10 +41,10 @@ interface IPP_Template_v1 {
     // Events
 
     /// @notice Emit when new payout amount has been set.
-    /// @param oldPayoutAmount Old payout amount.
-    /// @param newPayoutAmount Newly set payout amount.
+    /// @param  oldPayoutAmount_ Old payout amount.
+    /// @param  newPayoutAmount_ Newly set payout amount.
     event NewPayoutAmountMultiplierSet(
-        uint indexed oldPayoutAmount, uint indexed newPayoutAmount
+        uint indexed oldPayoutAmount_, uint indexed newPayoutAmount_
     );
 
     //--------------------------------------------------------------------------
@@ -26,15 +54,17 @@ interface IPP_Template_v1 {
     error Module__PP_Template_InvalidAmount();
 
     /// @notice Client is not valid.
-    error Module__PP_Template__NotValidClient();
+    error Module__PP_Template__ClientNotValid();
 
     //--------------------------------------------------------------------------
     // Public (Getter)
 
     /// @notice Returns the payout amount for each payment order.
-    /// @param payoutAmount The payout amount.
-    function getPayoutAmountMultiplier() external returns (uint payoutAmount);
+    /// @return payoutAmountMultiplier_ The payout amount multiplier.
+    function getPayoutAmountMultiplier()
+        external
+        returns (uint payoutAmountMultiplier_);
 
     //--------------------------------------------------------------------------
-    // Public (Mutation)
+    // Public (Mutating)
 }

--- a/src/templates/modules/PP_Template_v1.sol
+++ b/src/templates/modules/PP_Template_v1.sol
@@ -41,7 +41,7 @@ import {IERC20} from "@oz/token/ERC20/IERC20.sol";
  *
  * @author  Inverter Network
  */
-contract PP_Template_v1 is IPP_Template_v1, IPaymentProcessor_v1, Module_v1 {
+contract PP_Template_v1 is IPP_Template_v1, Module_v1 {
     //--------------------------------------------------------------------------
     // Libraries
 

--- a/src/templates/modules/PP_Template_v1.sol
+++ b/src/templates/modules/PP_Template_v1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity 0.8.23;
 
-// Internal Dependencies
+// Internal
 import {IOrchestrator_v1} from
     "src/orchestrator/interfaces/IOrchestrator_v1.sol";
 import {IPaymentProcessor_v1} from "@pp/IPaymentProcessor_v1.sol";
@@ -10,25 +10,34 @@ import {IERC20PaymentClientBase_v1} from
 import {IPP_Template_v1} from "./IPP_Template_v1.sol";
 import {ERC165Upgradeable, Module_v1} from "src/modules/base/Module_v1.sol";
 
-// External Dependencies
+// External
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 /**
  * @title   Inverter Template Payment Processor
  *
- * @notice  Basic template payment processor used as base for developing new payment processors.
+ * @notice  Basic template payment processor used as base for developing new
+ *          payment processors.
  *
- * @dev     This contract is used to showcase a basic setup for a payment processor. The contract showcases the
- *          following:
- *          - Inherit from the Module_v1 contract to enable interaction with the Inverter workflow.
- *          - Use of the IPaymentProcessor_v1 interface to facilitate interaction with a payment client.
- *          - Implement custom interface which has all the public facing functions, errors, events and structs.
- *          - Pre-defined layout for all contract functions, modifiers, state variables etc.
- *          - Use of the ERC165Upgradeable contract to check for interface support.
+ * @dev     This contract is used to showcase a basic setup for a payment
+ *          processor. The contract showcases the following:
+ *          - Inherit from the Module_v1 contract to enable interaction with
+ *            the Inverter workflow.
+ *          - Use of the IPaymentProcessor_v1 interface to facilitate
+ *            interaction with a payment client.
+ *          - Implement custom interface which has all the public facing
+ *            functions, errors, events and structs.
+ *          - Pre-defined layout for all contract functions, modifiers, state
+ *            variables etc.
+ *          - Use of the ERC165Upgradeable contract to check for interface
+ *            support.
  *
  * @custom:security-contact security@inverter.network
- *                          In case of any concerns or findings, please refer to our Security Policy
- *                          at security.inverter.network or email us directly!
+ *                          In case of any concerns or findings, please refer
+ *                          to our Security Policy at security.inverter.network
+ *                          or email us directly!
+ *
+ * @custom:version 1.0.0
  *
  * @author  Inverter Network
  */
@@ -65,16 +74,16 @@ contract PP_Template_v1 is IPP_Template_v1, IPaymentProcessor_v1, Module_v1 {
     /// @dev    Payout amount multiplier.
     uint internal _payoutAmountMultiplier;
 
-    /// @dev    The number of payment orders.
+    /// @dev    Payment ID of the last processed payment order.
     uint internal _paymentId;
 
     //--------------------------------------------------------------------------
     // Modifiers
 
     /// @dev    Checks that the client is calling for itself.
-    modifier validClient(address client_) {
-        // modifier logic moved to internal function for contract size reduction
-        _validClientModifier(client_);
+    modifier clientIsValid(address client_) {
+        // Modifier logic moved to internal function for contract size reduction.
+        _ensureValidClient(client_);
         _;
     }
 
@@ -84,14 +93,15 @@ contract PP_Template_v1 is IPP_Template_v1, IPaymentProcessor_v1, Module_v1 {
     /// @inheritdoc Module_v1
     function init(
         IOrchestrator_v1 orchestrator_,
-        Metadata memory metadata,
-        bytes memory configData
+        Metadata memory metadata_,
+        bytes memory configData_
     ) external override(Module_v1) initializer {
-        __Module_init(orchestrator_, metadata);
+        __Module_init(orchestrator_, metadata_);
 
-        // Decode module specific init data through use of configData bytes. This value is an example value used to
-        // showcase the setters/getters and internal functions/state formating style.
-        (uint payoutAmountMultiplier_) = abi.decode(configData, (uint));
+        // Decode module specific init data through use of configData bytes.
+        // This value is an example value used to showcase the setters/getters
+        // and internal functions/state formating style.
+        (uint payoutAmountMultiplier_) = abi.decode(configData_, (uint));
 
         // Set init state.
         _setPayoutAmountMultiplier(payoutAmountMultiplier_);
@@ -110,63 +120,65 @@ contract PP_Template_v1 is IPP_Template_v1, IPaymentProcessor_v1, Module_v1 {
     }
 
     //--------------------------------------------------------------------------
-    // Public (Mutation)
+    // Public (Mutating)
 
     /// @inheritdoc IPaymentProcessor_v1
     function processPayments(IERC20PaymentClientBase_v1 client_)
         external
-        validClient(address(client_))
+        clientIsValid(address(client_))
     {
-        // The IERC20PaymentClientBase_v1 client should be used to access created payment orders
-        // in the Logic Module (LM) implementing the interface. The interface should be referenced to see the different
+        // The IERC20PaymentClientBase_v1 client should be used to access
+        // created payment orders in the Logic Module (LM) implementing the
+        // interface. The interface should be referenced to see the different
         // functionalities provided by the ERC20PaymentClientBase_v1.
 
         // Collect orders from the client
         IERC20PaymentClientBase_v1.PaymentOrder[] memory orders;
         (orders,,) = client_.collectPaymentOrders();
 
-        // Custom logic to proces the payment orders should be implemented below. This template implements
-        // a straight forward token transfer using the first order of the payment order array for simplicity.
+        // Custom logic to proces the payment orders should be implemented
+        // below. This template implements a straight forward token transfer
+        // using the first order of the payment order array for simplicity.
 
         // Get payment order details
-        address recipient = orders[0].recipient;
+        address recipient_ = orders[0].recipient;
         address token_ = orders[0].paymentToken;
         uint amount_ = orders[0].amount * _payoutAmountMultiplier;
         _paymentId = _paymentId + 1;
 
-        // Emit event of the IPaymentProcessor_v1. This is used by Inverter's indexer
+        // Emit event of the IPaymentProcessor_v1. This is used by Inverter's
+        // Indexer.
         emit PaymentOrderProcessed(
-            address(client_),
-            orders[0].recipient,
-            orders[0].paymentToken,
-            amount_,
-            0,
-            0,
-            0
+            address(client_), recipient_, token_, amount_, 0, 0, 0
         );
 
-        // Transfer tokens from {IERC20PaymentClientBase_v1} to order recipients.
-        // Please note, when processing multiple payment orders then letting the call revert as in this example
-        // might not be the best solution. Ways to handle this by implementing the `unclaimable` function can be
-        // found in the other Payment Processor (PP) implementations.
-        IERC20(token_).transferFrom(address(client_), recipient, amount_);
+        // Transfer tokens from {IERC20PaymentClientBase_v1} to order
+        // recipients.
+        // Please note: When processing multiple payment orders and then
+        // letting the call revert as in this example might not be the best
+        // solution. Ways to handle this by implementing the `unclaimable`
+        // function can be found in the other Payment Processor (PP)
+        // implementations.
+        IERC20(token_).transferFrom(address(client_), recipient_, amount_);
 
         // Inform the client about the amount that was released, to keep
-        //      the accounting correct.
+        // the accounting correct.
         client_.amountPaid(token_, amount_);
 
-        // Emit event of the IPaymentProcessor_v1. This is used by Inverter's indexer
-        emit TokensReleased(recipient, token_, amount_);
+        // Emit event of the IPaymentProcessor_v1. This is used by Inverter's
+        // Indexer.
+        emit TokensReleased(recipient_, token_, amount_);
     }
 
     /// @inheritdoc IPaymentProcessor_v1
     function cancelRunningPayments(IERC20PaymentClientBase_v1 client_)
         external
         view
-        validClient(address(client_))
+        clientIsValid(address(client_))
     {
-        // This function is used to implement custom logic to cancel running payments. If the nature of
-        // processing payments is one of direct processing then this function can be left empty, return nothing.
+        // This function is used to implement custom logic to cancel running
+        // payments. If the nature of processing payments is one of direct
+        // processing then this function can be left empty, return nothing.
         return;
     }
 
@@ -176,9 +188,10 @@ contract PP_Template_v1 is IPP_Template_v1, IPaymentProcessor_v1, Module_v1 {
         address, /*token_*/
         address /*paymentReceiver_*/
     ) external pure returns (uint amount_) {
-        // This function is used to check if there are unclaimable tokens for a specific client, token and payment
-        // receiver. As this template only executes one payment order at a time, this function is not utilzed and can
-        // return 0.
+        // This function is used to check if there are unclaimable tokens for a
+        // specific client, token and payment receiver. As this template only
+        // executes one payment order at a time, this function is not utilzed
+        // and can return 0.
         return 0;
     }
 
@@ -195,8 +208,10 @@ contract PP_Template_v1 is IPP_Template_v1, IPaymentProcessor_v1, Module_v1 {
     function validPaymentOrder(
         IERC20PaymentClientBase_v1.PaymentOrder memory order_
     ) external view returns (bool) {
-        // This function is used to validate the payment order created on the client side (LM) with the input required by the
-        // Payment Processor (PP). The function should return true if the payment order is valid and false if it is not.
+        // This function is used to validate the payment order created on the
+        // client side (LM_PC) with the input required by the Payment Processor
+        // (PP). The function should return true if the payment order is valid
+        // and false if it is not.
 
         // For this template, only the receiver is validated.
         return _validPaymentReceiver(order_.recipient);
@@ -205,8 +220,9 @@ contract PP_Template_v1 is IPP_Template_v1, IPaymentProcessor_v1, Module_v1 {
     //--------------------------------------------------------------------------
     // Internal
 
-    /// @dev Internal function to set the new payout amount multiplier.
-    /// @param newPayoutAmountMultiplier_ Payout amount multiplier to be set in the state. Cannot be zero.
+    /// @dev    Internal function to set the new payout amount multiplier.
+    /// @param  newPayoutAmountMultiplier_ Payout amount multiplier to be set in
+    //                                    the state. Cannot be zero.
     function _setPayoutAmountMultiplier(uint newPayoutAmountMultiplier_)
         internal
     {
@@ -219,24 +235,27 @@ contract PP_Template_v1 is IPP_Template_v1, IPaymentProcessor_v1, Module_v1 {
         _payoutAmountMultiplier = newPayoutAmountMultiplier_;
     }
 
-    /// @dev    Validate address input.
-    /// @param  addr_ Address to validate.
-    /// @return True if address is valid.
-    function _validPaymentReceiver(address addr_)
+    /// @dev    Validate whether the address is a valid payment receiver.
+    /// @param  receiver_ Address to validate.
+    /// @return validPaymentReceiver_ True if address is valid.
+    function _validPaymentReceiver(address receiver_)
         internal
         view
         returns (bool)
     {
         return !(
-            addr_ == address(0) || addr_ == _msgSender()
-                || addr_ == address(this) || addr_ == address(orchestrator())
-                || addr_ == address(orchestrator().fundingManager().token())
+            receiver_ == address(0) || receiver_ == _msgSender()
+                || receiver_ == address(this)
+                || receiver_ == address(orchestrator())
+                || receiver_ == address(orchestrator().fundingManager().token())
         );
     }
 
-    function _validClientModifier(address client_) internal view {
+    /// @dev    Internal function to check whether the client is valid.
+    /// @param  client_ Address to validate.
+    function _ensureValidClient(address client_) internal view {
         if (_msgSender() != client_) {
-            revert Module__PP_Template__NotValidClient();
+            revert Module__PP_Template__ClientNotValid();
         }
     }
 

--- a/src/templates/tests/unit/PP_Template_v1.t.sol
+++ b/src/templates/tests/unit/PP_Template_v1.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-// Internal Dependencies
+// Internal
 import {
     ModuleTest,
     IModule_v1,
@@ -9,7 +9,7 @@ import {
 } from "test/modules/ModuleTest.sol";
 import {OZErrors} from "test/utils/errors/OZErrors.sol";
 
-// External Dependencies
+// External
 import {Clones} from "@oz/proxy/Clones.sol";
 
 // Tests and Mocks
@@ -21,28 +21,29 @@ import {
     ERC20Mock
 } from "test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1Mock.sol";
 
-// System under test (SuT)
+// System under Test (SuT)
 import {
     IPP_Template_v1,
     IPaymentProcessor_v1
 } from "src/templates/modules/PP_Template_v1.sol";
 
 /**
- * @title   Inverter Template Payment Processor
+ * @title   Inverter Template Payment Processor Tests
  *
- * @notice  Basic template payment processor used to showcase the unit testing setup
+ * @notice  Basic template payment processor used to showcase the unit testing
+ *          setup
  *
- * @dev     Not all functions are tested in this template. Placeholders of the functions that are not tested are added
- *          into the contract. This test showcases the following:
- *          - Inherit from the ModuleTest contract to enable interaction with the Inverter workflow.
+ * @dev     Not all functions are tested in this template. Placeholders of the
+ *          functions that are not tested are added into the contract. This test
+ *          showcases the following:
+ *          - Inherit from the ModuleTest contract to enable interaction with
+ *            the Inverter workflow.
  *          - Showcases the setup of the workflow, uses in test unit tests.
  *          - Pre-defined layout for all setup and functions to be tested.
- *          - Shows the use of Gherkin for documenting the testing. VS Code extension used for formatting is recommended.
- *          - Shows the use of the modifierInPlace pattern to test the modifier placement.
- *
- * @custom:security-contact security@inverter.network
- *                          In case of any concerns or findings, please refer to our Security Policy
- *                          at security.inverter.network or email us directly!
+ *          - Shows the use of Gherkin for documenting the testing. VS Code
+ *            extension used for formatting is recommended.
+ *          - Shows the use of the modifierInPlace pattern to test the modifier
+ *            placement.
  *
  * @author  Inverter Network
  */
@@ -137,7 +138,7 @@ contract PP_Template_v1_Test is ModuleTest {
             new ERC20PaymentClientBaseV1Mock();
 
         vm.expectRevert(
-            IPP_Template_v1.Module__PP_Template__NotValidClient.selector
+            IPP_Template_v1.Module__PP_Template__ClientNotValid.selector
         );
         paymentProcessor.processPayments(nonRegisteredClient);
     }

--- a/src/templates/tests/unit/PP_Template_v1_Exposed.sol
+++ b/src/templates/tests/unit/PP_Template_v1_Exposed.sol
@@ -1,17 +1,29 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "forge-std/console.sol";
-
-// Internal Dependencies
+// Internal
 import {PP_Template_v1} from "src/templates/modules/PP_Template_v1.sol";
 
-// Mock of the PP_Template_v1 contract for testing
+// Access Mock of the PP_Template_v1 contract for Testing.
 contract PP_Template_v1_Exposed is PP_Template_v1 {
-    // Use the `exposed_` prefix for functions to expose internal contract for testing
+    // Use the `exposed_` prefix for functions to expose internal contract for
+    // testing.
+
     function exposed_setPayoutAmountMultiplier(uint newPayoutAmountMultiplier_)
         external
     {
         _setPayoutAmountMultiplier(newPayoutAmountMultiplier_);
+    }
+
+    function exposed_validPaymentReceiver(address receiver_)
+        external
+        view
+        returns (bool validPaymentReceiver_)
+    {
+        validPaymentReceiver_ = _validPaymentReceiver(receiver_);
+    }
+
+    function exposed_ensureValidClient(address client_) external view {
+        _ensureValidClient(client_);
     }
 }


### PR DESCRIPTION
Resolves issues from #674, like formatting and the dev guideline adherence. I just did one pass, so there might still be something.

What is still open?
* There are still multiple functions in the template contract (`processPayments`, `cancelRunningPayments`, etc.) that are not covered in the interface. Either add these to the interface directly or have the interface inherit the `IPaymentProcessor.sol` interface (and subsequently only extend the template itself from `IPP_Template_v1` as this then is an `IPaymentProcessor`).
  * after looking at how the streaming one handles it, probably the second option i listed is how we should do it
* There is no getter for the `_paymentId`, which is not important for the template itself, but it would be a good example of a variable that is definitely needed for the outside (like guardian, etc.) to be accessible, but isn't as it doesn't have a getter.
* We never explicitly spoke about whether variables and internal functions should have a `@dev` or `@notice` tag. Currently, you are using `@dev` tags for these. I've seen both used in other projects. Could make sense to keep it like this, as `@notice` is intended for end-users and internal functions/variables are arguably never seen by an end-user, but I'm not sure if it makes a difference for the doc-generating parts of the system at some point. We can keep it as `@dev` for now though I guess.