### PR TITLE
Fix: Resolve guidelines issues prior to v1.1.0 release

### DIFF
--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -46,21 +46,27 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 /**
  * @title   Inverter Bancor Virtual Supply Bonding Curve Funding Manager
  *
- * @notice  This contract enables the issuance and redeeming of tokens on a bonding curve, using
- *          a virtual supply for both the issuance and the collateral as input. It integrates
- *          Aragon's {BancorFormula} to manage the calculations for token issuance and redemption
- *          rates based on specified reserve ratios.
+ * @notice  This contract enables the issuance and redeeming of tokens on a
+ *          bonding curve, using a virtual supply for both the issuance and
+ *          the collateral as input. It integrates Aragon's {BancorFormula}
+ *          to manage the calculations for token issuance and redemption rates
+ *          based on specified reserve ratios.
  *
- * @dev     Inherits {BondingCurveBase_v1}, {RedeemingBondingCurveBase_v1}, {VirtualIssuanceSupplyBase_v1},
- *          and {VirtualCollateralSupplyBase_v1}. Implements formulaWrapper functions for bonding curve
- *          calculations using the {BancorFormula}. {Orchestrator_v1} Admin manages
- *          configuration such as virtual supplies and reserve ratios. Ensure interaction adheres to
- *          defined transactional limits and decimal precision requirements to prevent computational
- *          overflows or underflows.
+ * @dev     Inherits {BondingCurveBase_v1}, {RedeemingBondingCurveBase_v1},
+ *          {VirtualIssuanceSupplyBase_v1}, and
+ *          {VirtualCollateralSupplyBase_v1}. Implements formulaWrapper
+ *          functions for bonding curve calculations using the {BancorFormula}.
+ *          {Orchestrator_v1} Admin manages configuration such as virtual
+ *          supplies and reserve ratios. Ensure interaction adheres to defined
+ *          transactional limits and decimal precision requirements to prevent
+ *          computational overflows or underflows.
  *
  * @custom:security-contact security@inverter.network
- *                          In case of any concerns or findings, please refer to our Security Policy
- *                          at security.inverter.network or email us directly!
+ *                          In case of any concerns or findings, please refer
+ *                          to our Security Policy at security.inverter.network
+ *                          or email us directly!
+ *
+ * @custom:version 1.1.0
  *
  * @author  Inverter Network
  */

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -12,25 +12,32 @@ import {
 /**
  * @title   Inverter Restricted Bancor Virtual Supply Bonding Curve Funding Manager
  *
- * @notice  This contract enables the issuance and redeeming of tokens on a bonding curve, using
- *          a virtual supply for both the issuance and the collateral as input. It integrates
- *          Aragon's Bancor Formula to manage the calculations for token issuance and redemption
- *          rates based on specified reserve ratios.
+ * @notice  This contract enables the issuance and redeeming of tokens on a
+ *          bonding curve, using a virtual supply for both the issuance and
+ *          the collateral as input. It integrates Aragon's Bancor Formula to
+ *          manage the calculations for token issuance and redemption rates
+ *          based on specified reserve ratios.
  *
- * @dev     It overrides the `buyFor()` and `sellTo()` functions of its parent contract to limit
- *          them to callers holding a "Curve Interaction" role. Since the upstream functions `buy()` and `sell()`
- *          call these functions internally, they also become gated.
+ * @dev     It overrides the `buyFor()` and `sellTo()` functions of its parent
+ *          contract to limit them to callers holding a "Curve Interaction"
+ *          role. Since the upstream functions `buy()` and `sell()` call these
+ *          functions internally, they also become gated.
  *
- *          PLEASE NOTE: This means that the workflow itself can only mint tokens through buying
- *          and selling by somebody with the `CURVE_INTERACTION_ROLE`, but NOT that there are no other ways to
- *          mint tokens. The Bonding Curve uses an external token contract, and there is no guarantee that said
- *          uses an external token contract, and there is no guarantee that said contract won't
- *          have an additional way to mint tokens (and potentially sell them on the cruve to receive
- *          backing collateral)
+ *          PLEASE NOTE: This means that the workflow itself can only mint
+ *          tokens through buying and selling by somebody with the
+ *          `CURVE_INTERACTION_ROLE`, but NOT that there are no other ways to
+ *          mint tokens. The Bonding Curve uses an external token contract, and
+ *          there is no guarantee that said uses an external token contract, and
+ *          there is no guarantee that said contract won't have an additional
+ *          way to mint tokens (and potentially sell them on the cruve to
+ *          receive backing collateral)
  *
  * @custom:security-contact security@inverter.network
- *                          In case of any concerns or findings, please refer to our Security Policy
- *                          at security.inverter.network or email us directly!
+ *                          In case of any concerns or findings, please refer
+ *                          to our Security Policy at security.inverter.network
+ *                          or email us directly!
+ *
+ * @custom:version 1.1.0
  *
  * @author  Inverter Network
  */

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -31,8 +31,11 @@ import {ERC165Upgradeable} from
  *          implemented in derived contracts.
  *
  * @custom:security-contact security@inverter.network
- *                          In case of any concerns or findings, please refer to our Security Policy
- *                          at security.inverter.network or email us directly!
+ *                          In case of any concerns or findings, please refer
+ *                          to our Security Policy at security.inverter.network
+ *                          or email us directly!
+ *
+ * @custom:version 1.1.0
  *
  * @author  Inverter Network
  */

--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -31,8 +31,11 @@ import {ERC165Upgradeable} from
  *          implemented in derived contracts.
  *
  * @custom:security-contact security@inverter.network
- *                          In case of any concerns or findings, please refer to our Security Policy
- *                          at security.inverter.network or email us directly!
+ *                          In case of any concerns or findings, please refer
+ *                          to our Security Policy at security.inverter.network
+ *                          or email us directly!
+ *
+ * @custom:version 1.1.0
  *
  * @author  Inverter Network
  */


### PR DESCRIPTION
Resolving some minor guidelines adherence issues for the v1.1.0 release of the two bonding curve funding managers, mainly:
* Added updated version tag to changes contracts NatSpec
* Some small NatSpec line length fixes