### PR TITLE
Fixes for [Audit] FM_PC_ExternalPrice_Redeeming, LM_ManualExternalPriceSetter_v1,

### DIFF
--- a/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
@@ -621,13 +621,17 @@ contract FM_PC_Oracle_Redeeming_v1 is
         virtual
         onlyModuleRole(QUEUE_EXECUTOR_ROLE)
     {
-        (bool success, bytes memory data) = address(__Module_orchestrator.paymentProcessor()).call(
+        (bool success, bytes memory data) = address(
+            __Module_orchestrator.paymentProcessor()
+        ).call(
             abi.encodeWithSignature(
                 "executePaymentQueue(address)", address(this)
             )
         );
         if (!success) {
-            revert Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed(data);
+            revert Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed(
+                data
+            );
         }
     }
 

--- a/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
@@ -621,13 +621,13 @@ contract FM_PC_Oracle_Redeeming_v1 is
         virtual
         onlyModuleRole(QUEUE_EXECUTOR_ROLE)
     {
-        (bool success,) = address(__Module_orchestrator.paymentProcessor()).call(
+        (bool success, bytes memory data) = address(__Module_orchestrator.paymentProcessor()).call(
             abi.encodeWithSignature(
                 "executePaymentQueue(address)", address(this)
             )
         );
         if (!success) {
-            revert Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed();
+            revert Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed(data);
         }
     }
 

--- a/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
@@ -686,14 +686,6 @@ contract FM_PC_Oracle_Redeeming_v1 is
             data: data
         });
 
-        // Add order to payment client.
-        _addPaymentOrder(order);
-
-        // Process payments through the payment processor.
-        __Module_orchestrator.paymentProcessor().processPayments(
-            IERC20PaymentClientBase_v2(address(this))
-        );
-
         // Emit event with order details.
         emit RedemptionOrderCreated(
             address(this),
@@ -707,6 +699,14 @@ contract FM_PC_Oracle_Redeeming_v1 is
             collateralRedeemAmount_,
             address(token()),
             RedemptionState.PENDING
+        );
+
+        // Add order to payment client.
+        _addPaymentOrder(order);
+
+        // Process payments through the payment processor.
+        __Module_orchestrator.paymentProcessor().processPayments(
+            IERC20PaymentClientBase_v2(address(this))
         );
     }
 

--- a/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
@@ -538,29 +538,9 @@ contract FM_PC_Oracle_Redeeming_v1 is
         emit TransferOrchestratorToken(to_, amount_);
     }
 
-    /// @inheritdoc IRedeemingBondingCurveBase_v1
-    function setSellFee(uint fee_)
-        public
-        virtual
-        override(RedeemingBondingCurveBase_v1, IRedeemingBondingCurveBase_v1)
-        onlyOrchestratorAdmin
-    {
-        _setSellFee(fee_);
-    }
-
     /// @inheritdoc IFM_PC_Oracle_Redeeming_v1
     function getSellFee() public view virtual returns (uint fee_) {
         return sellFee;
-    }
-
-    /// @inheritdoc IBondingCurveBase_v1
-    function setBuyFee(uint fee_)
-        external
-        virtual
-        override(BondingCurveBase_v1, IBondingCurveBase_v1)
-        onlyOrchestratorAdmin
-    {
-        _setBuyFee(fee_);
     }
 
     /// @inheritdoc IFM_PC_Oracle_Redeeming_v1

--- a/src/modules/fundingManager/oracle/interfaces/IFM_PC_Oracle_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/interfaces/IFM_PC_Oracle_Redeeming_v1.sol
@@ -73,7 +73,7 @@ interface IFM_PC_Oracle_Redeeming_v1 is
     error Module__FM_PC_ExternalPrice_Redeeming_ThirdPartyOperationsDisabled();
 
     /// @notice	Thrown when a redemption queue execution fails.
-    error Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed();
+    error Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed(bytes data);
 
     /// @notice Thrown when the project treasury address is invalid.
     error Module__FM_PC_ExternalPrice_Redeeming_InvalidProjectTreasury();

--- a/src/modules/paymentProcessor/PP_Queue_ManualExecution_v1.sol
+++ b/src/modules/paymentProcessor/PP_Queue_ManualExecution_v1.sol
@@ -90,7 +90,6 @@ contract PP_Queue_ManualExecution_v1 is
     function executePaymentQueue(IERC20PaymentClientBase_v2 client_)
         external
         virtual
-        clientIsValid(address(client_))
         onlyModule
     {
         _executePaymentQueue(address(client_));

--- a/src/modules/paymentProcessor/PP_Queue_v1.sol
+++ b/src/modules/paymentProcessor/PP_Queue_v1.sol
@@ -895,9 +895,6 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
     /// @notice Internal function to check whether the client is valid.
     /// @param  client_ Address to validate.
     function _ensureValidClient(address client_) internal view virtual {
-        if (client_ == address(0)) {
-            revert Module__PP_Queue_InvalidClientAddress(client_);
-        }
         if (client_ != _msgSender()) {
             revert Module__PP_Queue_OnlyCallableByClient();
         }

--- a/src/modules/paymentProcessor/PP_Queue_v1.sol
+++ b/src/modules/paymentProcessor/PP_Queue_v1.sol
@@ -596,10 +596,8 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
         }
 
         uint processedCount;
-        while (firstId != LinkedIdList._SENTINEL && _processNextOrder(client_))
-        {
+        while (_processNextOrder(client_)) {
             ++processedCount;
-            firstId = _queue[client_].getNextId(LinkedIdList._SENTINEL);
         }
 
         emit PaymentQueueExecuted(_msgSender(), client_, processedCount);

--- a/src/modules/paymentProcessor/PP_Queue_v1.sol
+++ b/src/modules/paymentProcessor/PP_Queue_v1.sol
@@ -463,20 +463,24 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
             return false;
         }
 
-        return _executePaymentTransfer(firstId, order);
+        // Execute payment transfer
+        _executePaymentTransfer(firstId, order);
+        // return true as payment has been processed
+        return true;
     }
 
-    /// @notice	Executes the actual payment transfer for an order.
+    /// @notice	Executes the actual payment transfer for an order. It sets
+    ///         the order state to PROCESSED if the transfer succeeds, otherwise
+    ///         if the transfer fails it sets the order state to FAILED. In both
+    ///         cases the order is removed from the queue.
     /// @param	orderId_ The ID of the order to process.
     /// @param	order_ The order to process.
-    /// @return	success_ True if the payment was successful.
     function _executePaymentTransfer(uint orderId_, QueuedOrder storage order_)
         internal
         virtual
-        returns (bool success_)
     {
         // Try to transfer payment from client to recipient
-        success_ = _tryPaymentTransfer(
+        bool success_ = _tryPaymentTransfer(
             order_.order_.paymentToken,
             order_.client_,
             order_.order_.recipient,

--- a/test/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.t.sol
+++ b/test/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.t.sol
@@ -968,8 +968,9 @@ contract FM_PC_ExternalPrice_Redeeming_v1_Test is ModuleTest {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IFM_PC_Oracle_Redeeming_v1
-                    .Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed
-                    .selector
+            .Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed
+            .selector,
+        bytes("")
             )
         );
         fundingManager.executeRedemptionQueue();

--- a/test/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.t.sol
+++ b/test/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.t.sol
@@ -968,9 +968,9 @@ contract FM_PC_ExternalPrice_Redeeming_v1_Test is ModuleTest {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IFM_PC_Oracle_Redeeming_v1
-            .Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed
-            .selector,
-        bytes("")
+                    .Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed
+                    .selector,
+                bytes("")
             )
         );
         fundingManager.executeRedemptionQueue();

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -76,7 +76,6 @@ contract PP_Queue_v1_Test is ModuleTest {
         admin = makeAddr("admin");
         canceledOrdersTreasury = makeAddr("canceledOrdersTreasury");
         failedOrdersTreasury = makeAddr("failedOrdersTreasury");
-        admin = address(this);
 
         address impl = address(new PP_Queue_v1_Exposed());
         queue = PP_Queue_v1_Exposed(Clones.clone(impl));
@@ -1850,54 +1849,239 @@ contract PP_Queue_v1_Test is ModuleTest {
     }
 
     // ================================================================================
-    // Test Process Next Order Revert Given Non Standard Token
+    // Test
 
-    /* Test testProcessNextOrder_RevertGivenNonStandardToken()
-        └── Given an order with non-standard token
-            └── When processing next order
-                └── Then it should revert with Module__PP_Queue_TransferFailed.
+    /* Test: internal _lowLevelTransfer()
+        ├── Given the recipient is not valie
+        │   └── When the function _lowLevelTransfer() is called
+        │       └── Then it should return false
+        └── Given the recipient is valid
+            └── When the function _lowLevelTransfer() is called
+                └── Then it should return true
     */
-    function testProcessNextOrder_RevertGivenNonStandardToken() public {
-        address recipient_ = makeAddr("recipient");
-        uint96 amount_ = 100;
-
-        NonStandardTokenMock nonStandardToken_ = new NonStandardTokenMock();
-        nonStandardToken_.setFailTransferTo(recipient_); // Hacer que el token falle al transferir al recipient
-
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
-        IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
-        IERC20PaymentClientBase_v2.PaymentOrder({
-            recipient: recipient_,
-            amount: amount_,
-            paymentToken: address(nonStandardToken_),
-            originChainId: block.chainid,
-            targetChainId: block.chainid,
-            flags: flags_,
-            data: data_
-        });
-
-        nonStandardToken_.mint(address(paymentClient), amount_);
-        paymentClient.exposed_addToOutstandingTokenAmounts(
-            address(nonStandardToken_), amount_
-        );
-        vm.startPrank(address(paymentClient));
-        nonStandardToken_.approve(address(queue), amount_);
-        uint orderId_ =
-            queue.exposed_addPaymentOrderToQueue(order_, address(paymentClient));
-        vm.stopPrank();
-
+    function testInternalLowLevelTransfer_worksGivenInvalidRecipientReturnsFalse(
+        uint amount_
+    ) public {
+        // Setup
+        address invalidRecipient_ = makeAddr("invalidRecipient");
+        vm.assume(amount_ > 0);
+        // initiate token and set fail transfer to invalid recipient
+        NonStandardTokenMock nonStandardToken = new NonStandardTokenMock();
+        nonStandardToken.setFailTransferTo(invalidRecipient_);
+        // mint tokens to payment client and approve queue to spend
+        nonStandardToken.mint(address(paymentClient), amount_);
         vm.prank(address(paymentClient));
-        bool success_ = queue.exposed_processNextOrder(address(paymentClient));
-        assertFalse(success_, "Processing should fail with non-standard token");
+        nonStandardToken.approve(address(queue), amount_);
 
-        IPP_Queue_v1.QueuedOrder memory queuedOrder_ = queue.getOrder(
-            orderId_, IERC20PaymentClientBase_v2(address(paymentClient))
+        // Assert pre-conditions
+        assertEq(
+            nonStandardToken.balanceOf(address(paymentClient)),
+            amount_,
+            "Payment Client should have tokens"
         );
         assertEq(
-            uint(queuedOrder_.state_),
-            uint(IPP_Queue_v1.RedemptionState.FAILED),
-            "Order should be marked as failed"
+            nonStandardToken.balanceOf(invalidRecipient_),
+            0,
+            "Invalid recipient should have no tokens"
+        );
+
+        // Test
+        bool success_ = queue.exposed_lowLevelTransfer(
+            address(_token), address(paymentClient), invalidRecipient_, amount_
+        );
+        // Assert
+        assertFalse(success_, "Transfer should fail");
+        assertEq(
+            nonStandardToken.balanceOf(address(paymentClient)),
+            amount_,
+            "Payment Client should have tokens"
+        );
+        assertEq(
+            nonStandardToken.balanceOf(invalidRecipient_),
+            0,
+            "Invalid recipient should have no tokens"
+        );
+    }
+
+    function testInternalLowLevelTransfer_worksGivenValidRecipientReturnsTrue(
+        uint amount_
+    ) public {
+        // Setup
+        address validRecipient_ = makeAddr("validRecipient");
+        vm.assume(amount_ > 0);
+        // mint tokens to payment client and approve queue to spend
+        _token.mint(address(paymentClient), amount_);
+        vm.prank(address(paymentClient));
+        _token.approve(address(queue), amount_);
+
+        // Assert pre-conditions
+        assertEq(
+            _token.balanceOf(address(paymentClient)),
+            amount_,
+            "Payment Client should have tokens"
+        );
+        assertEq(
+            _token.balanceOf(validRecipient_),
+            0,
+            "Recipient should have no tokens"
+        );
+
+        // Test
+        bool success_ = queue.exposed_lowLevelTransfer(
+            address(_token), address(paymentClient), validRecipient_, amount_
+        );
+
+        // Assert post-conditions
+        assertTrue(success_, "Transfer should succeed");
+        assertEq(
+            _token.balanceOf(address(paymentClient)),
+            0,
+            "Payment Client should have no tokens"
+        );
+        assertEq(
+            _token.balanceOf(validRecipient_),
+            amount_,
+            "Recipient should have tokens"
+        );
+    }
+
+    /* Test: internal _tryPaymentTransfer()
+        └── Given the payment processor has enough balance
+            ├── And recipient is not valid (transfer fails)
+            │   └── When the function _tryPaymentTransfer() is called
+            │       ├── Then the low level transfer should fail
+            │       ├── And the amount should be transferred to the payment processor
+            │       ├── And the amount is added to the unclaimable amounts
+            │       └── And the function should return false
+            └── And the recipient is valid (transfer succeeds)
+                └── When the function _tryPaymentTransfer() is called
+                    ├── Then the low level transfer should succeed
+                    ├── And the amount should be transferred to the recipient
+                    ├── And an event should be emitted
+                    └── And the function should return true
+    */
+    function testInternalTryPaymentTransfer_worksGivenAmountTransferredToPPAndReturnFalse(
+        uint amount_
+    ) public {
+        // Setup
+        address invalidRecipient_ = makeAddr("invalidRecipient");
+        vm.assume(amount_ > 0);
+        // initiate token and set fail transfer to invalid recipient
+        NonStandardTokenMock nonStandardToken = new NonStandardTokenMock();
+        nonStandardToken.setFailTransferTo(invalidRecipient_);
+        // mint tokens to payment client and approve queue to spend
+        nonStandardToken.mint(address(paymentClient), amount_);
+        vm.prank(address(paymentClient));
+        nonStandardToken.approve(address(queue), amount_);
+        // add tokens to outstanding amounts in payment client mock
+        paymentClient.exposed_addToOutstandingTokenAmounts(
+            address(nonStandardToken), amount_
+        );
+
+        // Assert pre-conditions
+        assertEq(
+            nonStandardToken.balanceOf(address(paymentClient)),
+            amount_,
+            "Payment Client should have tokens"
+        );
+        assertEq(
+            nonStandardToken.balanceOf(address(queue)),
+            0,
+            "Payment Processor should have no tokens"
+        );
+        assertEq(
+            paymentClient.outstandingTokenAmount(address(nonStandardToken)),
+            amount_,
+            "Payment Client should have tokens in outstanding amounts"
+        );
+
+        // Test
+        bool success_ = queue.exposed_tryPaymentTransfer(
+            address(nonStandardToken),
+            address(paymentClient),
+            invalidRecipient_,
+            amount_
+        );
+
+        // Assert post-conditions
+        assertFalse(
+            success_,
+            "Should return false as transfer to invalid recipient failed"
+        );
+
+        assertEq(
+            nonStandardToken.balanceOf(address(paymentClient)),
+            0,
+            "Payment Client should have no tokens"
+        );
+        assertEq(
+            nonStandardToken.balanceOf(address(queue)),
+            amount_,
+            "Payment Processor should have tokens"
+        );
+        assertEq(
+            paymentClient.outstandingTokenAmount(address(nonStandardToken)),
+            0,
+            "Payment Client should have no tokens in outstanding amounts"
+        );
+    }
+
+    function testInternalTryPaymentTransfer_worksGivenAmountTransferredToRecipientAndReturnTrue(
+        uint amount_
+    ) public {
+        // Setup
+        address validRecipient_ = makeAddr("validRecipient");
+        vm.assume(amount_ > 0);
+        // mint tokens to payment client and approve queue to spend
+        _token.mint(address(paymentClient), amount_);
+        vm.prank(address(paymentClient));
+        _token.approve(address(queue), amount_);
+        // add tokens to outstanding amounts in payment client mock
+        paymentClient.exposed_addToOutstandingTokenAmounts(
+            address(_token), amount_
+        );
+
+        // Assert pre-conditions
+        assertEq(
+            _token.balanceOf(address(paymentClient)),
+            amount_,
+            "Payment Client should have tokens"
+        );
+        assertEq(
+            _token.balanceOf(validRecipient_),
+            0,
+            "Recipient should have no tokens"
+        );
+        assertEq(
+            paymentClient.outstandingTokenAmount(address(_token)),
+            amount_,
+            "Payment Client should have tokens in outstanding amounts"
+        );
+
+        vm.expectEmit(true, true, true, true, address(queue));
+        emit IPaymentProcessor_v2.TokensReleased(
+            validRecipient_, address(_token), amount_
+        );
+        // Test
+        bool success_ = queue.exposed_tryPaymentTransfer(
+            address(_token), address(paymentClient), validRecipient_, amount_
+        );
+
+        // Assert post-conditions
+        assertEq(
+            _token.balanceOf(address(paymentClient)),
+            0,
+            "Payment Client should have no tokens"
+        );
+        assertEq(
+            _token.balanceOf(validRecipient_),
+            amount_,
+            "Recipient should have tokens"
+        );
+        assertEq(
+            paymentClient.outstandingTokenAmount(address(_token)),
+            0,
+            "Payment Client should have no tokens in outstanding amounts"
         );
     }
 

--- a/test/modules/paymentProcessor/PP_Simple_v2.t.sol
+++ b/test/modules/paymentProcessor/PP_Simple_v2.t.sol
@@ -395,8 +395,12 @@ contract PP_SimpleV2Test is ModuleTest {
         vm.startPrank(sender);
         bool expectedValue = paymentProcessor.exposed_validPaymentReceiver(
             order.recipient
-        ) && paymentProcessor.exposed_validPaymentToken(order.paymentToken)
-            && paymentProcessor.exposed__validTotal(order.amount);
+        ) && paymentProcessor.exposed__validTotal(order.amount)
+            && paymentProcessor.exposed_validPaymentToken(order.paymentToken)
+            && paymentProcessor.exposed_validOriginAndTargetChain(
+                order.originChainId, order.targetChainId
+            );
+
         assertEq(paymentProcessor.validPaymentOrder(order), expectedValue);
 
         vm.stopPrank();

--- a/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
+++ b/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
@@ -82,16 +82,26 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
         return _processNextOrder(client_);
     }
 
-    // function exposed_executePaymentTransfer(
-    //     uint orderId_,
-    //     IERC20PaymentClientBase_v2 client_
-    // ) public returns (bool) {
-    //     QueuedOrder storage order_ = getOrder(orderId_, client_);
-    //     return _executePaymentTransfer(orderId_, order_);
-    // }
-
     function exposed_executePaymentQueue(address client_) external {
         _executePaymentQueue(client_);
+    }
+
+    function exposed_tryPaymentTransfer(
+        address token_,
+        address client_,
+        address recipient_,
+        uint amount_
+    ) external returns (bool) {
+        return _tryPaymentTransfer(token_, client_, recipient_, amount_);
+    }
+
+    function exposed_lowLevelTransfer(
+        address token_,
+        address client_,
+        address recipient_,
+        uint amount_
+    ) external returns (bool) {
+        return _lowLevelTransfer(token_, client_, recipient_, amount_);
     }
 
     function exposed_orderExists(

--- a/test/utils/mocks/modules/paymentProcessor/PP_Simple_v2AccessMock.sol
+++ b/test/utils/mocks/modules/paymentProcessor/PP_Simple_v2AccessMock.sol
@@ -20,6 +20,13 @@ contract PP_Simple_v2AccessMock is PP_Simple_v2 {
         return _validTotal(_total);
     }
 
+    function exposed_validOriginAndTargetChain(
+        uint originChainId,
+        uint targetChainId
+    ) external view returns (bool) {
+        return _validOriginAndTargetChain(originChainId, targetChainId);
+    }
+
     function exposed_validPaymentToken(address _token)
         external
         returns (bool)


### PR DESCRIPTION
- Removed redundant check on `_executePaymentQueue`
- Removed the redundant client validation in `executePaymentQueue`
- Moved `RedemptionOrderCreated` event emit before `_addPaymentOrder`
- Added the bytes data from the low level call in `executeRedemptionQueue` to the custom error