### PR TITLE
[Audit] Revised Payment Order Struct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Compile contracts
               run: forge build
@@ -53,7 +53,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Download compiled artifacts
               uses: actions/download-artifact@v4
@@ -80,7 +80,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Download compiled artifacts
               uses: actions/download-artifact@v4
@@ -107,7 +107,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Download compiled artifacts
               uses: actions/download-artifact@v4
@@ -134,7 +134,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Download compiled artifacts
               uses: actions/download-artifact@v4

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -418,7 +418,9 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
 
             // mint fee amount
             _mint(_treasury, _feeAmount);
-            emit ProtocolFeeMinted(address(this), _treasury, _feeAmount);
+            emit ProtocolFeeMinted(
+                address(issuanceToken), _treasury, _feeAmount
+            );
         }
     }
 

--- a/src/modules/logicModule/LM_PC_Bounties_v1.sol
+++ b/src/modules/logicModule/LM_PC_Bounties_v1.sol
@@ -275,6 +275,8 @@ contract LM_PC_Bounties_v1 is ILM_PC_Bounties_v1, ERC20PaymentClientBase_v1 {
         bytes memory
     ) external override(Module_v1) initializer {
         __Module_init(orchestrator_, metadata);
+        // This module does not use any PaymentOrder flags.
+        __ERC20PaymentClientBase_v1_init(new uint8[](0));
         // init empty list of bounties and claims
         _bountyList.init();
         _claimList.init();
@@ -519,14 +521,18 @@ contract LM_PC_Bounties_v1 is ILM_PC_Bounties_v1, ERC20PaymentClientBase_v1 {
         for (uint i; i < length;) {
             contrib = contribs[i];
 
+            (bytes32 flags, bytes32[] memory data) =
+                _assemblePaymentConfig(new bytes32[](0)); // No additional payment data
+
             _addPaymentOrder(
                 PaymentOrder({
                     recipient: contrib.addr,
                     paymentToken: address(orchestrator().fundingManager().token()),
                     amount: contrib.claimAmount,
-                    start: block.timestamp,
-                    cliff: 0,
-                    end: block.timestamp // end date is now
+                    originChainId: block.chainid,
+                    targetChainId: block.chainid,
+                    flags: flags,
+                    data: data
                 })
             );
             unchecked {

--- a/src/modules/logicModule/LM_PC_Bounties_v1.sol
+++ b/src/modules/logicModule/LM_PC_Bounties_v1.sol
@@ -276,7 +276,7 @@ contract LM_PC_Bounties_v1 is ILM_PC_Bounties_v1, ERC20PaymentClientBase_v1 {
     ) external override(Module_v1) initializer {
         __Module_init(orchestrator_, metadata);
         // This module does not use any PaymentOrder flags.
-        __ERC20PaymentClientBase_v1_init(new uint8[](0));
+        __ERC20PaymentClientBase_v1_init(bytes32(0));
         // init empty list of bounties and claims
         _bountyList.init();
         _claimList.init();

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -79,14 +79,13 @@ contract LM_PC_KPIRewarder_v1 is
 
     // KPI and Configuration Storage
     /// @dev	The number of KPIs created.
-    uint public KPICounter;
+    uint internal KPICounter;
     /// @dev	Registry of KPIsid -> KPI.
-    mapping(uint => KPI) public registryOfKPIs;
+    mapping(uint => KPI) internal registryOfKPIs;
     /// @dev	Registry of Assertion Configurations assertionId -> RewardRoundConfiguration.
-    mapping(bytes32 => RewardRoundConfiguration) public assertionConfig;
-
+    mapping(bytes32 => RewardRoundConfiguration) internal assertionConfig;
     /// @dev	 For locking certain utilities when there are assertions open.
-    bool public assertionPending;
+    bool internal assertionPending;
 
     /// @dev	Storage gap for future upgrades.
     uint[50] private __gap;
@@ -136,17 +135,27 @@ contract LM_PC_KPIRewarder_v1 is
     // View functions
 
     /// @inheritdoc ILM_PC_KPIRewarder_v1
-    function getKPI(uint KPInum) public view returns (KPI memory) {
+    function getKPI(uint KPInum) external view returns (KPI memory) {
         return registryOfKPIs[KPInum];
     }
 
     /// @inheritdoc ILM_PC_KPIRewarder_v1
     function getAssertionConfig(bytes32 assertionId)
-        public
+        external
         view
         returns (RewardRoundConfiguration memory)
     {
         return assertionConfig[assertionId];
+    }
+
+    /// @inheritdoc ILM_PC_KPIRewarder_v1
+    function getKPICounter() external view returns (uint) {
+        return KPICounter;
+    }
+
+    /// @inheritdoc ILM_PC_KPIRewarder_v1
+    function getAssertionPending() external view returns (bool) {
+        return assertionPending;
     }
 
     // ========================================================================

--- a/src/modules/logicModule/LM_PC_PaymentRouter_v1.sol
+++ b/src/modules/logicModule/LM_PC_PaymentRouter_v1.sol
@@ -69,8 +69,8 @@ contract LM_PC_PaymentRouter_v1 is
     ) external override(Module_v1) initializer {
         __Module_init(orchestrator_, metadata);
 
-        // Set the flags for the PaymentOrders
-        uint8[] memory flags = new uint8[](3); // The Module will use 3 flags
+        // Set the flags for the PaymentOrders (this module uses 3 flags).
+        uint8[] memory flags = new uint8[](3);
         flags[0] = 1; // start, flag_ID 1
         flags[1] = 2; // cliff, flag_ID 2
         flags[2] = 3; // end, flag_ID 3

--- a/src/modules/logicModule/LM_PC_PaymentRouter_v1.sol
+++ b/src/modules/logicModule/LM_PC_PaymentRouter_v1.sol
@@ -95,9 +95,9 @@ contract LM_PC_PaymentRouter_v1 is
 
         {
             bytes32[] memory paymentParameters = new bytes32[](3);
-            paymentParameters[0] = bytes32(start);
+            paymentParameters[0] = bytes32(start == 0 ? block.timestamp : start);
             paymentParameters[1] = bytes32(cliff);
-            paymentParameters[2] = bytes32(end);
+            paymentParameters[2] = bytes32(end == 0 ? block.timestamp : end);
 
             (flags, data) = _assemblePaymentConfig(paymentParameters);
         }

--- a/src/modules/logicModule/LM_PC_PaymentRouter_v1.sol
+++ b/src/modules/logicModule/LM_PC_PaymentRouter_v1.sol
@@ -60,6 +60,10 @@ contract LM_PC_PaymentRouter_v1 is
     /// @dev	The role that allows the pushing of payments.
     bytes32 public constant PAYMENT_PUSHER_ROLE = "PAYMENT_PUSHER";
 
+    uint8 public constant FLAG_START = 1;
+    uint8 public constant FLAG_CLIFF = 2;
+    uint8 public constant FLAG_END = 3;
+
     //--------------------------------------------------------------------------
     // Initializer
     function init(
@@ -70,10 +74,10 @@ contract LM_PC_PaymentRouter_v1 is
         __Module_init(orchestrator_, metadata);
 
         // Set the flags for the PaymentOrders (this module uses 3 flags).
-        uint8[] memory flags = new uint8[](3);
-        flags[0] = 1; // start, flag_ID 1
-        flags[1] = 2; // cliff, flag_ID 2
-        flags[2] = 3; // end, flag_ID 3
+        bytes32 flags;
+        flags |= bytes32(1 << FLAG_START);
+        flags |= bytes32(1 << FLAG_CLIFF);
+        flags |= bytes32(1 << FLAG_END);
 
         __ERC20PaymentClientBase_v1_init(flags);
     }

--- a/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
+++ b/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
@@ -112,6 +112,10 @@ contract LM_PC_RecurringPayments_v1 is
     /// @dev	List of RecurringPayment id's.
     LinkedIdList.List _paymentList;
 
+    /// @dev	Flags used for the payment order.
+    uint8 constant FLAG_START = 1;
+    uint8 constant FLAG_END = 3;
+
     /// @dev	Storage gap for future upgrades.
     uint[50] private __gap;
 
@@ -139,10 +143,9 @@ contract LM_PC_RecurringPayments_v1 is
 
         emit EpochLengthSet(newEpochLength);
 
-        // Set the flags for the PaymentOrders (this module uses 2 flags).
-        uint8[] memory flags = new uint8[](2);
-        flags[0] = 1; // start, flag_ID 1
-        flags[1] = 3; // end, flag_ID 3
+        bytes32 flags;
+        flags |= bytes32(1 << FLAG_START);
+        flags |= bytes32(1 << FLAG_END);
 
         __ERC20PaymentClientBase_v1_init(flags);
     }

--- a/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
+++ b/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
@@ -139,8 +139,8 @@ contract LM_PC_RecurringPayments_v1 is
 
         emit EpochLengthSet(newEpochLength);
 
-        // Set the flags for the PaymentOrders
-        uint8[] memory flags = new uint8[](2); // The Module will use 2 flags
+        // Set the flags for the PaymentOrders (this module uses 2 flags).
+        uint8[] memory flags = new uint8[](2);
         flags[0] = 1; // start, flag_ID 1
         flags[1] = 3; // end, flag_ID 3
 

--- a/src/modules/logicModule/LM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/LM_PC_Staking_v1.sol
@@ -114,7 +114,7 @@ contract LM_PC_Staking_v1 is
         address _stakingToken = abi.decode(configData, (address));
         __LM_PC_Staking_v1_init(_stakingToken);
 
-        __ERC20PaymentClientBase_v1_init(new uint8[](0)); // This module does not use any PaymentOrder flags
+        __ERC20PaymentClientBase_v1_init(bytes32(0)); // This module does not use any PaymentOrder flags
     }
 
     /// @dev	Initializes the staking contract.

--- a/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
+++ b/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
@@ -102,7 +102,7 @@ abstract contract ERC20PaymentClientBase_v1 is
     /// @dev	Initializes the staking contract.
     /// @param  flags_ The flags, represented as an array of uint8 containing
     ///         the flag IDs between 0 and 255.
-    function __ERC20PaymentClientBase_v1_init(uint8[] memory flags_)
+    function __ERC20PaymentClientBase_v1_init(bytes32 flags_)
         internal
         onlyInitializing
     {
@@ -147,19 +147,17 @@ abstract contract ERC20PaymentClientBase_v1 is
     /// @dev    Sets the flags for the PaymentOrders.
     /// @param  flags_ The flags, represented as an array of uint8 containing
     ///         the flag IDs between 0 and 255.
-    function _setFlags(uint8[] memory flags_) internal virtual {
-        uint amountOfFlags = flags_.length;
+    function _setFlags(bytes32 flags_) internal virtual {
+        uint8 amountOfFlags = 0;
 
-        if (amountOfFlags > type(uint8).max) {
-            revert Module__ERC20PaymentClientBase_v1__FlagAmountTooHigh();
+        for (uint i = 0; i <= type(uint8).max; i++) {
+            if (flags_ & bytes32((1 << i)) != 0) {
+                amountOfFlags++;
+            }
         }
 
-        _flagCount = uint8(amountOfFlags);
-
-        _flags = 0;
-        for (uint8 i = 0; i < amountOfFlags; i++) {
-            _flags |= bytes32((1 << flags_[i]));
-        }
+        _flags = flags_;
+        _flagCount = amountOfFlags;
 
         emit FlagsSet(uint8(amountOfFlags), _flags);
     }

--- a/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
+++ b/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
@@ -161,7 +161,7 @@ abstract contract ERC20PaymentClientBase_v1 is
             _flags |= bytes32((1 << flags_[i]));
         }
 
-        emit FlagsSet(_flagCount, _flags);
+        emit FlagsSet(uint8(amountOfFlags), _flags);
     }
 
     //--------------------------------------------------------------------------

--- a/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
+++ b/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
@@ -106,11 +106,7 @@ abstract contract ERC20PaymentClientBase_v1 is
         internal
         onlyInitializing
     {
-        uint amountOfFlags = flags_.length;
-        if (amountOfFlags > type(uint8).max) {
-            revert Module__ERC20PaymentClientBase_v1__FlagAmountTooHigh();
-        }
-        _setFlags(uint8(flags_.length), flags_);
+        _setFlags(flags_);
     }
 
     /// @dev	Adds a new {PaymentOrder} to the list of outstanding orders.
@@ -149,28 +145,23 @@ abstract contract ERC20PaymentClientBase_v1 is
     }
 
     /// @dev    Sets the flags for the PaymentOrders.
-    /// @param  flagCount_ The number of flags.
     /// @param  flags_ The flags, represented as an array of uint8 containing
     ///         the flag IDs between 0 and 255.
-    function _setFlags(uint8 flagCount_, uint8[] memory flags_)
-        internal
-        virtual
-    {
-        if (flagCount_ != flags_.length) {
-            revert
-                Module__ERC20PaymentClientBase__MismatchBetweenFlagCountAndArrayLength(
-                flagCount_, flags_.length
-            );
+    function _setFlags(uint8[] memory flags_) internal virtual {
+        uint amountOfFlags = flags_.length;
+
+        if (amountOfFlags > type(uint8).max) {
+            revert Module__ERC20PaymentClientBase_v1__FlagAmountTooHigh();
         }
 
-        _flagCount = flagCount_;
+        _flagCount = uint8(amountOfFlags);
 
         _flags = 0;
-        for (uint8 i = 0; i < flagCount_; i++) {
+        for (uint8 i = 0; i < amountOfFlags; i++) {
             _flags |= bytes32((1 << flags_[i]));
         }
 
-        emit FlagsSet(flagCount_, _flags);
+        emit FlagsSet(_flagCount, _flags);
     }
 
     //--------------------------------------------------------------------------

--- a/src/modules/logicModule/interfaces/IERC20PaymentClientBase_v1.sol
+++ b/src/modules/logicModule/interfaces/IERC20PaymentClientBase_v1.sol
@@ -42,23 +42,13 @@ interface IERC20PaymentClientBase_v1 {
     /*
     | Flag | Variable type | Name       | Description                         |
     |------|---------------|------------|-------------------------------------|
-    | 0    | bytes32       | orderID    | ID of the order.                    |
+    | 0    | uint256       | orderID    | ID of the order within the client.  |
     | 1    | uint256       | start      | Start date of the streaming period. | 
     | 2    | uint256       | cliff      | Duration of the cliff period.       |
     | 3    | uint256       | end        | Due Date of the order               |
     | ...  | ...           | ...        | (yet unassigned)                    |
     | 255  | .             | .          | (Max Value).                        | 
     |------|---------------|------------|-------------------------------------|
-    */
-
-    /*
-    | Flag | Name       | Disclaimer                                          |
-    |------|------------|-----------------------------------------------------|
-    | 0    | orderID    | The order id should be a hashed value of an         |
-    |      |            | internally tracked id and the paymentOrder origin   |
-    |      |            | address, to prevent duplicate order ids from        |
-    |      |            | different ERC20PaymentClients.                      |
-    |------|------------|-----------------------------------------------------|
     */
 
     //--------------------------------------------------------------------------

--- a/src/modules/logicModule/interfaces/IERC20PaymentClientBase_v1.sol
+++ b/src/modules/logicModule/interfaces/IERC20PaymentClientBase_v1.sol
@@ -5,24 +5,83 @@ pragma solidity ^0.8.0;
 import {IPaymentProcessor_v1} from
     "src/modules/paymentProcessor/IPaymentProcessor_v1.sol";
 
+/**
+ * @title   Inverter ERC20 Payment Client Base Interface
+ *
+ * @notice  Enables modules within the Inverter Network to create and manage
+ *          payment orders that can be processed by authorized payment
+ *          processors, ensuring efficient and secure transactions. Refer to
+ *          the implementations contract for more details.
+ *
+ * @dev     STRUCTURING OF THE FLAGS AND DATA FIELDS
+ *          The PaymentOrder struct implements a flag system to manage the
+ *          information payloads received by the payment processor. It is
+ *          comprised of a bytes32 value that indicates the number of flags
+ *          that are active, and a bytes32[] value that stores the
+ *          corresponding values.
+ *
+ *          For example:
+ *          If the value of 'flags' is '0000 [...] 0000 1011', then that order
+ *          stores values for the paramters 0, 1 and 3 of the master list. The
+ *          byte code for simple flag setups might also be represented by
+ *          hexadecimal values like 0xB, which has the same value as the bit
+ *          combination above.
+ *
+ *          If a module wants to set flags, it can use bit shifts, in this case
+ *          1 << 0, 1 << 1 and 1 << 3.
+ *          Afterwards, to be correct, the following data variable should
+ *          contain 3 elements of the type specified in the master list, each
+ *          stored as bytes32 value.
+ *
+ * @author  Inverter Network
+ */
 interface IERC20PaymentClientBase_v1 {
+    //-------------------------------------------------------------------------
+    // MASTER LIST OF PAYMENT ORDER FLAGS
+
+    /*
+    | Flag | Variable type | Name       | Description                         |
+    |------|---------------|------------|-------------------------------------|
+    | 0    | bytes32       | orderID    | ID of the order.                    |
+    | 1    | uint256       | start      | Start date of the streaming period. | 
+    | 2    | uint256       | cliff      | Duration of the cliff period.       |
+    | 3    | uint256       | end        | Due Date of the order               |
+    | ...  | ...           | ...        | (yet unassigned)                    |
+    | 255  | .             | .          | (Max Value).                        | 
+    |------|---------------|------------|-------------------------------------|
+    */
+
+    /*
+    | Flag | Name       | Disclaimer                                          |
+    |------|------------|-----------------------------------------------------|
+    | 0    | orderID    | The order id should be a hashed value of an         |
+    |      |            | internally tracked id and the paymentOrder origin   |
+    |      |            | address, to prevent duplicate order ids from        |
+    |      |            | different ERC20PaymentClients.                      |
+    |------|------------|-----------------------------------------------------|
+    */
+
     //--------------------------------------------------------------------------
     // Structs
 
     /// @notice Struct used to store information about a payment order.
     /// @param  recipient The recipient of the payment.
-    /// @param  paymentToken The token in which to pay.
+    /// @param  paymentToken The token in which to pay. Assumed to always
+    ///         be on the local chain.
     /// @param  amount The amount of tokens to pay.
-    /// @param  start Timestamp at which the payment should start.
-    /// @param  cliff Duration of the payment cliff.
-    /// @param  end Timestamp at which the payment should be fulfilled.
+    /// @param  originChainId The id of the origin chain.
+    /// @param  targetChainId The id of the target chain.
+    /// @param  flags Flags that indicate which information the data array
+    ///         contains.
+    /// @param  data Array of additional data regarding the payment order.
     struct PaymentOrder {
         address recipient;
         address paymentToken;
         uint amount;
-        uint start;
-        uint cliff;
-        uint end;
+        uint originChainId;
+        uint targetChainId;
+        bytes32 flags;
+        bytes32[] data;
     }
 
     //--------------------------------------------------------------------------
@@ -50,11 +109,13 @@ interface IERC20PaymentClientBase_v1 {
     /// @notice Given paymentOrder is invalid.
     error Module__ERC20PaymentClientBase__InvalidPaymentOrder();
 
-    /// @notice Given end invalid.
-    error Module__ERC20PaymentClientBase__Invalidend();
+    /// @notice Given mismatch between flag count and supplied array length.
+    error Module__ERC20PaymentClientBase__MismatchBetweenFlagCountAndArrayLength(
+        uint8 flagCount, uint arrayLength
+    );
 
-    /// @notice Given arrays' length mismatch.
-    error Module__ERC20PaymentClientBase__ArrayLengthMismatch();
+    /// @notice Given number of flags exceeds the limit.
+    error Module__ERC20PaymentClientBase_v1__FlagAmountTooHigh();
 
     //--------------------------------------------------------------------------
     // Events
@@ -63,9 +124,25 @@ interface IERC20PaymentClientBase_v1 {
     /// @param  recipient The address that will receive the payment.
     /// @param  token The token in which to pay.
     /// @param  amount The amount of tokens the payment consists of.
+    /// @param  originChainId The id of the origin chain.
+    /// @param  targetChainId The id of the target chain.
+    /// @param  flags Flags that indicate additional data used by the payment
+    ///         order.
+    /// @param  data Array of additional data regarding the payment order.
     event PaymentOrderAdded(
-        address indexed recipient, address indexed token, uint amount
+        address indexed recipient,
+        address indexed token,
+        uint amount,
+        uint originChainId,
+        uint targetChainId,
+        bytes32 flags,
+        bytes32[] data
     );
+
+    /// @notice Emitted when the flags are set.
+    /// @param  flagCount The number of flags set.
+    /// @param  newFlags The newly set flags.
+    event FlagsSet(uint8 flagCount, bytes32 newFlags);
 
     //--------------------------------------------------------------------------
     // Functions
@@ -75,26 +152,39 @@ interface IERC20PaymentClientBase_v1 {
     function paymentOrders() external view returns (PaymentOrder[] memory);
 
     /// @notice Returns the total outstanding token payment amount.
-    /// @param  token The token in which to pay.
-    /// @return total amount of token to pay.
-    function outstandingTokenAmount(address token)
+    /// @param  token_ The token in which to pay.
+    /// @return total_ amount of token to pay.
+    function outstandingTokenAmount(address token_)
         external
         view
-        returns (uint);
+        returns (uint total_);
 
     /// @notice Collects outstanding payment orders.
     /// @dev	Marks the orders as completed for the client.
-    /// @return list of payment orders.
-    /// @return list of token addresses.
-    /// @return list of amounts.
+    /// @return paymentOrders_ list of payment orders.
+    /// @return tokens_ list of token addresses.
+    /// @return totalAmounts_ list of amounts.
     function collectPaymentOrders()
         external
-        returns (PaymentOrder[] memory, address[] memory, uint[] memory);
+        returns (
+            PaymentOrder[] memory paymentOrders_,
+            address[] memory tokens_,
+            uint[] memory totalAmounts_
+        );
 
     /// @notice Notifies the PaymentClient, that tokens have been paid out accordingly.
     /// @dev	Payment Client will reduce the total amount of tokens it will stock up by the given amount.
     /// @dev	This has to be called by a paymentProcessor.
-    /// @param  token The token in which the payment was made.
-    /// @param  amount amount of tokens that have been paid out.
-    function amountPaid(address token, uint amount) external;
+    /// @param  token_ The token in which the payment was made.
+    /// @param  amount_ amount of tokens that have been paid out.
+    function amountPaid(address token_, uint amount_) external;
+
+    /// @notice Returns the flags used when creating payment orders in this
+    ///         client.
+    /// @return flags_ The flags this client will use.
+    function getFlags() external view returns (bytes32 flags_);
+
+    /// @notice Returns the number of flags this client uses for PaymentOrders.
+    /// @return flagCount_ The number of flags.
+    function getFlagCount() external view returns (uint8 flagCount_);
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -150,4 +150,12 @@ interface ILM_PC_KPIRewarder_v1 {
     /// @dev    This function is only callable by the Orchestrator Admin.
     /// @param  assertionId The id of the assertion to delete.
     function deleteStuckAssertion(bytes32 assertionId) external;
+
+    /// @notice Returns the current KPI counter.
+    /// @return The KPI counter.
+    function getKPICounter() external view returns (uint);
+
+    /// @notice Returns the assertion pending flag.
+    /// @return The assertion pending flag.
+    function getAssertionPending() external view returns (bool);
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_PaymentRouter_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_PaymentRouter_v1.sol
@@ -2,6 +2,12 @@
 pragma solidity ^0.8.0;
 
 interface ILM_PC_PaymentRouter_v1 {
+    // -----------------------------------------------------------------------------
+    // Errors
+
+    /// @notice Given arrays' length mismatch.
+    error Module__LM_PC_PaymentRouter_v1__ArrayLengthMismatch();
+
     //--------------------------------------------------------------------------
     // Mutating Functions
 

--- a/src/modules/logicModule/interfaces/ILM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_Staking_v1.sol
@@ -61,28 +61,28 @@ interface ILM_PC_Staking_v1 {
 
     /// @notice Returns address of the token users can stake.
     /// @return The address of the token.
-    function stakingToken() external view returns (address);
+    function getStakingToken() external view returns (address);
 
     /// @notice Returns the total supply of staked tokens of this contract.
     /// @return The total supply of staked tokens.
-    function totalSupply() external view returns (uint);
+    function getTotalSupply() external view returns (uint);
 
     /// @notice Returns how much Tokens will be distributed per second to all users that staked in this contract.
     /// @return The reward rate.
-    function rewardRate() external view returns (uint);
+    function getRewardRate() external view returns (uint);
 
     /// @notice Returns when the rewards will not be distributed anymore.
     /// @return The timestamp of when the rewards will end.
-    function rewardsEnd() external view returns (uint);
+    function getRewardsEnd() external view returns (uint);
 
     /// @notice Returns the amount of tokens a user staked in this contract.
     /// @param  user The address of a user that staked.
-    function balanceOf(address user) external view returns (uint);
+    function getBalance(address user) external view returns (uint);
 
     /// @notice Returns the amount of tokens earned up until now by the current stake of a user.
     /// @param  user The address of a user that staked.
     /// @return The amount of tokens earned.
-    function earned(address user) external view returns (uint);
+    function getEarned(address user) external view returns (uint);
 
     /// @notice Returns a estimation of how much rewards will be earned with the current state of the staking contract.
     /// @dev	This calculation uses the current reward rate and the current totalSupply to calculate the rewards.
@@ -90,10 +90,18 @@ interface ILM_PC_Staking_v1 {
     /// @param  amount How much token are staked.
     /// @param  duration How long the tokens will be staked.
     /// @return The estimated amount of tokens earned.
-    function estimateReward(uint amount, uint duration)
+    function getEstimatedReward(uint amount, uint duration)
         external
         view
         returns (uint);
+
+    /// @notice Returns the reward value.
+    /// @return The reward value.
+    function getRewardValue() external view returns (uint);
+
+    /// @notice Returns the timestamp of last state change.
+    /// @return The timestamp of last state change.
+    function getLastUpdate() external view returns (uint);
 
     //--------------------------------------------------------------------------
     // Mutating Functions

--- a/src/modules/paymentProcessor/IPaymentProcessor_v1.sol
+++ b/src/modules/paymentProcessor/IPaymentProcessor_v1.sol
@@ -31,17 +31,20 @@ interface IPaymentProcessor_v1 {
     /// @param  recipient The address that will receive the payment.
     /// @param  paymentToken The address of the token that will be used for the payment.
     /// @param  amount The amount of tokens the payment consists of.
-    /// @param  start Timestamp at which the payment should start being paid out.
-    /// @param  cliff Duration of the cliff period.
-    /// @param  end Timestamp at which the payment should finished being paid out.
+    /// @param  originChainId The id of the origin chain.
+    /// @param  targetChainId The id of the target chain.
+    /// @param  flags Flags that indicate additional data used by the payment
+    ///         order.
+    /// @param  data Array of additional data regarding the payment order.
     event PaymentOrderProcessed(
         address indexed paymentClient,
         address indexed recipient,
         address indexed paymentToken,
         uint amount,
-        uint start,
-        uint cliff,
-        uint end
+        uint originChainId,
+        uint targetChainId,
+        bytes32 flags,
+        bytes32[] data
     );
 
     /// @notice Emitted when an amount of ERC20 tokens gets sent out of the contract.

--- a/src/modules/paymentProcessor/PP_Simple_v1.sol
+++ b/src/modules/paymentProcessor/PP_Simple_v1.sol
@@ -119,9 +119,10 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
                 recipient,
                 address(token_),
                 amount,
-                orders[i].start,
-                orders[i].cliff,
-                orders[i].end
+                orders[i].originChainId,
+                orders[i].targetChainId,
+                orders[i].flags,
+                orders[i].data
             );
 
             (bool success, bytes memory data) = token_.call(
@@ -194,7 +195,8 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
         IERC20PaymentClientBase_v1.PaymentOrder memory order
     ) external returns (bool) {
         return _validPaymentReceiver(order.recipient)
-            && _validTotal(order.amount) && _validPaymentToken(order.paymentToken);
+            && _validTotal(order.amount) && _validPaymentToken(order.paymentToken)
+            && _validOriginAndTargetChain(order.originChainId, order.targetChainId);
     }
 
     //--------------------------------------------------------------------------
@@ -257,5 +259,15 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
             )
         );
         return (success && data.length != 0 && _token.code.length != 0);
+    }
+
+    function _validOriginAndTargetChain(
+        uint originChainId_,
+        uint targetChainId_
+    ) internal view returns (bool) {
+        return (
+            (originChainId_ == targetChainId_)
+                && (originChainId_ == block.chainid)
+        );
     }
 }

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -101,13 +101,13 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     ///         client => paymentReceiver => arrayOfStreamIdsWithPendingPayment(uint[]).
     mapping(address => mapping(address => uint[])) private activeStreams;
 
-    /// @dev    The flags that this PaymentProcessor uses
+    /// @dev    The flags that this PaymentProcessor uses.
     ///         Contains the value 1110.
     bytes32 internal constant PROCESSOR_FLAGS =
         0x000000000000000000000000000000000000000000000000000000000000000e;
 
     /// @dev    The default values for those flags, in ascending order: start
-    //          cliff, end
+    //          cliff, end.
     uint[3] private defaultValues;
 
     /// @dev	Storage gap for future upgrades.

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -233,6 +233,12 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
             uint numOrders = orders.length;
 
             for (uint i; i < numOrders;) {
+                if (!validPaymentOrder(orders[i])) {
+                    revert
+                        IERC20PaymentClientBase_v1
+                        .Module__ERC20PaymentClientBase__InvalidPaymentOrder();
+                }
+
                 _addPayment(
                     address(client),
                     orders[i],
@@ -420,7 +426,7 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     /// @inheritdoc IPaymentProcessor_v1
     function validPaymentOrder(
         IERC20PaymentClientBase_v1.PaymentOrder memory order
-    ) external returns (bool) {
+    ) public returns (bool) {
         (uint start, uint cliff, uint end) =
             _getStreamingDetails(order.flags, order.data);
 

--- a/src/modules/paymentProcessor/interfaces/IPP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/interfaces/IPP_Streaming_v1.sol
@@ -81,26 +81,6 @@ interface IPP_Streaming_v1 is IPaymentProcessor_v1 {
         uint end
     );
 
-    /// @notice Emitted when a payment gets processed for execution.
-    /// @param  paymentClient The payment client that originated the order.
-    /// @param  recipient The address that will receive the payment.
-    /// @param  paymentToken The address of the token that will be used for the payment.
-    /// @param  streamId ID of the streaming payment order that was processed.
-    /// @param  amount The amount of tokens the payment consists of.
-    /// @param  start The start date of the streaming period.
-    /// @param  cliff The duration of the cliff period.
-    /// @param  end The ending of the streaming period.
-    event PaymentOrderProcessed(
-        address indexed paymentClient,
-        address indexed recipient,
-        address indexed paymentToken,
-        uint streamId,
-        uint amount,
-        uint start,
-        uint cliff,
-        uint end
-    );
-
     /// @notice Emitted when a payment was unclaimable due to a token error.
     /// @param  paymentClient The payment client that originated the order.
     /// @param  recipient The address that wshould have received the payment.
@@ -150,6 +130,14 @@ interface IPP_Streaming_v1 is IPaymentProcessor_v1 {
     /// @param  paymentReceiver The address that will receive the payment.
     error Module__PP_Streaming__In_validPaymentReceiver(
         address paymentClient, address paymentReceiver
+    );
+
+    /// @notice The default start, cliff and end times are invalid.
+    /// @param  start The start time.
+    /// @param  cliff The cliff duration.
+    /// @param  end The end time.
+    error Module__PP_Streaming__InvalidDefaultTimes(
+        uint start, uint cliff, uint end
     );
 
     //--------------------------------------------------------------------------

--- a/src/templates/modules/PP_Template_v1.sol
+++ b/src/templates/modules/PP_Template_v1.sol
@@ -149,7 +149,14 @@ contract PP_Template_v1 is IPP_Template_v1, Module_v1 {
         // Emit event of the IPaymentProcessor_v1. This is used by Inverter's
         // Indexer.
         emit PaymentOrderProcessed(
-            address(client_), recipient_, token_, amount_, 0, 0, 0
+            address(client_),
+            recipient_,
+            token_,
+            amount_,
+            block.chainid,
+            block.chainid,
+            bytes32(0),
+            new bytes32[](0)
         );
 
         // Transfer tokens from {IERC20PaymentClientBase_v1} to order

--- a/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
+++ b/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
@@ -130,7 +130,7 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
             console.log(
                 "Failed to get valid rpc url for sepolia from env, using fallback"
             );
-            rpcUrl = vm.rpcUrl("https://rpc2.sepolia.org/");
+            rpcUrl = vm.rpcUrl("https://sepolia.drpc.org/");
         }
 
         // Try creating the fork via the rpc url set above

--- a/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
+++ b/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
@@ -298,12 +298,7 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
             vm.prank(users[i]);
             kpiRewarder.unstake(amounts[i]);
 
-            /*console.log(
-                "Current staking Balance:",
-                stakingToken.balanceOf(address(kpiRewarder))
-            );*/
-
-            assertEq(kpiRewarder.balanceOf(users[i]), 0);
+            assertEq(kpiRewarder.getBalance(users[i]), 0);
             assertEq(stakingToken.balanceOf(users[i]), amounts[i]);
             assertEq(rewardToken.balanceOf(users[i]), accumulatedRewards[i]);
         }
@@ -372,12 +367,7 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
 
         for (uint i; i < TOTAL_USERS; i++) {
             uint currentUserBalance = rewardToken.balanceOf(users[i]);
-            uint reward = kpiRewarder.earned(users[i]);
-            /*console.log(
-                    "User %s has a pre-balance of %s",
-                    users[i],
-                    rewardToken.balanceOf(users[i])
-                );*/
+            uint reward = kpiRewarder.getEarned(users[i]);
             if (reward > 0) {
                 vm.prank(users[i]);
                 kpiRewarder.claimRewards();
@@ -389,7 +379,6 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
                     rewardToken.balanceOf(users[i])
                 );
             }
-            // console.log("User %s has a reward of %s", users[i], reward);
         }
 
         uint rewardBalanceAfter = rewardToken.balanceOf(address(fundingManager));

--- a/test/e2e/logicModules/RecurringPaymentManagerE2E.t.sol
+++ b/test/e2e/logicModules/RecurringPaymentManagerE2E.t.sol
@@ -40,6 +40,11 @@ contract RecurringPaymentManagerE2E is E2ETest {
     uint epochLength = 1 weeks; // 1 week;
     uint epochsAmount = 10;
 
+    // Default values for the streaming payments
+    uint defaultStart = 10;
+    uint defaultCliff = 0;
+    uint defaultEnd = 30;
+
     // Constants
     uint constant _SENTINEL = type(uint).max;
 
@@ -78,7 +83,8 @@ contract RecurringPaymentManagerE2E is E2ETest {
         setUpStreamingPaymentProcessor();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                streamingPaymentProcessorMetadata, bytes("")
+                streamingPaymentProcessorMetadata,
+                abi.encode(defaultStart, defaultCliff, defaultEnd)
             )
         );
 

--- a/test/e2e/logicModules/StakingManagerLifecycle.t.sol
+++ b/test/e2e/logicModules/StakingManagerLifecycle.t.sol
@@ -200,7 +200,7 @@ contract LM_PC_Staking_v1Lifecycle is E2ETest {
         // Staker 4:     |   Staker 4:               |   Staker 4:
 
         // Check if values are accurate
-        assertEq(amount1 / 2, stakingManager.earned(staker1));
+        assertEq(amount1 / 2, stakingManager.getEarned(staker1));
         assertEq(amount1 / 2, rewardToken.balanceOf(staker2));
 
         // 8. Set up reward period 2
@@ -218,7 +218,7 @@ contract LM_PC_Staking_v1Lifecycle is E2ETest {
         // Staker 4:     |   Staker 4:               |   Staker 4:
 
         // Check if values are accurate
-        assertEq(amount1 / 2 + amount2 / 2, stakingManager.earned(staker1));
+        assertEq(amount1 / 2 + amount2 / 2, stakingManager.getEarned(staker1));
 
         // 10. Let staker 3 and 4 into it
 
@@ -250,9 +250,11 @@ contract LM_PC_Staking_v1Lifecycle is E2ETest {
         // Staker 4: 5   |   Staker 4: 1/8 amount2               |   Staker 4:
 
         // Check if values are accurate
-        assertEq(amount1 / 2 + amount2 * 3 / 4, stakingManager.earned(staker1));
+        assertEq(
+            amount1 / 2 + amount2 * 3 / 4, stakingManager.getEarned(staker1)
+        );
         assertEq(amount2 * 1 / 8, rewardToken.balanceOf(staker3));
-        assertEq(amount2 * 1 / 8, stakingManager.earned(staker4));
+        assertEq(amount2 * 1 / 8, stakingManager.getEarned(staker4));
 
         // 13. Let 4 stake more
 
@@ -289,9 +291,9 @@ contract LM_PC_Staking_v1Lifecycle is E2ETest {
 
         assertEq(
             amount1 / 2 + amount2 * 3 / 4 + amount3,
-            stakingManager.earned(staker1)
+            stakingManager.getEarned(staker1)
         );
-        assertEq(amount3, stakingManager.earned(staker4));
+        assertEq(amount3, stakingManager.getEarned(staker4));
 
         // 16. Let 1 withdraw half and 4 withdraw full
 
@@ -309,7 +311,7 @@ contract LM_PC_Staking_v1Lifecycle is E2ETest {
 
         // Check if values are accurate
 
-        assertEq(5, stakingManager.balanceOf(staker1));
+        assertEq(5, stakingManager.getBalance(staker1));
         assertEq(
             amount1 / 2 + amount2 * 3 / 4 + amount3,
             rewardToken.balanceOf(staker1)

--- a/test/e2e/paymentProcessor/StreamingPaymentProcessorE2E.sol
+++ b/test/e2e/paymentProcessor/StreamingPaymentProcessorE2E.sol
@@ -39,6 +39,11 @@ contract StreamingPaymentProcessorE2E is E2ETest {
     uint epochLength = 1 weeks; // 1 week;
     uint epochsAmount = 10;
 
+    // Default values for the streaming payments
+    uint defaultStart = 10;
+    uint defaultCliff = 5;
+    uint defaultEnd = 30;
+
     // Modules, for reference between functions
     IOrchestrator_v1 orchestrator;
     FM_Rebasing_v1 fundingManager;
@@ -77,7 +82,8 @@ contract StreamingPaymentProcessorE2E is E2ETest {
         setUpStreamingPaymentProcessor();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                streamingPaymentProcessorMetadata, bytes("")
+                streamingPaymentProcessorMetadata,
+                abi.encode(defaultStart, defaultCliff, defaultEnd)
             )
         );
 

--- a/test/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
@@ -510,9 +510,7 @@ contract BondingCurveBaseV1Test is ModuleTest {
         vm.expectEmit(
             true, true, true, true, address(bondingCurveFundingManager)
         );
-        emit ProtocolFeeMinted(
-            address(bondingCurveFundingManager), treasury, _feeAmount
-        );
+        emit ProtocolFeeMinted(address(issuanceToken), treasury, _feeAmount);
         // Function call
         bondingCurveFundingManager.call_processProtocolFeeViaMinting(
             treasury, _feeAmount

--- a/test/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
@@ -394,11 +394,6 @@ contract BondingCurveBaseV1Test is ModuleTest {
             bondingCurveFundingManager.distributeIssuanceTokenFunctionCalled(),
             1
         );
-        assertEq(
-            bondingCurveFundingManager
-                .distributeCollateralTokenBeforeBuyFunctionCalled(),
-            1
-        );
     }
 
     /* Test _getBuyFeesAndTreasuryAddresses() function

--- a/test/modules/logicModule/paymentClient/ERCPaymentClientBase_v1.t.sol
+++ b/test/modules/logicModule/paymentClient/ERCPaymentClientBase_v1.t.sol
@@ -481,7 +481,7 @@ contract ERC20PaymentClientBaseV1Test is ModuleTest {
     function test_setFlags(bytes32 newFlags_) public {
         uint8 flagCounter;
 
-        for (uint i = 0; i < type(uint8).max; i++) {
+        for (uint i = 0; i <= type(uint8).max; i++) {
             if (uint(newFlags_) & (1 << i) != 0) {
                 flagCounter++;
             }

--- a/test/modules/logicModule/paymentClient/ERCPaymentClientBase_v1.t.sol
+++ b/test/modules/logicModule/paymentClient/ERCPaymentClientBase_v1.t.sol
@@ -487,7 +487,7 @@ contract ERC20PaymentClientBaseV1Test is ModuleTest {
             flags[i] = uint8(i);
         }
 
-        paymentClient.exposed_setFlags(flagCount_, flags);
+        paymentClient.exposed_setFlags(flags);
 
         assertEq(paymentClient.getFlagCount(), flagCount_);
         assertEq(

--- a/test/modules/logicModule/paymentClient/ERCPaymentClientBase_v1.t.sol
+++ b/test/modules/logicModule/paymentClient/ERCPaymentClientBase_v1.t.sol
@@ -478,21 +478,21 @@ contract ERC20PaymentClientBaseV1Test is ModuleTest {
         }
     }
 
-    function test_setFlags(uint8 flagCount_) public {
-        bytes32 newFlags = 0;
-        uint8[] memory flags = new uint8[](flagCount_);
+    function test_setFlags(bytes32 newFlags_) public {
+        uint8 flagCounter;
 
-        for (uint i = 0; i < flagCount_; i++) {
-            newFlags |= bytes32((1 << i));
-            flags[i] = uint8(i);
+        for (uint i = 0; i < type(uint8).max; i++) {
+            if (uint(newFlags_) & (1 << i) != 0) {
+                flagCounter++;
+            }
         }
 
-        paymentClient.exposed_setFlags(flags);
+        paymentClient.exposed_setFlags(newFlags_);
 
-        assertEq(paymentClient.getFlagCount(), flagCount_);
+        assertEq(paymentClient.getFlagCount(), flagCounter);
         assertEq(
             abi.encodePacked(paymentClient.getFlags()),
-            abi.encodePacked(newFlags)
+            abi.encodePacked(newFlags_)
         );
     }
 

--- a/test/modules/logicModule/paymentClient/LM_PC_Bounties_v1.t.sol
+++ b/test/modules/logicModule/paymentClient/LM_PC_Bounties_v1.t.sol
@@ -98,7 +98,10 @@ contract LM_PC_BountiesV1Test is ModuleTest {
     }
 
     // This function also tests all the getters
-    function testInit() public override(ModuleTest) {}
+    function testInit() public override(ModuleTest) {
+        assertEq(bountyManager.getFlagCount(), 0);
+        assertEq(bountyManager.getFlags(), 0);
+    }
 
     function testReinitFails() public override(ModuleTest) {
         vm.expectRevert(OZErrors.Initializable__InvalidInitialization);
@@ -954,9 +957,17 @@ contract LM_PC_BountiesV1Test is ModuleTest {
             assertEq(orders[i].recipient, contribs[i].addr);
 
             assertEq(orders[i].amount, claimAmount);
-            assertEq(orders[i].start, block.timestamp);
 
-            assertEq(orders[i].end, block.timestamp);
+            // Decode start and end from flags and data
+            bool hasStart = (uint(orders[i].flags) & (1 << 1)) != 0;
+            bool hasEnd = (uint(orders[i].flags) & (1 << 3)) != 0;
+
+            if (hasStart) {
+                assertEq(uint(orders[i].data[0]), 0);
+            }
+            if (hasEnd) {
+                assertEq(uint(orders[i].data[2]), 0);
+            }
         }
 
         assertEqualClaim(claimId, bountyId, contribs, details, true);

--- a/test/modules/logicModule/paymentClient/LM_PC_RecurringPayments_v1.t.sol
+++ b/test/modules/logicModule/paymentClient/LM_PC_RecurringPayments_v1.t.sol
@@ -30,6 +30,8 @@ contract LM_PC_RecurringV1Test is ModuleTest {
     LM_PC_RecurringPayments_v1 recurringPaymentManager;
 
     uint private constant _SENTINEL = type(uint).max;
+    bytes32 private constant _FLAGS_SET =
+        0x000000000000000000000000000000000000000000000000000000000000000a;
 
     event RecurringPaymentAdded(
         uint indexed recurringPaymentId,
@@ -95,6 +97,11 @@ contract LM_PC_RecurringV1Test is ModuleTest {
         );
 
         assertEq(recurringPaymentManager.getEpochLength(), 1 weeks);
+
+        assertEq(recurringPaymentManager.getFlagCount(), 2);
+        bytes32 _START_END_FLAG =
+            0x000000000000000000000000000000000000000000000000000000000000000a;
+        assertEq(recurringPaymentManager.getFlags(), _START_END_FLAG);
     }
 
     function testReinitFails() public override(ModuleTest) {
@@ -686,7 +693,6 @@ contract LM_PC_RecurringV1Test is ModuleTest {
 
         IERC20PaymentClientBase_v1.PaymentOrder[] memory orders =
             recurringPaymentManager.paymentOrders();
-
         assertEq(length, currentRecurringPayments.length);
 
         // prediction of how many orders have to be created for this recurring payment
@@ -762,8 +768,13 @@ contract LM_PC_RecurringV1Test is ModuleTest {
         assertEq(order.recipient, recipient);
 
         assertEq(order.amount, amount);
-        assertEq(order.start, start);
+        // if first three flags are set the flags array is 0x07
+        assertEq(order.flags, _FLAGS_SET);
 
-        assertEq(order.end, end);
+        uint decodedStart = uint(order.data[0]);
+        uint decodedEnd = uint(order.data[1]);
+
+        assertEq(decodedStart, start);
+        assertEq(decodedEnd, end);
     }
 }

--- a/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
@@ -1947,11 +1947,16 @@ contract PP_StreamingV1Test is ModuleTest {
     function test__getStreamingDetails(bytes32 flags, bytes32[] memory data)
         public
     {
+        bool hasOrderId = false; // the processor doesn't use this, but it could be part of recieved data
         bool hasStart = false;
         bool hasCliff = false;
         bool hasEnd = false;
 
         uint8 numOnes = 0;
+        if ((uint(flags) & (1 << 0)) != 0) {
+            hasOrderId = true;
+            numOnes++;
+        }
         if ((uint(flags) & (1 << 1)) != 0) {
             hasStart = true;
             numOnes++;
@@ -1979,6 +1984,7 @@ contract PP_StreamingV1Test is ModuleTest {
             paymentProcessor.exposed_getStreamingDetails(flags, data);
 
         uint idx = 0;
+        if (hasOrderId) idx++; // if there was an orderId, we start comparing results one index further
         assertEq(start, hasStart ? uint(data[idx]) : defaultStart);
         if (hasStart) idx++;
         assertEq(cliff, hasCliff ? uint(data[idx]) : defaultCliff);
@@ -2030,6 +2036,11 @@ contract PP_StreamingV1Test is ModuleTest {
         paymentProcessor.setStreamingDefaults(
             defaultStart, defaultCliff, defaultEnd
         );
+    }
+
+    function test_getProcessorFlags() public {
+        bytes32 flags = paymentProcessor.getProcessorFlags();
+        assertEq(flags, _START_END_CLIFF_FLAG);
     }
 
     //--------------------------------------------------------------------------

--- a/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
@@ -1947,7 +1947,8 @@ contract PP_StreamingV1Test is ModuleTest {
     function test__getStreamingDetails(bytes32 flags, bytes32[] memory data)
         public
     {
-        bool hasOrderId = false; // the processor doesn't use this, but it could be part of recieved data
+        // the P_P doesn't use this, but it could be part of recieved data
+        bool hasOrderId = false;
         bool hasStart = false;
         bool hasCliff = false;
         bool hasEnd = false;
@@ -1984,7 +1985,8 @@ contract PP_StreamingV1Test is ModuleTest {
             paymentProcessor.exposed_getStreamingDetails(flags, data);
 
         uint idx = 0;
-        if (hasOrderId) idx++; // if there was an orderId, we start comparing results one index further
+        // if there was an orderId, start comparing results one index further
+        if (hasOrderId) idx++;
         assertEq(start, hasStart ? uint(data[idx]) : defaultStart);
         if (hasStart) idx++;
         assertEq(cliff, hasCliff ? uint(data[idx]) : defaultCliff);

--- a/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
@@ -1120,6 +1120,172 @@ contract PP_StreamingV1Test is ModuleTest {
         paymentProcessor.processPayments(otherERC20PaymentClient);
     }
 
+    function test_processPayments_FailsIfPaymentOrderRecipientIsInvalid()
+        public
+    {
+        // Values to use for testing.
+        address recipient = address(paymentClient); // Wrong Value
+        address paymentToken = address(_token);
+        uint amount = 1e18;
+        uint start = block.timestamp;
+        uint cliff = 100;
+        uint end = block.timestamp + 200;
+
+        // Add payment order to client.
+        paymentClient.exposed_addPaymentOrder(
+            createPaymentOrder(
+                recipient, paymentToken, amount, start, cliff, end
+            )
+        );
+
+        vm.prank(address(paymentClient));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20PaymentClientBase_v1
+                    .Module__ERC20PaymentClientBase__InvalidPaymentOrder
+                    .selector
+            )
+        );
+
+        paymentProcessor.processPayments(paymentClient);
+    }
+
+    function test_processPayments_FailsIfPaymentOrderTokenIsInvalid() public {
+        // Values to use for testing.
+        address recipient = address(0x1234);
+        address paymentToken = address(paymentClient); // Wrong Value
+        uint amount = 1e18;
+        uint start = block.timestamp;
+        uint cliff = 100;
+        uint end = block.timestamp + 200;
+
+        // Add payment order to client.
+        paymentClient.exposed_addPaymentOrder(
+            createPaymentOrder(
+                recipient, paymentToken, amount, start, cliff, end
+            )
+        );
+
+        vm.prank(address(paymentClient));
+        vm.expectRevert(
+            // The call to check if it's an ERC20 reverts
+        );
+
+        paymentProcessor.processPayments(paymentClient);
+    }
+
+    function test_processPayments_FailsIfPaymentOrderAmountsInvalid() public {
+        // Values to use for testing.
+        address recipient = address(0x1234);
+        address paymentToken = address(_token);
+        uint amount = 0; // Wrong value
+        uint start = block.timestamp;
+        uint cliff = 100;
+        uint end = block.timestamp + 200;
+
+        // Add payment order to client.
+        paymentClient.exposed_addPaymentOrder(
+            createPaymentOrder(
+                recipient, paymentToken, amount, start, cliff, end
+            )
+        );
+
+        vm.prank(address(paymentClient));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20PaymentClientBase_v1
+                    .Module__ERC20PaymentClientBase__InvalidPaymentOrder
+                    .selector
+            )
+        );
+
+        paymentProcessor.processPayments(paymentClient);
+    }
+
+    function test_processPayments_FailsIfPaymentOrderStartIsInvalid() public {
+        // Values to use for testing.
+        address recipient = address(0x1234);
+        address paymentToken = address(_token);
+        uint amount = 1e18;
+        uint start = block.timestamp + 300; // Wrong Value
+        uint cliff = 100;
+        uint end = block.timestamp + 200;
+
+        // Add payment order to client.
+        paymentClient.exposed_addPaymentOrder(
+            createPaymentOrder(
+                recipient, paymentToken, amount, start, cliff, end
+            )
+        );
+
+        vm.prank(address(paymentClient));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20PaymentClientBase_v1
+                    .Module__ERC20PaymentClientBase__InvalidPaymentOrder
+                    .selector
+            )
+        );
+
+        paymentProcessor.processPayments(paymentClient);
+    }
+
+    function test_processPayments_FailsIfPaymentOrderCliffIsInvalid() public {
+        // Values to use for testing.
+        address recipient = address(0x1234);
+        address paymentToken = address(_token);
+        uint amount = 1e18;
+        uint start = block.timestamp;
+        uint cliff = 300; // Wrong Value
+        uint end = block.timestamp + 200;
+
+        // Add payment order to client.
+        paymentClient.exposed_addPaymentOrder(
+            createPaymentOrder(
+                recipient, paymentToken, amount, start, cliff, end
+            )
+        );
+
+        vm.prank(address(paymentClient));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20PaymentClientBase_v1
+                    .Module__ERC20PaymentClientBase__InvalidPaymentOrder
+                    .selector
+            )
+        );
+
+        paymentProcessor.processPayments(paymentClient);
+    }
+
+    function test_processPayments_FailsIfPaymentOrderEndIsInvalid() public {
+        // Values to use for testing.
+        address recipient = address(0x1234);
+        address paymentToken = address(_token);
+        uint amount = 1e18;
+        uint start = block.timestamp;
+        uint cliff = 100;
+        uint end = block.timestamp - 100; // Wrong Value
+
+        // Add payment order to client.
+        paymentClient.exposed_addPaymentOrder(
+            createPaymentOrder(
+                recipient, paymentToken, amount, start, cliff, end
+            )
+        );
+
+        vm.prank(address(paymentClient));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20PaymentClientBase_v1
+                    .Module__ERC20PaymentClientBase__InvalidPaymentOrder
+                    .selector
+            )
+        );
+
+        paymentProcessor.processPayments(paymentClient);
+    }
+
     function test_cancelRunningPayments_allCreatedOrdersGetCancelled(
         address[] memory recipients,
         uint128[] memory amounts

--- a/test/utils/mocks/modules/PaymentProcessorV1Mock.sol
+++ b/test/utils/mocks/modules/PaymentProcessorV1Mock.sol
@@ -35,7 +35,14 @@ contract PaymentProcessorV1Mock is IPaymentProcessor_v1, ERC165 {
 
     function processPayments(IERC20PaymentClientBase_v1 /*client*/ ) external {
         emit PaymentOrderProcessed(
-            address(0), address(0), address(0), 0, 0, 0, 0
+            address(0),
+            address(0),
+            address(0),
+            0,
+            0,
+            0,
+            bytes32(0),
+            new bytes32[](0)
         );
         processPaymentsTriggered += 1;
     }

--- a/test/utils/mocks/modules/logicModules/LM_PC_PaymentRouter_v1AccessMock.sol
+++ b/test/utils/mocks/modules/logicModules/LM_PC_PaymentRouter_v1AccessMock.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+// Internal Dependencies
+import {LM_PC_PaymentRouter_v1} from "@lm/LM_PC_PaymentRouter_v1.sol";
+
+contract LM_PC_PaymentRouter_v1AccessMock is LM_PC_PaymentRouter_v1 {
+    //--------------------------------------------------------------------------
+    // Internal Functions
+
+    function direct__assemblePaymentConfig(bytes32[] memory data)
+        external
+        view
+        returns (bytes32, bytes32[] memory)
+    {
+        return _assemblePaymentConfig(data);
+    }
+}

--- a/test/utils/mocks/modules/logicModules/LM_PC_Staking_v1AccessMock.sol
+++ b/test/utils/mocks/modules/logicModules/LM_PC_Staking_v1AccessMock.sol
@@ -8,20 +8,12 @@ contract LM_PC_Staking_v1AccessMock is LM_PC_Staking_v1 {
     //--------------------------------------------------------------------------
     // Getter Functions
 
-    function getRewardValue() external view returns (uint) {
-        return rewardValue;
-    }
-
-    function getLastUpdate() external view returns (uint) {
-        return lastUpdate;
-    }
-
     function getUserRewardValue(address user) external view returns (uint) {
-        return userRewardValue[user];
+        return userRewardValues[user];
     }
 
-    function getRewards(address user) external view returns (uint) {
-        return rewards[user];
+    function getUserRewards(address user) external view returns (uint) {
+        return userRewards[user];
     }
 
     //--------------------------------------------------------------------------
@@ -40,7 +32,7 @@ contract LM_PC_Staking_v1AccessMock is LM_PC_Staking_v1 {
     }
 
     function setUserRewardValue(address user, uint rV) external {
-        userRewardValue[user] = rV;
+        userRewardValues[user] = rV;
     }
 
     function setRewardsEnd(uint newRewardsEnd) external {

--- a/test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1AccessMock.sol
+++ b/test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1AccessMock.sol
@@ -89,10 +89,8 @@ contract ERC20PaymentClientBaseV1AccessMock is ERC20PaymentClientBase_v1 {
         _outstandingTokenAmounts[token] = amount;
     }
 
-    function exposed_setFlags(uint8 flagCount_, uint8[] memory flags_)
-        external
-    {
-        _setFlags(flagCount_, flags_);
+    function exposed_setFlags(uint8[] memory flags_) external {
+        _setFlags(flags_);
     }
 
     function exposed_assemblePaymentConfig(bytes32[] memory flagValues_)

--- a/test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1AccessMock.sol
+++ b/test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1AccessMock.sol
@@ -37,7 +37,7 @@ contract ERC20PaymentClientBaseV1AccessMock is ERC20PaymentClientBase_v1 {
     //--------------------------------------------------------------------------
     // IERC20PaymentClientBase_v1 Wrapper Functions
 
-    function addPaymentOrder(PaymentOrder memory order) external {
+    function exposed_addPaymentOrder(PaymentOrder memory order) external {
         _addPaymentOrder(order);
     }
 
@@ -50,34 +50,55 @@ contract ERC20PaymentClientBaseV1AccessMock is ERC20PaymentClientBase_v1 {
         _orders.push(order);
 
         emit PaymentOrderAdded(
-            order.recipient, order.paymentToken, order.amount
+            order.recipient,
+            order.paymentToken,
+            order.amount,
+            order.originChainId,
+            order.targetChainId,
+            order.flags,
+            order.data
         );
     }
 
-    function addPaymentOrders(PaymentOrder[] memory orders) external {
+    function exposed_addPaymentOrders(PaymentOrder[] memory orders) external {
         _addPaymentOrders(orders);
     }
 
     // for testing the original functionality of the internal functions I created these placeholders
 
-    function originalEnsureTokenBalance(address token) external {
+    function exposed_ensureTokenBalance(address token) external {
         return _ensureTokenBalance(token);
     }
 
-    function originalEnsureTokenAllowance(
+    function exposed_ensureTokenAllowance(
         IPaymentProcessor_v1 spender,
         address token
     ) external {
         return _ensureTokenAllowance(spender, token);
     }
 
-    function originalIsAuthorizedPaymentProcessor(
+    function exposed_isAuthorizedPaymentProcessor(
         IPaymentProcessor_v1 processor
     ) external view returns (bool) {
         return _isAuthorizedPaymentProcessor(processor);
     }
 
-    function set_outstandingTokenAmount(address token, uint amount) external {
+    function exposed_outstandingTokenAmount(address token, uint amount)
+        external
+    {
         _outstandingTokenAmounts[token] = amount;
+    }
+
+    function exposed_setFlags(uint8 flagCount_, uint8[] memory flags_)
+        external
+    {
+        _setFlags(flagCount_, flags_);
+    }
+
+    function exposed_assemblePaymentConfig(bytes32[] memory flagValues_)
+        external
+        returns (bytes32 flags_, bytes32[] memory data_)
+    {
+        return _assemblePaymentConfig(flagValues_);
     }
 }

--- a/test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1AccessMock.sol
+++ b/test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1AccessMock.sol
@@ -89,7 +89,7 @@ contract ERC20PaymentClientBaseV1AccessMock is ERC20PaymentClientBase_v1 {
         _outstandingTokenAmounts[token] = amount;
     }
 
-    function exposed_setFlags(uint8[] memory flags_) external {
+    function exposed_setFlags(bytes32 flags_) external {
         _setFlags(flags_);
     }
 

--- a/test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1Mock.sol
+++ b/test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1Mock.sol
@@ -41,7 +41,7 @@ contract ERC20PaymentClientBaseV1Mock is ERC20PaymentClientBase_v1 {
     //--------------------------------------------------------------------------
     // IERC20PaymentClientBase_v1 Wrapper Functions
 
-    function addPaymentOrder(PaymentOrder memory order) external {
+    function exposed_addPaymentOrder(PaymentOrder memory order) external {
         _addPaymentOrder(order);
     }
 
@@ -54,11 +54,17 @@ contract ERC20PaymentClientBaseV1Mock is ERC20PaymentClientBase_v1 {
         _orders.push(order);
 
         emit PaymentOrderAdded(
-            order.recipient, order.paymentToken, order.amount
+            order.recipient,
+            order.paymentToken,
+            order.amount,
+            order.originChainId,
+            order.targetChainId,
+            order.flags,
+            order.data
         );
     }
 
-    function addPaymentOrders(PaymentOrder[] memory orders) external {
+    function exposed_addPaymentOrders(PaymentOrder[] memory orders) external {
         _addPaymentOrders(orders);
     }
 

--- a/test/utils/mocks/modules/paymentProcessor/PP_Simple_v1AccessMock.sol
+++ b/test/utils/mocks/modules/paymentProcessor/PP_Simple_v1AccessMock.sol
@@ -8,7 +8,7 @@ import {IERC20PaymentClientBase_v1} from
 import {PP_Simple_v1} from "@pp/PP_Simple_v1.sol";
 
 contract PP_Simple_v1AccessMock is PP_Simple_v1 {
-    function original_validPaymentReceiver(address addr)
+    function exposed_validPaymentReceiver(address addr)
         external
         view
         returns (bool)
@@ -16,11 +16,11 @@ contract PP_Simple_v1AccessMock is PP_Simple_v1 {
         return _validPaymentReceiver(addr);
     }
 
-    function original__validTotal(uint _total) external pure returns (bool) {
+    function exposed__validTotal(uint _total) external pure returns (bool) {
         return _validTotal(_total);
     }
 
-    function original_validPaymentToken(address _token)
+    function exposed_validPaymentToken(address _token)
         external
         returns (bool)
     {

--- a/test/utils/mocks/modules/paymentProcessor/PP_Streaming_v1AccessMock.sol
+++ b/test/utils/mocks/modules/paymentProcessor/PP_Streaming_v1AccessMock.sol
@@ -28,7 +28,7 @@ contract PP_Streaming_v1AccessMock is PP_Streaming_v1 {
         return unclaimableAmountsForStream[client][token][sender][id];
     }
 
-    function original_validPaymentReceiver(address addr)
+    function exposed_validPaymentReceiver(address addr)
         external
         view
         returns (bool)
@@ -36,11 +36,11 @@ contract PP_Streaming_v1AccessMock is PP_Streaming_v1 {
         return _validPaymentReceiver(addr);
     }
 
-    function original__validTotal(uint _total) external pure returns (bool) {
+    function exposed__validTotal(uint _total) external pure returns (bool) {
         return _validTotal(_total);
     }
 
-    function original_validTimes(uint _start, uint _cliff, uint _end)
+    function exposed_validTimes(uint _start, uint _cliff, uint _end)
         external
         pure
         returns (bool)
@@ -48,10 +48,18 @@ contract PP_Streaming_v1AccessMock is PP_Streaming_v1 {
         return _validTimes(_start, _cliff, _end);
     }
 
-    function original_validPaymentToken(address _token)
+    function exposed_validPaymentToken(address _token)
         external
         returns (bool)
     {
         return _validPaymentToken(_token);
+    }
+
+    function exposed_getStreamingDetails(bytes32 flags, bytes32[] memory data)
+        external
+        view
+        returns (uint start, uint cliff, uint end)
+    {
+        return _getStreamingDetails(flags, data);
     }
 }


### PR DESCRIPTION
This PR contains changes related to our revised Payment Order Struct. A payment order is a formalized set of information used by payment clients and are sent to a payment processor, who acts based upon the information contained in the order.

**What have we done**
We revamped the struct and made a distinction between base information (i.e. amount, token, chainId, etc.) and additional information, where we saw that the additional information needs to allow for certain changes over time. We ultimately arrived at this struct:

```Solidity
struct PaymentOrder {
    address recipient;    
    address paymentToken;
    uint amount;
    uint originChainId;
    uint targetChainId;        
    bytes32 flags;
    bytes32[] data;
}
```
The way the `flags` and `data` fields work is as follows:
The `flags` field encodes which information is contained in the `data` array. The way this happens is similar to a bit-mask, where each of the bits in the `bytes32` variable represents one potential data type. We currently have these slots defined:
```
    | Flag | Variable type | Name       | Description                         |
    |------|---------------|------------|-------------------------------------|
    | 0    | bytes32       | orderID    | ID of the order.                    |
    | 1    | uint256       | start      | Start date of the streaming period. | 
    | 2    | uint256       | cliff      | Duration of the cliff period.       |
    | 3    | uint256       | end        | Due Date of the order               |
    | ...  | ...           | ...        | (yet unassigned)                    |
    | 255  | .             | .          | (Max Value).                        | 
    |------|---------------|------------|-------------------------------------|
```
So in this example, if we want to make use of the streamed payment processor and want to encode the `start`, `cliff`, and `end` times, we would set the `flags` value to be `0000 [...] 0000 1110`, so the flags at position 1, 2 and 3 and set to 1, while the rest is set to 0. If the used payment processor allows for `start`, `cliff`, and `end` values, it will check whether these slots are set (i.e. are 1) and - if that is the case - extract these values from the array.

The data array only contains values for slots where the flag is 1, so for the example above (`0000 [...] 0000 1110`) it would contain three data entries (length of 3), where the first one is from flag 1 and so on.

The documentation around this and the definition of the available slots can be found in `IERC20PaymentClientBase_v1.sol`.

