### PR TITLE
Fix: Move CI workflows to stable Foundry version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Compile contracts
               run: forge build
@@ -53,7 +53,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Download compiled artifacts
               uses: actions/download-artifact@v4
@@ -80,7 +80,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Download compiled artifacts
               uses: actions/download-artifact@v4
@@ -107,7 +107,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Download compiled artifacts
               uses: actions/download-artifact@v4
@@ -134,7 +134,7 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: nightly
+                  version: stable
 
             - name: Download compiled artifacts
               uses: actions/download-artifact@v4


### PR DESCRIPTION
Switching away from the nightly build as its causing issues and is a bit unpredictable. We are at a stage in the project where relying on stable versions makes more sense :D