### PR TITLE
Chore: modifies funding logic

### DIFF
--- a/src/factories/custom/Restricted_PIM_Factory_v1.sol
+++ b/src/factories/custom/Restricted_PIM_Factory_v1.sol
@@ -15,6 +15,8 @@ import {IRestricted_PIM_Factory_v1} from
 import {IBondingCurveBase_v1} from
     "@fm/bondingCurve/interfaces/IBondingCurveBase_v1.sol";
 import {IModule_v1} from "src/modules/base/IModule_v1.sol";
+import {LM_PC_PaymentRouter_v1} from
+    "src/modules/logicModule/LM_PC_PaymentRouter_v1.sol";
 import {ILM_PC_PaymentRouter_v1} from
     "src/modules/logicModule/interfaces/ILM_PC_PaymentRouter_v1.sol";
 
@@ -324,7 +326,7 @@ contract Restricted_PIM_Factory_v1 is
 
         // assign payment pusher role to beneficiary
         bytes32 paymentPusherRole =
-            ILM_PC_PaymentRouter_v1(paymentRouter).PAYMENT_PUSHER_ROLE();
+            LM_PC_PaymentRouter_v1(paymentRouter).PAYMENT_PUSHER_ROLE();
         IModule_v1(paymentRouter).grantModuleRole(
             paymentPusherRole, beneficiary
         );

--- a/src/factories/custom/Restricted_PIM_Factory_v1.sol
+++ b/src/factories/custom/Restricted_PIM_Factory_v1.sol
@@ -81,7 +81,7 @@ contract Restricted_PIM_Factory_v1 is
                             => mapping(address token => Funding funding)
                     )
             )
-    ) public fundings;
+    ) private fundings;
 
     //--------------------------------------------------------------------------
     // Constructor
@@ -139,15 +139,11 @@ contract Restricted_PIM_Factory_v1 is
         uint amount
     ) external {
         Funding storage funding = fundings[deployer][beneficiary][admin][token];
-        if (funding.sponsor != address(0) && funding.sponsor != _msgSender()) {
-            revert
-                IRestricted_PIM_Factory_v1
-                .FundingAlreadyAddedByDifferentSponsor();
-        }
 
         // records funding amount
         funding.amount += amount;
-        funding.sponsor = _msgSender();
+        funding.sponsorships[_msgSender()] += amount;
+
         // sends amount from msg.sender to factory
         IERC20(token).safeTransferFrom(_msgSender(), address(this), amount);
 
@@ -167,23 +163,15 @@ contract Restricted_PIM_Factory_v1 is
         // checks if the requested amount is available
         Funding storage funding = fundings[deployer][beneficiary][admin][token];
 
-        if (amount > funding.amount) {
+        if (amount > funding.sponsorships[_msgSender()]) {
             revert IRestricted_PIM_Factory_v1.InsufficientFunding(
-                funding.amount
+                funding.sponsorships[_msgSender()]
             );
-        }
-
-        if (_msgSender() != funding.sponsor) {
-            revert IRestricted_PIM_Factory_v1.NotAuthorized();
         }
 
         // if so adjusts internal balancing
         funding.amount -= amount;
-
-        // if complete withdrawal, reset sponsor
-        if (funding.amount == 0) {
-            funding.sponsor = address(0);
-        }
+        funding.sponsorships[_msgSender()] -= amount;
 
         // and sends amount to msg sender
         IERC20(token).safeTransfer(_msgSender(), amount);
@@ -191,6 +179,26 @@ contract Restricted_PIM_Factory_v1 is
         emit IRestricted_PIM_Factory_v1.FundingRemoved(
             _msgSender(), deployer, beneficiary, admin, token, amount
         );
+    }
+
+    function getFundingAmount(
+        address deployer,
+        address beneficiary,
+        address admin,
+        address token
+    ) external view returns (uint amount) {
+        return fundings[deployer][beneficiary][admin][token].amount;
+    }
+
+    function getFundingSponsorship(
+        address deployer,
+        address beneficiary,
+        address admin,
+        address token,
+        address sponsor
+    ) external view returns (uint amount) {
+        return
+            fundings[deployer][beneficiary][admin][token].sponsorships[sponsor];
     }
 
     //--------------------------------------------------------------------------
@@ -361,9 +369,6 @@ contract Restricted_PIM_Factory_v1 is
         }
 
         funding.amount -= initialCollateralSupply;
-        if (funding.amount == 0) {
-            funding.sponsor = address(0);
-        }
 
         // collateral token funding needs to be sponsored beforehand
         collateralToken.safeTransfer(

--- a/src/factories/interfaces/IRestricted_PIM_Factory_v1.sol
+++ b/src/factories/interfaces/IRestricted_PIM_Factory_v1.sol
@@ -70,7 +70,7 @@ interface IRestricted_PIM_Factory_v1 {
     /// @param  sponsor The address of the sponsor.
     struct Funding {
         uint amount;
-        address sponsor;
+        mapping(address sponsor => uint amount) sponsorships;
     }
 
     //--------------------------------------------------------------------------
@@ -136,19 +136,33 @@ interface IRestricted_PIM_Factory_v1 {
     //--------------------------------------------------------------------------
     // Functions
 
-    /// @notice Returns an existing Funding.
-    /// @param  deployer The address of the deployer.
-    /// @param  beneficiary The address of the beneficiary (who receives benefits of deployment).
-    /// @param  admin The address of the admin.
-    /// @param  token The address of the token used for funding.
-    /// @return amount The amount of funding.
-    /// @return sponsor The address of the sponsor.
-    function fundings(
+    /// @notice Gets the amount of funding available for a specific deployment configuration.
+    /// @param deployer The address that can do the deployment.
+    /// @param beneficiary The address that can use the funding.
+    /// @param admin The address that controls the workflow.
+    /// @param token The token used for funding.
+    /// @return amount The amount of funding available.
+    function getFundingAmount(
         address deployer,
         address beneficiary,
         address admin,
         address token
-    ) external view returns (uint amount, address sponsor);
+    ) external view returns (uint amount);
+
+    /// @notice Gets the amount of funding provided by a specific sponsor for a deployment configuration.
+    /// @param deployer The address that can do the deployment.
+    /// @param beneficiary The address that can use the funding.
+    /// @param admin The address that controls the workflow.
+    /// @param token The token used for funding.
+    /// @param sponsor The address of the sponsor to check.
+    /// @return amount The amount sponsored by this address.
+    function getFundingSponsorship(
+        address deployer,
+        address beneficiary,
+        address admin,
+        address token,
+        address sponsor
+    ) external view returns (uint amount);
 
     /// @notice Deploys a new issuance token and uses that to deploy a workflow with restricted bonding curve.
     /// @dev Requires the deployment to have been funded previously via `addFunding`.

--- a/src/modules/logicModule/interfaces/ILM_PC_PaymentRouter_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_PaymentRouter_v1.sol
@@ -3,13 +3,6 @@ pragma solidity ^0.8.0;
 
 interface ILM_PC_PaymentRouter_v1 {
     //--------------------------------------------------------------------------
-    // Non-Mutating Functions
-
-    /// @notice Returns constant PAYMENT_PUSHER_ROLE.
-    /// @return Role that allows to push payments thorugh the Payment Router.
-    function PAYMENT_PUSHER_ROLE() external view returns (bytes32);
-
-    //--------------------------------------------------------------------------
     // Mutating Functions
 
     /// @notice Adds a new Payment Order.

--- a/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
+++ b/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
@@ -419,26 +419,26 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         assertEq(recordedSponsor, address(0));
     }
 
-    // /* Test createPIMWorkflow
-    //     └── given that the curve creation has been funded
-    //     |   └── when called
-    //     |       └── then it mints initial issuance supply to beneficiary
-    //     |       └── then it transfers initial collateral supply from sponsor to bonding curve
-    //     |       └── then it revokes issuanceToken minting rights from factory
-    //     |       └── then it grants issuanceToken minting rights to mint wrapper
-    //     |       └── then it grants minting minting rights on mint wrapper to bonding curve
-    //     |       └── then it grants curve interaction role to beneficiary
-    //     |       └── then it grants payment pusher role to beneficiary
-    //     |       └── then it transfers ownership of mint wrapper to admin
-    //     |       └── then it renounces ownership of issuance token
-    //     |       └── then it revokes orchestrator admin rights from factory and transfers them to admin
-    //     |       └── then it removes available funding from factory
-    //     |       └── then it resets the sponsor
-    //     |       └── then it emits a PIMWorkflowCreated event
-    //     └── given that there is no funding
-    //     |   └── when called
-    //     |       └── then it reverts
-    // */
+    /* Test createPIMWorkflow
+        └── given that the curve creation has been funded
+        |   └── when called
+        |       └── then it mints initial issuance supply to beneficiary
+        |       └── then it transfers initial collateral supply from sponsor to bonding curve
+        |       └── then it revokes issuanceToken minting rights from factory
+        |       └── then it grants issuanceToken minting rights to mint wrapper
+        |       └── then it grants minting minting rights on mint wrapper to bonding curve
+        |       └── then it grants curve interaction role to beneficiary
+        |       └── then it grants payment pusher role to beneficiary
+        |       └── then it transfers ownership of mint wrapper to admin
+        |       └── then it renounces ownership of issuance token
+        |       └── then it revokes orchestrator admin rights from factory and transfers them to admin
+        |       └── then it removes available funding from factory
+        |       └── then it resets the sponsor
+        |       └── then it emits a PIMWorkflowCreated event
+        └── given that there is no funding
+        |   └── when called
+        |       └── then it reverts
+    */
 
     function testCreatePIMWorkflow_WithFunding() public {
         // add funding

--- a/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
+++ b/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
@@ -25,6 +25,8 @@ import {IERC20Issuance_v1} from "@ex/token/IERC20Issuance_v1.sol";
 import {IOwnable} from "@ex/interfaces/IOwnable.sol";
 import {ILM_PC_PaymentRouter_v1} from
     "src/modules/logicModule/interfaces/ILM_PC_PaymentRouter_v1.sol";
+import {LM_PC_PaymentRouter_v1} from
+    "src/modules/logicModule/LM_PC_PaymentRouter_v1.sol";
 import {ERC165Upgradeable} from
     "@oz-up/utils/introspection/ERC165Upgradeable.sol";
 
@@ -528,7 +530,7 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
             }
         }
         bytes32 paymentPusherRole =
-            ILM_PC_PaymentRouter_v1(paymentRouter).PAYMENT_PUSHER_ROLE();
+            LM_PC_PaymentRouter_v1(paymentRouter).PAYMENT_PUSHER_ROLE();
         bytes32 paymentPusherRoleId = orchestrator.authorizer().generateRoleId(
             paymentRouter, paymentPusherRole
         );

--- a/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
+++ b/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
@@ -45,12 +45,12 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
     IOrchestratorFactory_v1.ModuleConfig[] logicModuleConfigs;
     IFM_BC_Bancor_Redeeming_VirtualSupply_v1.BondingCurveProperties bcProperties;
     IBondingCurveBase_v1.IssuanceToken issuanceTokenParams;
-    address beneficiary = vm.addr(69);
 
     // addresses
-    address admin = vm.addr(420);
-    address actor = address(this);
-    address sponsor = vm.addr(1);
+    address sponsor = vm.addr(420);
+    address deployer = address(this);
+    address beneficiary = vm.addr(69);
+    address admin = vm.addr(666);
     address mockTrustedForwarder = vm.addr(3);
 
     // bc params
@@ -122,112 +122,336 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
             maxSupply: type(uint).max - 1
         });
 
-        // mint collateral token to deployer and approve to factory
-        token.mint(admin, type(uint).max);
+        // mint collateral token to sponsor
+        token.mint(sponsor, type(uint).max);
     }
 
     /* Test addFunding
         └── given that token has been approved
         |   └── when called
         |       └── then it sends collateral tokens from sender to factory
+        |       └── then records the funding amount
         |       └── then emits an event
         └── given that token has NOT been approved
             └── when called
                 └── then it reverts
     */
     function testAddFunding() public {
-        vm.startPrank(admin);
+        vm.startPrank(sponsor);
 
         token.approve(address(factory), initialCollateralSupply);
 
         // CHECK: event is emitted
         vm.expectEmit(true, true, true, true);
         emit IRestricted_PIM_Factory_v1.FundingAdded(
-            admin, actor, address(token), initialCollateralSupply
+            sponsor,
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
         );
 
-        factory.addFunding(actor, address(token), initialCollateralSupply);
+        factory.addFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
 
+        // CHECK: funding amount is recorded
+        (uint amount, address recordedSponsor) =
+            factory.fundings(deployer, beneficiary, admin, address(token));
+        assertEq(amount, initialCollateralSupply);
+        assertEq(recordedSponsor, sponsor);
         // CHECK: factory HOLDS collateral tokens
         assertEq(token.balanceOf(address(factory)), initialCollateralSupply);
         vm.stopPrank();
     }
 
     function testAddFunding_WithoutApproval() public {
-        vm.startPrank(admin);
+        vm.startPrank(sponsor);
         vm.expectRevert();
-        factory.addFunding(actor, address(token), initialCollateralSupply);
+        factory.addFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
+    }
+
+    function testAddFunding_MultipleTimes() public {
+        vm.startPrank(sponsor);
+
+        uint firstAmount = 10;
+        uint secondAmount = 10;
+
+        // First funding
+        token.approve(address(factory), firstAmount);
+        factory.addFunding(
+            deployer, beneficiary, admin, address(token), firstAmount
+        );
+
+        // Second funding
+        token.approve(address(factory), secondAmount);
+        factory.addFunding(
+            deployer, beneficiary, admin, address(token), secondAmount
+        );
+
+        // CHECK: total funding amount is recorded correctly
+        (uint amount,) =
+            factory.fundings(deployer, beneficiary, admin, address(token));
+        assertEq(amount, firstAmount + secondAmount);
+
+        // CHECK: factory HOLDS total collateral tokens
+        assertEq(token.balanceOf(address(factory)), firstAmount + secondAmount);
+        vm.stopPrank();
+    }
+
+    function testAddFunding_DifferentSponsor() public {
+        // First sponsor adds funding
+        vm.startPrank(sponsor);
+        token.approve(address(factory), initialCollateralSupply / 2);
+        factory.addFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply / 2
+        );
+        vm.stopPrank();
+
+        // Different sponsor tries to add funding
+        address differentSponsor = address(0x123);
+        vm.startPrank(differentSponsor);
+        deal(address(token), differentSponsor, initialCollateralSupply / 2);
+        token.approve(address(factory), initialCollateralSupply / 2);
+
+        vm.expectRevert(
+            IRestricted_PIM_Factory_v1
+                .FundingAlreadyAddedByDifferentSponsor
+                .selector
+        );
+        factory.addFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply / 2
+        );
+        vm.stopPrank();
     }
 
     /* Test withdrawFunding
         └── given that caller had added funding before
         |   └── when called
         |       └── then it withdraws tokens from factory
+        |       └── then it adjusts the funding amount as recorded on the contract
         |       └── then emits an event
         └── given that caller had NOT added funding before (trying to steal someones funding)
             └── when called
                 └── then it reverts
     */
-    function testWithdrawFunding() public {
-        vm.startPrank(admin);
+
+    function testWithdrawFunding_Completely() public {
+        vm.startPrank(sponsor);
         token.approve(address(factory), initialCollateralSupply);
-        factory.addFunding(actor, address(token), initialCollateralSupply);
+        factory.addFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
 
         // CHECK: event is emitted
         vm.expectEmit(true, true, true, true);
         emit IRestricted_PIM_Factory_v1.FundingRemoved(
-            admin, actor, address(token), initialCollateralSupply
+            sponsor,
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
         );
 
         // CHECK: factory DOES NOT hold collateral tokens
-        factory.withdrawFunding(actor, address(token), initialCollateralSupply);
-        assertEq(token.balanceOf(address(factory)), 0);
-        vm.stopPrank();
-    }
-
-    function testWithdrawFunding_AsThief() public {
-        vm.startPrank(admin);
-        token.approve(address(factory), initialCollateralSupply);
-        factory.addFunding(actor, address(token), initialCollateralSupply);
-        vm.stopPrank();
-
-        address thief = vm.addr(69);
-        vm.startPrank(thief);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IRestricted_PIM_Factory_v1.InsufficientFunding.selector, 0
-            )
+        factory.withdrawFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
         );
-        factory.withdrawFunding(actor, address(token), initialCollateralSupply);
+        assertEq(token.balanceOf(address(factory)), 0);
+
+        // CHECK: funding amount is adjusted on contract
+        (uint amount, address recordedSponsor) =
+            factory.fundings(deployer, beneficiary, admin, address(token));
+        assertEq(amount, 0);
+
+        // CHECK: sponsor is set to zero
+        assertEq(recordedSponsor, address(0));
         vm.stopPrank();
     }
 
-    /* Test createPIMWorkflow
-        └── given that the curve creation has been funded
-        |   └── when called
-        |       └── then it mints initial issuance supply to beneficiary
-        |       └── then it transfers initial collateral supply from sponsor to bonding curve
-        |       └── then it revokes issuanceToken minting rights from factory
-        |       └── then it grants issuanceToken minting rights to mint wrapper
-        |       └── then it grants minting minting rights on mint wrapper to bonding curve
-        |       └── then it grants curve interaction role to beneficiary
-        |       └── then it grants payment pusher role to beneficiary
-        |       └── then it transfers ownership of mint wrapper to admin
-        |       └── then it renounces ownership of issuance token
-        |       └── then it revokes orchestrator admin rights from factory and transfers them to admin
-        |       └── then it emits a PIMWorkflowCreated event
-        └── given that there is no funding
-        |   └── when called
-        |       └── then it reverts
-    */
+    function testWithdrawFunding_Partially() public {
+        uint partialWithdrawalAmount = initialCollateralSupply / 2;
+
+        vm.startPrank(sponsor);
+        token.approve(address(factory), initialCollateralSupply);
+        factory.addFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
+
+        // CHECK: event is emitted
+        vm.expectEmit(true, true, true, true);
+        emit IRestricted_PIM_Factory_v1.FundingRemoved(
+            sponsor,
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            partialWithdrawalAmount
+        );
+
+        // Perform partial withdrawal
+        factory.withdrawFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            partialWithdrawalAmount
+        );
+
+        // CHECK: factory holds remaining collateral tokens
+        assertEq(
+            token.balanceOf(address(factory)),
+            initialCollateralSupply - partialWithdrawalAmount
+        );
+
+        // CHECK: funding amount is adjusted on contract
+        (uint remainingAmount, address recordedSponsor) =
+            factory.fundings(deployer, beneficiary, admin, address(token));
+        assertEq(
+            remainingAmount, initialCollateralSupply - partialWithdrawalAmount
+        );
+
+        // CHECK: sponsor is still set
+        assertEq(recordedSponsor, sponsor);
+
+        vm.stopPrank();
+    }
+
+    function testWithdrawFunding_OnlySponsorCanWithdraw() public {
+        // Setup: Add funding
+        vm.startPrank(sponsor);
+        token.approve(address(factory), initialCollateralSupply);
+        factory.addFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
+        vm.stopPrank();
+
+        // Attempt to withdraw as non-sponsor
+        vm.startPrank(deployer);
+        vm.expectRevert(IRestricted_PIM_Factory_v1.NotAuthorized.selector);
+        factory.withdrawFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
+        vm.stopPrank();
+
+        // Attempt to withdraw as beneficiary
+        vm.startPrank(beneficiary);
+        vm.expectRevert(IRestricted_PIM_Factory_v1.NotAuthorized.selector);
+        factory.withdrawFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
+        vm.stopPrank();
+
+        // Attempt to withdraw as admin
+        vm.startPrank(admin);
+        vm.expectRevert(IRestricted_PIM_Factory_v1.NotAuthorized.selector);
+        factory.withdrawFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
+        vm.stopPrank();
+
+        // Successful withdrawal as sponsor
+        vm.startPrank(sponsor);
+        factory.withdrawFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
+        vm.stopPrank();
+
+        // CHECK: Funding is completely withdrawn
+        (uint remainingAmount, address recordedSponsor) =
+            factory.fundings(deployer, beneficiary, admin, address(token));
+        assertEq(remainingAmount, 0);
+        // CHECK: sponsor is reset
+        assertEq(recordedSponsor, address(0));
+    }
+
+    // /* Test createPIMWorkflow
+    //     └── given that the curve creation has been funded
+    //     |   └── when called
+    //     |       └── then it mints initial issuance supply to beneficiary
+    //     |       └── then it transfers initial collateral supply from sponsor to bonding curve
+    //     |       └── then it revokes issuanceToken minting rights from factory
+    //     |       └── then it grants issuanceToken minting rights to mint wrapper
+    //     |       └── then it grants minting minting rights on mint wrapper to bonding curve
+    //     |       └── then it grants curve interaction role to beneficiary
+    //     |       └── then it grants payment pusher role to beneficiary
+    //     |       └── then it transfers ownership of mint wrapper to admin
+    //     |       └── then it renounces ownership of issuance token
+    //     |       └── then it revokes orchestrator admin rights from factory and transfers them to admin
+    //     |       └── then it removes available funding from factory
+    //     |       └── then it resets the sponsor
+    //     |       └── then it emits a PIMWorkflowCreated event
+    //     └── given that there is no funding
+    //     |   └── when called
+    //     |       └── then it reverts
+    // */
 
     function testCreatePIMWorkflow_WithFunding() public {
         // add funding
-        vm.startPrank(admin);
+        vm.startPrank(sponsor);
         token.approve(address(factory), initialCollateralSupply);
-        factory.addFunding(beneficiary, address(token), initialCollateralSupply);
+        factory.addFunding(
+            deployer,
+            beneficiary,
+            admin,
+            address(token),
+            initialCollateralSupply
+        );
         vm.stopPrank();
 
+        vm.startPrank(deployer);
         // start recording logs
         vm.recordLogs();
         IOrchestrator_v1 orchestrator = factory.createPIMWorkflow(
@@ -240,6 +464,7 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
             beneficiary
         );
         Vm.Log[] memory logs = vm.getRecordedLogs();
+        vm.stopPrank();
         // get issuance token address from event
         (bool emitted, bytes32 eventTopic) = eventHelpers.getEventTopic(
             IRestricted_PIM_Factory_v1.PIMWorkflowCreated.selector, logs, 2
@@ -265,8 +490,14 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
             token.balanceOf(fundingManager),
             bcProperties.initialCollateralSupply
         );
-        // CHECK: factory DOES NOT have minting rights on token anymore
+        // CHECK: factory DOES NOT have minting rights on token
         assertFalse(issuanceToken.allowedMinters(address(factory)));
+        // CHECK: factory DOES NOT have minting rights on mint wrapper
+        assertFalse(
+            IERC20Issuance_v1(mintWrapperAddress).allowedMinters(
+                address(factory)
+            )
+        );
         // CHECK: mint wrapper HAS minting rights on token
         assertTrue(issuanceToken.allowedMinters(mintWrapperAddress));
         // CHECK: bonding curve HAS minting rights on mint wrapper
@@ -317,6 +548,12 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         assertFalse(
             orchestrator.authorizer().hasRole(adminRole, address(factory))
         );
+        // CHECK: available funding is removed from factory
+        (uint amount, address recordedSponsor) =
+            factory.fundings(deployer, beneficiary, admin, address(token));
+        assertEq(amount, 0);
+        // CHECK: sponsor is reset
+        assertEq(recordedSponsor, address(0));
     }
 
     function testCreatePIMWorkflow_WithoutFunding() public {

--- a/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
+++ b/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
@@ -57,7 +57,7 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
 
     // bc params
     uint initialIssuuanceSupply = 122_727_272_727_272_727_272_727;
-    uint initialCollateralSupply = 3_163_408_614_166_851_161;
+    uint initialCollateralSupply = 3_163_408_614_166_851_162;
     uint32 reserveRatio = 160_000;
 
     function setUp() public override {
@@ -163,10 +163,14 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         );
 
         // CHECK: funding amount is recorded
-        (uint amount, address recordedSponsor) =
-            factory.fundings(deployer, beneficiary, admin, address(token));
+        uint amount = factory.getFundingAmount(
+            deployer, beneficiary, admin, address(token)
+        );
         assertEq(amount, initialCollateralSupply);
-        assertEq(recordedSponsor, sponsor);
+        uint sponsorAmount = factory.getFundingSponsorship(
+            deployer, beneficiary, admin, address(token), sponsor
+        );
+        assertEq(sponsorAmount, initialCollateralSupply);
         // CHECK: factory HOLDS collateral tokens
         assertEq(token.balanceOf(address(factory)), initialCollateralSupply);
         vm.stopPrank();
@@ -203,9 +207,14 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         );
 
         // CHECK: total funding amount is recorded correctly
-        (uint amount,) =
-            factory.fundings(deployer, beneficiary, admin, address(token));
+        uint amount = factory.getFundingAmount(
+            deployer, beneficiary, admin, address(token)
+        );
         assertEq(amount, firstAmount + secondAmount);
+        uint sponsorAmount = factory.getFundingSponsorship(
+            deployer, beneficiary, admin, address(token), sponsor
+        );
+        assertEq(sponsorAmount, firstAmount + secondAmount);
 
         // CHECK: factory HOLDS total collateral tokens
         assertEq(token.balanceOf(address(factory)), firstAmount + secondAmount);
@@ -231,11 +240,6 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         deal(address(token), differentSponsor, initialCollateralSupply / 2);
         token.approve(address(factory), initialCollateralSupply / 2);
 
-        vm.expectRevert(
-            IRestricted_PIM_Factory_v1
-                .FundingAlreadyAddedByDifferentSponsor
-                .selector
-        );
         factory.addFunding(
             deployer,
             beneficiary,
@@ -244,6 +248,22 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
             initialCollateralSupply / 2
         );
         vm.stopPrank();
+
+        // CHECK: funding amount is added
+        uint amount = factory.getFundingAmount(
+            deployer, beneficiary, admin, address(token)
+        );
+        assertEq(amount, initialCollateralSupply);
+
+        uint sponsorAmount = factory.getFundingSponsorship(
+            deployer, beneficiary, admin, address(token), sponsor
+        );
+        assertEq(sponsorAmount, initialCollateralSupply / 2);
+
+        uint differentSponsorAmount = factory.getFundingSponsorship(
+            deployer, beneficiary, admin, address(token), differentSponsor
+        );
+        assertEq(differentSponsorAmount, initialCollateralSupply / 2);
     }
 
     /* Test withdrawFunding
@@ -290,12 +310,15 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         assertEq(token.balanceOf(address(factory)), 0);
 
         // CHECK: funding amount is adjusted on contract
-        (uint amount, address recordedSponsor) =
-            factory.fundings(deployer, beneficiary, admin, address(token));
+        uint amount = factory.getFundingAmount(
+            deployer, beneficiary, admin, address(token)
+        );
         assertEq(amount, 0);
+        uint sponsorAmount = factory.getFundingSponsorship(
+            deployer, beneficiary, admin, address(token), sponsor
+        );
+        assertEq(sponsorAmount, 0);
 
-        // CHECK: sponsor is set to zero
-        assertEq(recordedSponsor, address(0));
         vm.stopPrank();
     }
 
@@ -339,14 +362,16 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         );
 
         // CHECK: funding amount is adjusted on contract
-        (uint remainingAmount, address recordedSponsor) =
-            factory.fundings(deployer, beneficiary, admin, address(token));
+        uint remainingAmount = factory.getFundingAmount(
+            deployer, beneficiary, admin, address(token)
+        );
         assertEq(
             remainingAmount, initialCollateralSupply - partialWithdrawalAmount
         );
-
-        // CHECK: sponsor is still set
-        assertEq(recordedSponsor, sponsor);
+        uint sponsorAmount = factory.getFundingSponsorship(
+            deployer, beneficiary, admin, address(token), sponsor
+        );
+        assertEq(sponsorAmount, partialWithdrawalAmount);
 
         vm.stopPrank();
     }
@@ -366,7 +391,12 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
 
         // Attempt to withdraw as non-sponsor
         vm.startPrank(deployer);
-        vm.expectRevert(IRestricted_PIM_Factory_v1.NotAuthorized.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IRestricted_PIM_Factory_v1.InsufficientFunding.selector, 
+                0 // Pass the parameter value here
+            )
+        );
         factory.withdrawFunding(
             deployer,
             beneficiary,
@@ -378,7 +408,12 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
 
         // Attempt to withdraw as beneficiary
         vm.startPrank(beneficiary);
-        vm.expectRevert(IRestricted_PIM_Factory_v1.NotAuthorized.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IRestricted_PIM_Factory_v1.InsufficientFunding.selector, 
+                0 // Pass the parameter value here
+            )
+        );
         factory.withdrawFunding(
             deployer,
             beneficiary,
@@ -390,7 +425,12 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
 
         // Attempt to withdraw as admin
         vm.startPrank(admin);
-        vm.expectRevert(IRestricted_PIM_Factory_v1.NotAuthorized.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IRestricted_PIM_Factory_v1.InsufficientFunding.selector, 
+                0 // Pass the parameter value here
+            )
+        );
         factory.withdrawFunding(
             deployer,
             beneficiary,
@@ -412,11 +452,14 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         vm.stopPrank();
 
         // CHECK: Funding is completely withdrawn
-        (uint remainingAmount, address recordedSponsor) =
-            factory.fundings(deployer, beneficiary, admin, address(token));
+        uint remainingAmount = factory.getFundingAmount(
+            deployer, beneficiary, admin, address(token)
+        );
         assertEq(remainingAmount, 0);
-        // CHECK: sponsor is reset
-        assertEq(recordedSponsor, address(0));
+        uint sponsorAmount = factory.getFundingSponsorship(
+            deployer, beneficiary, admin, address(token), sponsor
+        );
+        assertEq(sponsorAmount, 0);
     }
 
     /* Test createPIMWorkflow
@@ -551,11 +594,15 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
             orchestrator.authorizer().hasRole(adminRole, address(factory))
         );
         // CHECK: available funding is removed from factory
-        (uint amount, address recordedSponsor) =
-            factory.fundings(deployer, beneficiary, admin, address(token));
+        uint amount = factory.getFundingAmount(
+            deployer, beneficiary, admin, address(token)
+        );
         assertEq(amount, 0);
-        // CHECK: sponsor is reset
-        assertEq(recordedSponsor, address(0));
+        // CHECK: sponsor's funding record is NOT removed from factory
+        uint sponsorAmount = factory.getFundingSponsorship(
+            deployer, beneficiary, admin, address(token), sponsor
+        );
+        assertEq(sponsorAmount, initialCollateralSupply);
     }
 
     function testCreatePIMWorkflow_WithoutFunding() public {

--- a/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
+++ b/test/factories/custom/Restricted_PIM_Factory_v1.t.sol
@@ -393,7 +393,7 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         vm.startPrank(deployer);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IRestricted_PIM_Factory_v1.InsufficientFunding.selector, 
+                IRestricted_PIM_Factory_v1.InsufficientFunding.selector,
                 0 // Pass the parameter value here
             )
         );
@@ -410,7 +410,7 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         vm.startPrank(beneficiary);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IRestricted_PIM_Factory_v1.InsufficientFunding.selector, 
+                IRestricted_PIM_Factory_v1.InsufficientFunding.selector,
                 0 // Pass the parameter value here
             )
         );
@@ -427,7 +427,7 @@ contract Restricted_PIM_Factory_v1Test is E2ETest {
         vm.startPrank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IRestricted_PIM_Factory_v1.InsufficientFunding.selector, 
+                IRestricted_PIM_Factory_v1.InsufficientFunding.selector,
                 0 // Pass the parameter value here
             )
         );


### PR DESCRIPTION
### Changes: split sponsor (who adds funding) and workflow admin + add deployer allowlist:
* previously the sponsor was equal to the workflow admin => for legal reasons this needs to be changed
* additionally: anyone could use a funding for a deployment, deploying with an arbitrary (undesired) config

=> both is addressed in this PR

---

* new logic: sponsor (who adds funding) specifies 
  * which deployer can deploy a workflow 
  * for which beneficiary (receives initial issuance supply and CURVE_INTERACTION as well as PAYMENT_PUSHER role)
  * with which admin (is the workflow admin)
* `createPIMWorkflow` interface stays unchanged