### PR TITLE
Fix: Account for wrapped Issuance Tokens

### DIFF
--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -190,7 +190,28 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     // Public Functions
 
     /// @inheritdoc IBondingCurveBase_v1
+    /// @dev        Always returns the address of the issuance token, even
+    //              if the issuance token is wrapped.
     function getIssuanceToken() external view virtual returns (address) {
+        // We attempt to call the issuance tokens "issuanceToken" function,
+        // which will succeed if the issuance token is wrapped, in which
+        // case we want to return the actual token address.
+        (bool success, bytes memory returnData) = address(issuanceToken)
+            .staticcall(
+            abi.encodeWithSelector(bytes4(keccak256("issuanceToken()")))
+        );
+
+        // If the call was successful and the return data is 32 bytes long
+        // (i.e. an address), we decode the return data and return the result.
+        // We further check that the address is not zero, as this would indicate
+        // that the issuance token is not wrapped.
+        if (success && returnData.length == 32) {
+            address result = abi.decode(returnData, (address));
+            if (result != address(0)) {
+                return result;
+            }
+        }
+
         return address(issuanceToken);
     }
 

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -190,8 +190,8 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     // Public Functions
 
     /// @inheritdoc IBondingCurveBase_v1
-    /// @dev        Always returns the address of the issuance token, even
-    //              if the issuance token is wrapped.
+    /// @dev    Always returns the address of the issuance token, even if the
+    //          issuance token is wrapped.
     function getIssuanceToken() external view virtual returns (address) {
         // We attempt to call the issuance tokens "issuanceToken" function,
         // which will succeed if the issuance token is wrapped, in which

--- a/test/mocks/modules/fundingManager/bondingCurve/abstracts/BondingCurveBaseV1Mock.sol
+++ b/test/mocks/modules/fundingManager/bondingCurve/abstracts/BondingCurveBaseV1Mock.sol
@@ -167,6 +167,10 @@ contract BondingCurveBaseV1Mock is BondingCurveBase_v1 {
         _projectFeeCollected(_workflowFeeAmount);
     }
 
+    // Returns the internal variable of the issuance token storage
+    function exposed_issuanceToken() external view returns (address) {
+        return address(issuanceToken);
+    }
     // -------------------------------------------------------------------------
     // Helper function
 

--- a/test/mocks/modules/fundingManager/bondingCurve/abstracts/IssuanceTokenWrapperMock.sol
+++ b/test/mocks/modules/fundingManager/bondingCurve/abstracts/IssuanceTokenWrapperMock.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.8.0;
+
+contract IssuanceTokenWrapperMock {
+    address public issuanceToken;
+
+    constructor(address _issuanceToken) {
+        issuanceToken = _issuanceToken;
+    }
+
+    function decimals() public view returns (uint8) {
+        return 18;
+    }
+}

--- a/test/mocks/modules/fundingManager/bondingCurve/abstracts/IssuanceTokenWrapperV1Mock.sol
+++ b/test/mocks/modules/fundingManager/bondingCurve/abstracts/IssuanceTokenWrapperV1Mock.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.0;
 
-contract IssuanceTokenWrapperMock {
+contract IssuanceTokenWrapperV1Mock {
     address public issuanceToken;
 
     constructor(address _issuanceToken) {

--- a/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
+++ b/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
@@ -890,11 +890,15 @@ contract BondingCurveBaseV1Test is ModuleTest {
             ERC20Issuance_v1(actualIssuanceToken).balanceOf(address(this)), 100
         );
 
-        // Create the wrapper and set it as the new issuance token
+        // Create the wrapper
         IssuanceTokenWrapperMock wrapper =
             new IssuanceTokenWrapperMock(actualIssuanceToken);
         assertEq(wrapper.issuanceToken(), actualIssuanceToken);
+
+        // Set the wrapper as the new issuance token
+        // and verify that it's set
         bondingCurveFundingManager.call_setIssuanceToken(address(wrapper));
+        assertEq(bondingCurveFundingManager.exposed_issuanceToken(), address(wrapper));
 
         // Obtain the issuance token again
         address issuanceTokenAfterWrapper =

--- a/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
+++ b/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
@@ -28,6 +28,8 @@ import {
     IBondingCurveBase_v1
 } from
     "@mocks/modules/fundingManager/bondingCurve/abstracts/BondingCurveBaseV1Mock.sol";
+import {IssuanceTokenWrapperMock} from
+    "@mocks/modules/fundingManager/bondingCurve/utils/mocks/IssuanceTokenWrapperMock.sol";
 import {IFundingManager_v1} from "@fm/IFundingManager_v1.sol";
 
 contract BondingCurveBaseV1Test is ModuleTest {
@@ -871,8 +873,38 @@ contract BondingCurveBaseV1Test is ModuleTest {
         assertEq(bondingCurveFundingManager.buyFee(), newFee);
     }
 
+    /* Test getIssuanceToken function
+        ├── When the token is a regular token
+        │       └── it should return the token address
+        └── When the token is wrapped
+                └── it should return the underlying token address
+    */
+    function testGetIssuanceToken() public {
+        address actualIssuanceToken =
+            bondingCurveFundingManager.getIssuanceToken();
+
+        // Verify that the returned token is the actual token (i.e. works as expected)
+        ERC20Issuance_v1(actualIssuanceToken).mint(address(this), 100);
+        assertEq(
+            ERC20Issuance_v1(actualIssuanceToken).balanceOf(address(this)), 100
+        );
+
+        // Create the wrapper and set it as the new issuance token
+        IssuanceTokenWrapperMock wrapper =
+            new IssuanceTokenWrapperMock(actualIssuanceToken);
+        assertEq(wrapper.issuanceToken(), actualIssuanceToken);
+        bondingCurveFundingManager.call_setIssuanceToken(address(wrapper));
+
+        // Obtain the issuance token again
+        address issuanceTokenAfterWrapper =
+            bondingCurveFundingManager.getIssuanceToken();
+
+        // Verify that the returned token is not the wrapper,
+        // but the actual underlying token
+        assertEq(issuanceTokenAfterWrapper, actualIssuanceToken);
+    }
+
     /* Test _setIssuanceToken function
-       
         └── when setting the Token
             ├── it should set the new token
             ├── it should emit an event

--- a/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
+++ b/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
@@ -898,7 +898,9 @@ contract BondingCurveBaseV1Test is ModuleTest {
         // Set the wrapper as the new issuance token
         // and verify that it's set
         bondingCurveFundingManager.call_setIssuanceToken(address(wrapper));
-        assertEq(bondingCurveFundingManager.exposed_issuanceToken(), address(wrapper));
+        assertEq(
+            bondingCurveFundingManager.exposed_issuanceToken(), address(wrapper)
+        );
 
         // Obtain the issuance token again
         address issuanceTokenAfterWrapper =

--- a/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
+++ b/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
@@ -28,8 +28,8 @@ import {
     IBondingCurveBase_v1
 } from
     "@mocks/modules/fundingManager/bondingCurve/abstracts/BondingCurveBaseV1Mock.sol";
-import {IssuanceTokenWrapperMock} from
-    "@mocks/modules/fundingManager/bondingCurve/utils/mocks/IssuanceTokenWrapperMock.sol";
+import {IssuanceTokenWrapperV1Mock} from
+    "@mocks/modules/fundingManager/bondingCurve/abstracts/IssuanceTokenWrapperV1Mock.sol";
 import {IFundingManager_v1} from "@fm/IFundingManager_v1.sol";
 
 contract BondingCurveBaseV1Test is ModuleTest {
@@ -891,8 +891,8 @@ contract BondingCurveBaseV1Test is ModuleTest {
         );
 
         // Create the wrapper
-        IssuanceTokenWrapperMock wrapper =
-            new IssuanceTokenWrapperMock(actualIssuanceToken);
+        IssuanceTokenWrapperV1Mock wrapper =
+            new IssuanceTokenWrapperV1Mock(actualIssuanceToken);
         assertEq(wrapper.issuanceToken(), actualIssuanceToken);
 
         // Set the wrapper as the new issuance token

--- a/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
+++ b/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
@@ -883,7 +883,7 @@ contract BondingCurveBaseV1Test is ModuleTest {
         address actualIssuanceToken =
             bondingCurveFundingManager.getIssuanceToken();
 
-        // Verify that the returned token is the actual token (i.e. works as 
+        // Verify that the returned token is the actual token (i.e. works as
         // expected)
         ERC20Issuance_v1(actualIssuanceToken).mint(address(this), 100);
         assertEq(

--- a/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
+++ b/test/unit/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
@@ -883,7 +883,8 @@ contract BondingCurveBaseV1Test is ModuleTest {
         address actualIssuanceToken =
             bondingCurveFundingManager.getIssuanceToken();
 
-        // Verify that the returned token is the actual token (i.e. works as expected)
+        // Verify that the returned token is the actual token (i.e. works as 
+        // expected)
         ERC20Issuance_v1(actualIssuanceToken).mint(address(this), 100);
         assertEq(
             ERC20Issuance_v1(actualIssuanceToken).balanceOf(address(this)), 100


### PR DESCRIPTION
The current issue is that `getIssuanceToken` in the bonding-curve-based funding managers does not return the issuance token if a wrapper is used. To address this I added a fallback in the function to attempt the retrieval of an underlying token in the case of it existing. If it doesn't exist, we return the existing storage value.

This solves the issue for now, as we can not get rid of the wrappers for existing workflows.