### PR TITLE
Add registerNonModuleBeacons

### DIFF
--- a/src/external/governance/Governor_v1.sol
+++ b/src/external/governance/Governor_v1.sol
@@ -343,7 +343,7 @@ contract Governor_v1 is
         IModule_v1.Metadata memory metadata,
         IInverterBeacon_v1 beacon
     ) external onlyCommunityOrTeamMultisig {
-        _addBeaconToLinkedBeacons(beacon); //@todo test?
+        _addBeaconToLinkedBeacons(beacon);
         moduleFactory.registerMetadata(metadata, beacon);
     }
 
@@ -352,7 +352,7 @@ contract Governor_v1 is
         external
         onlyCommunityOrTeamMultisig
     {
-        _addBeaconToLinkedBeacons(beacon); //@note check if module?
+        _addBeaconToLinkedBeacons(beacon);
     }
 
     //--------------------------------------------------------------------------

--- a/src/external/governance/Governor_v1.sol
+++ b/src/external/governance/Governor_v1.sol
@@ -194,9 +194,12 @@ contract Governor_v1 is
         // grant COMMUNITY_MULTISIG_ROLE to specified address
         _grantRole(TEAM_MULTISIG_ROLE, _teamMultisig);
 
+        // set timelock period
         _setTimelockPeriod(_timelockPeriod);
 
+        // set fee manager
         _setFeeManager(_feeManager);
+        // set module factory
         _setModuleFactory(_moduleFactory);
     }
 
@@ -333,15 +336,23 @@ contract Governor_v1 is
     }
 
     //--------------------------------------------------------------------------
-    // Factory Functions
+    // Register Beacons
 
     /// @inheritdoc IGovernor_v1
     function registerMetadataInModuleFactory(
         IModule_v1.Metadata memory metadata,
         IInverterBeacon_v1 beacon
-    ) external onlyCommunityOrTeamMultisig accessibleBeacon(address(beacon)) {
-        linkedBeacons.push(beacon);
+    ) external onlyCommunityOrTeamMultisig {
+        _addBeaconToLinkedBeacons(beacon); //@todo test?
         moduleFactory.registerMetadata(metadata, beacon);
+    }
+
+    /// @inheritdoc IGovernor_v1
+    function registerNonModuleBeacons(IInverterBeacon_v1 beacon)
+        external
+        onlyCommunityOrTeamMultisig
+    {
+        _addBeaconToLinkedBeacons(beacon); //@note check if module?
     }
 
     //--------------------------------------------------------------------------
@@ -567,5 +578,15 @@ contract Governor_v1 is
 
         // we are here, that means target is owned by this address and inverter beacon
         return true;
+    }
+
+    /// @dev	Internal function that adds a beacon to the linked beacons array.
+    /// @param  beacon the beacon to add.
+    function _addBeaconToLinkedBeacons(IInverterBeacon_v1 beacon)
+        internal
+        accessibleBeacon(address(beacon))
+    {
+        linkedBeacons.push(beacon);
+        emit BeaconAddedToLinkedBeacons(address(beacon));
     }
 }

--- a/src/external/governance/Governor_v1.sol
+++ b/src/external/governance/Governor_v1.sol
@@ -581,7 +581,7 @@ contract Governor_v1 is
     }
 
     /// @dev	Internal function that adds a beacon to the linked beacons array.
-    /// @param  beacon the beacon to add.
+    /// @param  beacon The beacon to add.
     function _addBeaconToLinkedBeacons(IInverterBeacon_v1 beacon)
         internal
         accessibleBeacon(address(beacon))

--- a/src/external/governance/Governor_v1.sol
+++ b/src/external/governance/Governor_v1.sol
@@ -348,7 +348,7 @@ contract Governor_v1 is
     }
 
     /// @inheritdoc IGovernor_v1
-    function registerNonModuleBeacons(IInverterBeacon_v1 beacon)
+    function registerNonModuleBeacon(IInverterBeacon_v1 beacon)
         external
         onlyCommunityOrTeamMultisig
     {

--- a/src/external/governance/interfaces/IGovernor_v1.sol
+++ b/src/external/governance/interfaces/IGovernor_v1.sol
@@ -59,6 +59,10 @@ interface IGovernor_v1 {
     //--------------------------------------------------------------------------
     // Events
 
+    /// @notice Event emitted when a new beacon is added to the linked beacons.
+    /// @param  beacon The address of the new beacon.
+    event BeaconAddedToLinkedBeacons(address beacon);
+
     /// @notice Event emitted when a new timelock period for a upgrade of a {IInverterBeacon_v1} is started.
     /// @param  beacon The address of the {IInverterBeacon_v1}.
     /// @param  newImplementation The address of the new Implementation.

--- a/src/external/governance/interfaces/IGovernor_v1.sol
+++ b/src/external/governance/interfaces/IGovernor_v1.sol
@@ -256,7 +256,7 @@ interface IGovernor_v1 {
     ) external;
 
     //--------------------------------------------------------------------------
-    // Factory Functions
+    // Register Beacons
 
     /// @notice Registers a {IInverterBeacon_v1} with the provided `metadata` in the target {ModuleFactory_v1}.
     /// @dev	Can only be accessed by either the `COMMUNITY_MULTISIG_ROLE` or the `TEAM_MULTISIG_ROLE`.
@@ -266,6 +266,11 @@ interface IGovernor_v1 {
         IModule_v1.Metadata memory metadata,
         IInverterBeacon_v1 beacon
     ) external;
+
+    /// @notice Registers a {IInverterBeacon_v1} as a linked beacon that is not a module.
+    /// @dev	Can only be accessed by either the `COMMUNITY_MULTISIG_ROLE` or the `TEAM_MULTISIG_ROLE`.
+    /// @param  beacon The {IInverterBeacon_v1} that will be registered.
+    function registerNonModuleBeacons(IInverterBeacon_v1 beacon) external;
 
     //--------------------------------------------------------------------------
     // Beacon Functions

--- a/src/external/governance/interfaces/IGovernor_v1.sol
+++ b/src/external/governance/interfaces/IGovernor_v1.sol
@@ -274,7 +274,7 @@ interface IGovernor_v1 {
     /// @notice Registers an {IInverterBeacon_v1} as a linked beacon that is not a module.
     /// @dev	Can only be accessed by either the `COMMUNITY_MULTISIG_ROLE` or the `TEAM_MULTISIG_ROLE`.
     /// @param  beacon The {IInverterBeacon_v1} that will be registered.
-    function registerNonModuleBeacons(IInverterBeacon_v1 beacon) external;
+    function registerNonModuleBeacon(IInverterBeacon_v1 beacon) external;
 
     //--------------------------------------------------------------------------
     // Beacon Functions

--- a/src/external/governance/interfaces/IGovernor_v1.sol
+++ b/src/external/governance/interfaces/IGovernor_v1.sol
@@ -271,7 +271,7 @@ interface IGovernor_v1 {
         IInverterBeacon_v1 beacon
     ) external;
 
-    /// @notice Registers a {IInverterBeacon_v1} as a linked beacon that is not a module.
+    /// @notice Registers an {IInverterBeacon_v1} as a linked beacon that is not a module.
     /// @dev	Can only be accessed by either the `COMMUNITY_MULTISIG_ROLE` or the `TEAM_MULTISIG_ROLE`.
     /// @param  beacon The {IInverterBeacon_v1} that will be registered.
     function registerNonModuleBeacons(IInverterBeacon_v1 beacon) external;

--- a/test/external/Governor_v1.t.sol
+++ b/test/external/Governor_v1.t.sol
@@ -650,31 +650,31 @@ contract GovernorV1Test is Test {
     }
 
     /*
-    Test: registerNonModuleBeacons
+    Test: registerNonModuleBeacon
     ├── Given: caller is neither the community multisig nor the team multisig
-    │   └── When: registerNonModuleBeacons is called
+    │   └── When: registerNonModuleBeacon is called
     │       └── Then: revert with error
     └── Given: caller is the community multisig or the team multisig
-        └── When: registerNonModuleBeacons is called
-            └── Then: The internal function _registerNonModuleBeacons is called
+        └── When: registerNonModuleBeacon is called
+            └── Then: The internal function _registerNonModuleBeacon is called
      */
 
-    function testRegisterNonModuleBeacons_ModifierInPosition() public {
+    function testregisterNonModuleBeacon_ModifierInPosition() public {
         // onlyCommunityOrTeamMultisig
         vm.expectRevert(
             abi.encodeWithSelector(
                 IGovernor_v1.Governor__OnlyCommunityOrTeamMultisig.selector
             )
         );
-        gov.registerNonModuleBeacons(IInverterBeacon_v1(ownedBeaconMock));
+        gov.registerNonModuleBeacon(IInverterBeacon_v1(ownedBeaconMock));
     }
 
-    function testRegisternonModuleBeacons_internalFunctionCalled() public {
+    function testregisterNonModuleBeacon_internalFunctionCalled() public {
         vm.expectEmit(true, true, true, true);
         emit IGovernor_v1.BeaconAddedToLinkedBeacons(address(ownedBeaconMock));
 
         vm.prank(communityMultisig);
-        gov.registerNonModuleBeacons(IInverterBeacon_v1(ownedBeaconMock));
+        gov.registerNonModuleBeacon(IInverterBeacon_v1(ownedBeaconMock));
     }
 
     //--------------------------------------------------------------------------

--- a/test/utils/mocks/external/GovernorV1Mock.sol
+++ b/test/utils/mocks/external/GovernorV1Mock.sol
@@ -102,6 +102,8 @@ contract GovernorV1Mock is IGovernor_v1 {
         IInverterBeacon_v1 beacon
     ) external {}
 
+    function registerNonModuleBeacons(IInverterBeacon_v1 beacon) external {}
+
     //--------------------------------------------------------------------------
     // Beacon Functions
 

--- a/test/utils/mocks/external/GovernorV1Mock.sol
+++ b/test/utils/mocks/external/GovernorV1Mock.sol
@@ -102,7 +102,7 @@ contract GovernorV1Mock is IGovernor_v1 {
         IInverterBeacon_v1 beacon
     ) external {}
 
-    function registerNonModuleBeacons(IInverterBeacon_v1 beacon) external {}
+    function registerNonModuleBeacon(IInverterBeacon_v1 beacon) external {}
 
     //--------------------------------------------------------------------------
     // Beacon Functions

--- a/test/utils/mocks/external/Governor_v1_Exposed.sol
+++ b/test/utils/mocks/external/Governor_v1_Exposed.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {Governor_v1} from "src/external/governance/Governor_v1.sol";
+import {IInverterBeacon_v1} from "src/proxies/interfaces/IInverterBeacon_v1.sol";
+
+contract Governor_v1_Exposed is Governor_v1 {
+    function exposed_addBeaconToLinkedBeacons(IInverterBeacon_v1 beacon)
+        external
+    {
+        _addBeaconToLinkedBeacons(beacon);
+    }
+}


### PR DESCRIPTION
In the registerNonModuleBeacons function should I check if the implementation of the beacon is not a module?
