### PR TITLE
Fix: Resolve Module Address Collisions

### DIFF
--- a/src/factories/ModuleFactory_v1.sol
+++ b/src/factories/ModuleFactory_v1.sol
@@ -291,7 +291,9 @@ contract ModuleFactory_v1 is
     ///         nonce is an increasing number for each user.
     function _createSalt() internal returns (bytes32) {
         return keccak256(
-            abi.encodePacked(_msgSender(), _deploymentNonces[_msgSender()]++)
+            abi.encodePacked(
+                _msgSender(), block.chainid, _deploymentNonces[_msgSender()]++
+            )
         );
     }
 

--- a/test/factories/ModuleFactory_v1.t.sol
+++ b/test/factories/ModuleFactory_v1.t.sol
@@ -516,6 +516,49 @@ contract ModuleFactoryV1Test is Test {
         );
     }
 
+    function testSaltModuleAddressWithChainId() public {
+        // Setup
+        beacon.overrideImplementation(address(module));
+
+        // Register metadata for beacon
+        vm.prank(address(governor));
+        factory.registerMetadata(DATA, beacon);
+
+        address orchestratorFactory = makeAddr("OrchestratorFactory");
+
+        // Create a module on the current chain ID
+        uint originalChainId = block.chainid;
+        vm.prank(orchestratorFactory);
+        address moduleOnChain1 = factory.createModuleProxy(
+            DATA,
+            IOrchestrator_v1(address(0x1)),
+            workflowConfigNoIndependentUpdates
+        );
+
+        // Change the chain ID to simulate deployment on a different chain
+        uint differentChainId = originalChainId + 1;
+        vm.chainId(differentChainId);
+
+        // Create a module with the same parameters but on a different chain ID
+        vm.prank(orchestratorFactory);
+        address moduleOnChain2 = factory.createModuleProxy(
+            DATA,
+            IOrchestrator_v1(address(0x1)),
+            workflowConfigNoIndependentUpdates
+        );
+
+        // Test: Deployments on different chains should result in different addresses
+        // This verifies that the salt includes the chain ID
+        assertNotEq(
+            moduleOnChain1,
+            moduleOnChain2,
+            "Deployments on different chains should have different addresses"
+        );
+
+        // Reset chain ID to original value
+        vm.chainId(originalChainId);
+    }
+
     //--------------------------------------------------------------------------
     // Internal Helper Functions
 


### PR DESCRIPTION
**Why does this PR exist?**
I noticed that the original idea - when we switched to create2-based deployments in the factories - was to allow users to deploy workflows at the same address across networks. What we did not think about back then: the `ModuleFactory_v1` is not just called by end users, but mainly be the `OrchestratorFactory_v1`, which makes the following salt calculation not unique per user:

```Solidity
function _createSalt() internal returns (bytes32) {
    return keccak256(
        abi.encodePacked(_msgSender(), _deploymentNonces[_msgSender()]++)
    );
}
```

So essentially, the system only works for `OrchestratorFactory_v1`, where the user calls the contract.

**How did I fix this?**
We decided, that it's enough if we guarantee folks that their Orchestrator can be at the same address across networks, and the modules don't matter really. So to resolve the underlying issue, I added the `chainId` into the salt calculation in the `ModuleFactory_v1`. This makes it unique at all times and the address can never be griefed (also not on accident).