### PR TITLE
Fix: Replace Sepolia Fallback RPC

### DIFF
--- a/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
+++ b/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
@@ -130,7 +130,7 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
             console.log(
                 "Failed to get valid rpc url for sepolia from env, using fallback"
             );
-            rpcUrl = vm.rpcUrl("https://rpc2.sepolia.org/");
+            rpcUrl = vm.rpcUrl("https://sepolia.drpc.org/");
         }
 
         // Try creating the fork via the rpc url set above


### PR DESCRIPTION
The CI was failing when making use of the fallback, which happens locally with no env set or in the CI if the PR is from outside of the repo - which was the case with the external devs. Changing it because of that to one that works. 

The old was that we use was the official one, but that one stopped working, that's why.