### PR TITLE
Fix: Replace address in event

### DIFF
--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -418,7 +418,9 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
 
             // mint fee amount
             _mint(_treasury, _feeAmount);
-            emit ProtocolFeeMinted(address(this), _treasury, _feeAmount);
+            emit ProtocolFeeMinted(
+                address(issuanceToken), _treasury, _feeAmount
+            );
         }
     }
 

--- a/test/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.t.sol
@@ -510,9 +510,7 @@ contract BondingCurveBaseV1Test is ModuleTest {
         vm.expectEmit(
             true, true, true, true, address(bondingCurveFundingManager)
         );
-        emit ProtocolFeeMinted(
-            address(bondingCurveFundingManager), treasury, _feeAmount
-        );
+        emit ProtocolFeeMinted(address(issuanceToken), treasury, _feeAmount);
         // Function call
         bondingCurveFundingManager.call_processProtocolFeeViaMinting(
             treasury, _feeAmount


### PR DESCRIPTION
Updated the emission of the `ProtocolFeeMinted` event in `BondingCurveBase_v1` to correctly return the issuance token’s address instead of `address(this)`, which likely was a leftover from when the funding manager itself was the token.

Also updated the test, so this should be fine now.