### PR TITLE
feat: add deduction of openRedemptionAmount

### DIFF
--- a/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
@@ -351,6 +351,14 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
         emit TransferOrchestratorToken(to_, amount_);
     }
 
+    /// @inheritdoc IFM_PC_ExternalPrice_Redeeming_v1
+    function deductProcessedRedeemptionAmount(uint processedRedemptionAmount_)
+        external
+        onlyPaymentClient
+    {
+        _deductFromOpenRedemptionAmount(processedRedemptionAmount_);
+    }
+
     /// @inheritdoc IRedeemingBondingCurveBase_v1
     function setSellFee(uint fee_)
         public
@@ -457,7 +465,7 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
         _orderId = _nextOrderId++;
 
         // Update open redemption amount.
-        _openRedemptionAmount += collateralRedeemAmount_;
+        _addToOpenRedemptionAmount(collateralRedeemAmount_);
 
         // Calculate redemption amount.
         uint redemptionAmount_ = collateralRedeemAmount_ - issuanceFeeAmount_;
@@ -698,6 +706,24 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
             );
         }
         _projectTreasury = projectTreasury_;
+    }
+
+    /// @notice Deducts the amount of redeemed tokens from the open redemption amount.
+    /// @param  processedRedemptionAmount_ The amount of redemption tokens that were processed.
+    function _deductFromOpenRedemptionAmount(uint processedRedemptionAmount_)
+        internal
+    {
+        _openRedemptionAmount -= processedRedemptionAmount_;
+        emit RedemptionAmountUpdated(_openRedemptionAmount, block.timestamp);
+    }
+
+    /// @notice Adds the amount of redeemed tokens to the open redemption amount.
+    /// @param  addedOpenRedemptionAmount_ The amount of redeemed tokens to add.
+    function _addToOpenRedemptionAmount(uint addedOpenRedemptionAmount_)
+        internal
+    {
+        _openRedemptionAmount += addedOpenRedemptionAmount_;
+        emit RedemptionAmountUpdated(_openRedemptionAmount, block.timestamp);
     }
 
     /// @inheritdoc BondingCurveBase_v1

--- a/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
@@ -352,7 +352,7 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
     }
 
     /// @inheritdoc IFM_PC_ExternalPrice_Redeeming_v1
-    function deductProcessedRedeemptionAmount(uint processedRedemptionAmount_)
+    function deductProcessedRedemptionAmount(uint processedRedemptionAmount_)
         external
         onlyPaymentClient
     {
@@ -708,8 +708,10 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
         _projectTreasury = projectTreasury_;
     }
 
-    /// @notice Deducts the amount of redeemed tokens from the open redemption amount.
-    /// @param  processedRedemptionAmount_ The amount of redemption tokens that were processed.
+    /// @notice Deducts the amount of redeemed tokens from the open redemption
+    ///         amount.
+    /// @param  processedRedemptionAmount_ The amount of redemption tokens that
+    ///         were processed.
     function _deductFromOpenRedemptionAmount(uint processedRedemptionAmount_)
         internal
     {
@@ -717,7 +719,8 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
         emit RedemptionAmountUpdated(_openRedemptionAmount, block.timestamp);
     }
 
-    /// @notice Adds the amount of redeemed tokens to the open redemption amount.
+    /// @notice Adds the amount of redeemed tokens to the open redemption
+    ///         amount.
     /// @param  addedOpenRedemptionAmount_ The amount of redeemed tokens to add.
     function _addToOpenRedemptionAmount(uint addedOpenRedemptionAmount_)
         internal

--- a/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
@@ -185,8 +185,10 @@ interface IFM_PC_ExternalPrice_Redeeming_v1 is
     /// @param  isDirectOperationsOnly_ The new value for the flag.
     function setIsDirectOperationsOnly(bool isDirectOperationsOnly_) external;
 
-    /// @notice Deducts the processed redeem amount from the open redemption amount.
-    /// @param  processedRedemptionAmount_ The amount of redemption tokens that were processed.
-    function deductProcessedRedeemptionAmount(uint processedRedemptionAmount_)
+    /// @notice Deducts the processed redeem amount from the open redemption
+    ///         amount.
+    /// @param  processedRedemptionAmount_ The amount of redemption tokens that
+    ///         were processed.
+    function deductProcessedRedemptionAmount(uint processedRedemptionAmount_)
         external;
 }

--- a/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
@@ -113,6 +113,13 @@ interface IFM_PC_ExternalPrice_Redeeming_v1 is
         RedemptionState state_
     );
 
+    /// @notice	Emitted when the open redemption amount is updated.
+    /// @param  redemptionAmount The new open redemption amount.
+    /// @param	timestamp The timestamp when the update was made.
+    event RedemptionAmountUpdated(
+        uint indexed redemptionAmount, uint indexed timestamp
+    );
+
     // -------------------------------------------------------------------------
     // View Functions
 
@@ -177,4 +184,9 @@ interface IFM_PC_ExternalPrice_Redeeming_v1 is
     /// @notice Toggles whether the contract only allows direct operations or not.
     /// @param  isDirectOperationsOnly_ The new value for the flag.
     function setIsDirectOperationsOnly(bool isDirectOperationsOnly_) external;
+
+    /// @notice Deducts the processed redeem amount from the open redemption amount.
+    /// @param  processedRedemptionAmount_ The amount of redemption tokens that were processed.
+    function deductProcessedRedeemptionAmount(uint processedRedemptionAmount_)
+        external;
 }


### PR DESCRIPTION
## What has been done?
- Add internal functions for adding/deducting from the `openRedemptionAmount`
- Add external function which is called by the Payment Processor which is called after clearing a queued payment order

## Why go this added
This change was already added [_see PR_](https://github.com/ZealynxSecurity/InverterContracts/pull/4/files) but for whatever reason is not in the feature branch. Re-adding it here