### PR TITLE
Feat: Funding Pot V1 - Creating and Editing a Round

### DIFF
--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -152,10 +152,11 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundAccessCriteria(uint64 _roundId, uint64 _id)
+    function getRoundAccessCriteria(uint64 _roundId, uint8 _id)
         external
         view
         returns (
+            bool isOpen,
             address nftContract,
             bytes32 merkleRoot,
             address[] memory allowedAddresses
@@ -163,12 +164,22 @@ contract LM_PC_FundingPot_v1 is
     {
         Round storage round = rounds[_roundId];
         AccessCriteria storage accessCriteria = round.accessCriterias[_id];
-        //@todo : Waht if the round is open? add a bool? check what can be done !!!
-        return (
-            accessCriteria.nftContract,
-            accessCriteria.merkleRoot,
-            accessCriteria.allowedAddresses
-        );
+
+        if (accessCriteria.accessCriteriaId == AccessCriteriaId.OPEN) {
+            return (
+                true,
+                accessCriteria.nftContract,
+                accessCriteria.merkleRoot,
+                accessCriteria.allowedAddresses
+            );
+        } else {
+            return (
+                false,
+                accessCriteria.nftContract,
+                accessCriteria.merkleRoot,
+                accessCriteria.allowedAddresses
+            );
+        }
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -126,8 +126,6 @@ contract LM_PC_FundingPot_v1 is
     // Public - Getters
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    /// @dev    Returns the generic parameters of a round.
-
     function getRoundGenericParameters(uint64 _roundId)
         external
         view
@@ -153,6 +151,7 @@ contract LM_PC_FundingPot_v1 is
         );
     }
 
+    /// @inheritdoc ILM_PC_FundingPot_v1
     function getRoundAccessCriteria(uint64 _roundId, uint64 _id)
         external
         view
@@ -228,16 +227,10 @@ contract LM_PC_FundingPot_v1 is
         bytes memory _hookFunction,
         bool _closureMechanism,
         bool _globalAccumulativeCaps
-    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (bool) {
+    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[_roundId];
 
-        if (round.roundEnd == 0 && round.roundCap == 0) {
-            revert Module__LM_PC_FundingPot__RoundNotCreated();
-        }
-
-        if (block.timestamp > round.roundStart) {
-            revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
-        }
+        _validateEditRoundParameters(round);
 
         round.roundStart = _roundStart;
         round.roundEnd = _roundEnd;
@@ -258,8 +251,6 @@ contract LM_PC_FundingPot_v1 is
             _closureMechanism,
             _globalAccumulativeCaps
         );
-
-        return true;
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -270,13 +261,7 @@ contract LM_PC_FundingPot_v1 is
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[_roundId];
 
-        if (round.roundEnd == 0 && round.roundCap == 0) {
-            revert Module__LM_PC_FundingPot__RoundNotCreated();
-        }
-
-        if (block.timestamp > round.roundStart) {
-            revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
-        }
+        _validateEditRoundParameters(round);
 
         if (
             (
@@ -331,6 +316,19 @@ contract LM_PC_FundingPot_v1 is
         if (round.hookContract == address(0) && round.hookFunction.length > 0) {
             revert
                 Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction();
+        }
+    }
+
+    /// @notice Validates the round parameters.
+    /// @param  round The round to validate.
+    /// @dev    Reverts if the round parameters are invalid.
+    function _validateEditRoundParameters(Round storage round) internal view {
+        if (round.roundEnd == 0 && round.roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundNotCreated();
+        }
+
+        if (block.timestamp > round.roundStart) {
+            revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
         }
     }
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -168,8 +168,7 @@ contract LM_PC_FundingPot_v1 is
         AccessCriteria storage accessCriteria = round.accessCriterias[id_];
 
         isOpen = (
-            accessCriteria.accessCriteriaType == AccessCriteriaType.UNSET
-                || accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN
+           accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN
         );
         return (
             isOpen,
@@ -360,7 +359,7 @@ contract LM_PC_FundingPot_v1 is
         }
     }
 
-    /// @notice Validates the round parameters.
+    /// @notice Validates the round parameters before editing.
     /// @param  round_ The round to validate.
     /// @dev    Reverts if the round parameters are invalid.
     function _validateEditRoundParameters(Round storage round_) internal view {

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -63,6 +63,16 @@ contract LM_PC_FundingPot_v1 is
     // -------------------------------------------------------------------------
 
     // State
+
+    /// @notice Payment token.
+    IERC20 internal _paymentToken;
+
+    /// @notice Stores all funding rounds by their unique ID.
+    mapping(uint64 => Round) public rounds;
+
+    /// @notice The next available round ID.
+    uint64 private nextRoundId;
+
     /// @notice Storage gap for future upgrades.
     uint[50] private __gap;
 
@@ -100,6 +110,108 @@ contract LM_PC_FundingPot_v1 is
     // -------------------------------------------------------------------------
     // Public - Mutating
 
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function createRound(
+        uint _roundStart,
+        uint _roundEnd,
+        uint _roundCap,
+        address _hookContract,
+        bytes memory _hookFunction,
+        bool _closureMechanism,
+        bool _globalAccumulativeCaps
+    ) external returns (uint64) {
+        if (_roundStart <= block.timestamp) {
+            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
+        }
+
+        if (_roundEnd <= _roundStart && _roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
+        }
+
+        if (_roundEnd > 0 && _roundEnd <= _roundStart) {
+            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
+        }
+
+        uint64 roundId = nextRoundId;
+        rounds[roundId] = Round({
+            roundStart: _roundStart,
+            roundEnd: _roundEnd,
+            roundCap: _roundCap,
+            hookContract: _hookContract,
+            hookFunction: _hookFunction,
+            closureMechanism: _closureMechanism,
+            globalAccumulativeCaps: _globalAccumulativeCaps,
+            isActive: true
+        });
+
+        nextRoundId++;
+
+        emit RoundCreated(
+            roundId,
+            _roundStart,
+            _roundEnd,
+            _roundCap,
+            _hookContract,
+            _closureMechanism,
+            _globalAccumulativeCaps
+        );
+
+        return roundId;
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function editRound(
+        uint64 _roundId,
+        uint _roundStart,
+        uint _roundEnd,
+        uint _roundCap,
+        address _hookContract,
+        bytes memory _hookFunction,
+        bool _closureMechanism,
+        bool _globalAccumulativeCaps
+    ) external returns (bool) {
+        Round storage round = rounds[_roundId];
+
+        if (round.roundStart == 0) {
+            revert Module__LM_PC_FundingPot__RoundDoesNotExist();
+        }
+
+        if (block.timestamp >= round.roundStart) {
+            revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
+        }
+
+        if (_roundStart <= block.timestamp) {
+            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
+        }
+
+        if (_roundEnd <= _roundStart && _roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
+        }
+
+        if (_roundEnd > 0 && _roundEnd <= _roundStart) {
+            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
+        }
+
+        round.roundStart = _roundStart;
+        round.roundEnd = _roundEnd;
+        round.roundCap = _roundCap;
+        round.hookContract = _hookContract;
+        round.hookFunction = _hookFunction;
+        round.closureMechanism = _closureMechanism;
+        round.globalAccumulativeCaps = _globalAccumulativeCaps;
+
+        emit RoundEdited(
+            _roundId,
+            _roundStart,
+            _roundEnd,
+            _roundCap,
+            _hookContract,
+            _closureMechanism,
+            _globalAccumulativeCaps
+        );
+
+        return true;
+    }
     // -------------------------------------------------------------------------
     // Internal
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -126,12 +126,47 @@ contract LM_PC_FundingPot_v1 is
     // Public - Getters
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundDetails(uint64 _roundId)
+    function getRoundGenericParameters(uint64 _roundId)
         external
         view
-        returns (Round memory)
+        returns (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        )
     {
-        return rounds[_roundId];
+        Round storage round = rounds[_roundId];
+        return (
+            round.roundStart,
+            round.roundEnd,
+            round.roundCap,
+            round.hookContract,
+            round.hookFunction,
+            round.closureMechanism,
+            round.globalAccumulativeCaps
+        );
+    }
+
+    function getRoundAccessCriteria(uint64 _roundId, uint64 _id)
+        external
+        view
+        returns (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        )
+    {
+        Round storage round = rounds[_roundId];
+        AccessCriteria storage accessCriteria = round.accessCriterias[_id];
+        return (
+            accessCriteria.nftContract,
+            accessCriteria.merkleRoot,
+            accessCriteria.allowedAddresses
+        );
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -155,17 +190,17 @@ contract LM_PC_FundingPot_v1 is
         nextRoundId++;
 
         uint64 roundId = nextRoundId;
-        rounds[roundId] = Round({
-            roundStart: _roundStart,
-            roundEnd: _roundEnd,
-            roundCap: _roundCap,
-            hookContract: _hookContract,
-            hookFunction: _hookFunction,
-            closureMechanism: _closureMechanism,
-            globalAccumulativeCaps: _globalAccumulativeCaps
-        });
 
-        _validateRoundParameters(rounds[roundId]);
+        Round storage round = rounds[roundId];
+        round.roundStart = _roundStart;
+        round.roundEnd = _roundEnd;
+        round.roundCap = _roundCap;
+        round.hookContract = _hookContract;
+        round.hookFunction = _hookFunction;
+        round.closureMechanism = _closureMechanism;
+        round.globalAccumulativeCaps = _globalAccumulativeCaps;
+
+        _validateRoundParameters(round);
 
         emit RoundCreated(
             roundId,
@@ -223,13 +258,49 @@ contract LM_PC_FundingPot_v1 is
 
         return true;
     }
+
+    function setAccessCriteriaForRound(
+        uint64 _roundId,
+        uint8 _accessId,
+        AccessCriteria memory _accessCriteria
+    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
+        Round storage round = rounds[_roundId];
+
+        if (round.roundEnd == 0 && round.roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundNotCreated();
+        }
+
+        if (block.timestamp > round.roundStart) {
+            revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
+        }
+
+        if (
+            (
+                _accessCriteria.accessCriteriaId == AccessCriteriaId.NFT
+                    && _accessCriteria.nftContract == address(0)
+            )
+                || (
+                    _accessCriteria.accessCriteriaId == AccessCriteriaId.MERKLE
+                        && _accessCriteria.merkleRoot == bytes32("")
+                )
+                || (
+                    _accessCriteria.accessCriteriaId == AccessCriteriaId.LIST
+                        && _accessCriteria.allowedAddresses.length == 0
+                )
+        ) {
+            revert Module__LM_PC_FundingPot__IncorrectAccessCriteria();
+        }
+
+        round.accessCriterias[_accessId] = _accessCriteria;
+        emit AccessCriteriaSet(_roundId, _accessId, _accessCriteria);
+    }
     // -------------------------------------------------------------------------
     // Internal
 
     /// @notice Validates the round parameters.
     /// @param  round The round to validate.
     /// @dev    Reverts if the round parameters are invalid.
-    function _validateRoundParameters(Round memory round) internal view {
+    function _validateRoundParameters(Round storage round) internal view {
         // Validate round start time is in the future
         // @note: The below condition wont allow _roundStart == block.timestamp
         if (round.roundStart <= block.timestamp) {

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -68,7 +68,7 @@ contract LM_PC_FundingPot_v1 is
     IERC20 internal _paymentToken;
 
     /// @notice Stores all funding rounds by their unique ID.
-    mapping(uint64 => Round) public rounds;
+    mapping(uint64 => Round) private rounds;
 
     /// @notice The next available round ID.
     uint64 private nextRoundId;
@@ -107,6 +107,20 @@ contract LM_PC_FundingPot_v1 is
     // -------------------------------------------------------------------------
     // Public - Getters
 
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function getRoundDetails(uint64 _roundId)
+        external
+        view
+        returns (Round memory)
+    {
+        return rounds[_roundId];
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function getRoundCount() external view returns (uint64) {
+        return nextRoundId;
+    }
+
     // -------------------------------------------------------------------------
     // Public - Mutating
 
@@ -119,18 +133,14 @@ contract LM_PC_FundingPot_v1 is
         bytes memory _hookFunction,
         bool _closureMechanism,
         bool _globalAccumulativeCaps
-    ) external returns (uint64) {
-        if (_roundStart <= block.timestamp) {
-            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
-        }
+    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (uint64) {
+        bool _isActive;
+        // @note: This logic is required if start time is set to block.timestamp
+        // if (_roundStart == block.timestamp) {
+        //     _isActive = true;
+        // }
 
-        if (_roundEnd <= _roundStart && _roundCap == 0) {
-            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
-        }
-
-        if (_roundEnd > 0 && _roundEnd <= _roundStart) {
-            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
-        }
+        nextRoundId++;
 
         uint64 roundId = nextRoundId;
         rounds[roundId] = Round({
@@ -141,10 +151,10 @@ contract LM_PC_FundingPot_v1 is
             hookFunction: _hookFunction,
             closureMechanism: _closureMechanism,
             globalAccumulativeCaps: _globalAccumulativeCaps,
-            isActive: true
+            isActive: _isActive
         });
 
-        nextRoundId++;
+        _validateRoundParameters(rounds[roundId]);
 
         emit RoundCreated(
             roundId,
@@ -169,27 +179,15 @@ contract LM_PC_FundingPot_v1 is
         bytes memory _hookFunction,
         bool _closureMechanism,
         bool _globalAccumulativeCaps
-    ) external returns (bool) {
+    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (bool) {
         Round storage round = rounds[_roundId];
 
         if (round.roundStart == 0) {
-            revert Module__LM_PC_FundingPot__RoundDoesNotExist();
+            revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
 
-        if (block.timestamp >= round.roundStart) {
+        if (block.timestamp > round.roundStart || round.isActive) {
             revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
-        }
-
-        if (_roundStart <= block.timestamp) {
-            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
-        }
-
-        if (_roundEnd <= _roundStart && _roundCap == 0) {
-            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
-        }
-
-        if (_roundEnd > 0 && _roundEnd <= _roundStart) {
-            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
         }
 
         round.roundStart = _roundStart;
@@ -199,6 +197,8 @@ contract LM_PC_FundingPot_v1 is
         round.hookFunction = _hookFunction;
         round.closureMechanism = _closureMechanism;
         round.globalAccumulativeCaps = _globalAccumulativeCaps;
+
+        _validateRoundParameters(round);
 
         emit RoundEdited(
             _roundId,
@@ -214,4 +214,38 @@ contract LM_PC_FundingPot_v1 is
     }
     // -------------------------------------------------------------------------
     // Internal
+
+    /// @notice Validates the round parameters.
+    /// @param  round The round to validate.
+    /// @dev    Reverts if the round parameters are invalid.
+    function _validateRoundParameters(Round memory round) internal view {
+        // Validate round start time is in the future
+        // @note: The below condition wont allow _roundStart == block.timestamp
+        // @note: If we allow if then _isActive should be set to true
+        if (round.roundStart <= block.timestamp) {
+            revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
+        }
+
+        // Validate that either end time or cap is set
+        if (round.roundEnd == 0 && round.roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
+        }
+
+        // If end time is set, validate it's after start time
+        if (round.roundEnd > 0 && round.roundEnd <= round.roundStart) {
+            revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
+        }
+
+        // Validate hook contract and function consistency
+        if (round.hookContract != address(0) && round.hookFunction.length == 0)
+        {
+            revert
+                Module__LM_PC_FundingPot__HookFunctionRequiredWithHookContract();
+        }
+
+        if (round.hookContract == address(0) && round.hookFunction.length > 0) {
+            revert
+                Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction();
+        }
+    }
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -167,9 +167,7 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[id_];
 
-        isOpen = (
-           accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN
-        );
+        isOpen = (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN);
         return (
             isOpen,
             accessCriteria.nftContract,

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -21,6 +21,27 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 import {ERC165Upgradeable} from
     "@oz-up/utils/introspection/ERC165Upgradeable.sol";
 
+/**
+ * @title   Inverter Funding Pot Module
+ *
+ * @notice  The module allows project supporters to contribute during funding rounds.
+ *
+ * @dev     Extends {ERC20PaymentClientBase_v2} and implements {ILM_PC_FundingPot_v1}.
+ *          This contract manages funding rounds with configurable parameters including
+ *          start/end times, funding caps, and hook contracts for custom logic.
+ *          Uses timestamps as flags for payment processing via FLAG_START, FLAG_CLIFF,
+ *          and FLAG_END constants.
+ *
+ * @custom:security-contact security@inverter.network
+ *                          In case of any concerns or findings, please refer to our Security Policy
+ *                          at security.inverter.network or email us directly!
+ *
+ * @custom:version  v1.0.0
+ *
+ * @custom:inverter-standard-version    v0.1.0
+ *
+ * @author  Inverter Network
+ */
 contract LM_PC_FundingPot_v1 is
     ILM_PC_FundingPot_v1,
     ERC20PaymentClientBase_v2
@@ -63,9 +84,6 @@ contract LM_PC_FundingPot_v1 is
     // -------------------------------------------------------------------------
 
     // State
-
-    /// @notice Payment token.
-    IERC20 internal _paymentToken;
 
     /// @notice Stores all funding rounds by their unique ID.
     mapping(uint64 => Round) private rounds;
@@ -175,7 +193,7 @@ contract LM_PC_FundingPot_v1 is
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (bool) {
         Round storage round = rounds[_roundId];
 
-        if (round.roundStart == 0) {
+        if (round.roundEnd == 0 && round.roundCap == 0) {
             revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
 

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -82,7 +82,6 @@ contract LM_PC_FundingPot_v1 is
     uint8 internal constant FLAG_END = 3;
 
     // -------------------------------------------------------------------------
-
     // State
 
     /// @notice Stores all funding rounds by their unique ID.
@@ -135,7 +134,7 @@ contract LM_PC_FundingPot_v1 is
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         )
     {
@@ -146,7 +145,7 @@ contract LM_PC_FundingPot_v1 is
             round.roundCap,
             round.hookContract,
             round.hookFunction,
-            round.closureMechanism,
+            round.autoClosure,
             round.globalAccumulativeCaps
         );
     }
@@ -165,7 +164,7 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[id_];
 
-        if (accessCriteria.accessCriteriaId == AccessCriteriaId.OPEN) {
+        if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
             return (
                 true,
                 accessCriteria.nftContract,
@@ -197,7 +196,7 @@ contract LM_PC_FundingPot_v1 is
         uint roundCap_,
         address hookContract_,
         bytes memory hookFunction_,
-        bool closureMechanism_,
+        bool autoClosure_,
         bool globalAccumulativeCaps_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (uint64) {
         nextRoundId++;
@@ -210,7 +209,7 @@ contract LM_PC_FundingPot_v1 is
         round.roundCap = roundCap_;
         round.hookContract = hookContract_;
         round.hookFunction = hookFunction_;
-        round.closureMechanism = closureMechanism_;
+        round.autoClosure = autoClosure_;
         round.globalAccumulativeCaps = globalAccumulativeCaps_;
 
         _validateRoundParameters(round);
@@ -221,7 +220,7 @@ contract LM_PC_FundingPot_v1 is
             roundEnd_,
             roundCap_,
             hookContract_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
 
@@ -236,7 +235,7 @@ contract LM_PC_FundingPot_v1 is
         uint roundCap_,
         address hookContract_,
         bytes memory hookFunction_,
-        bool closureMechanism_,
+        bool autoClosure_,
         bool globalAccumulativeCaps_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
@@ -248,7 +247,7 @@ contract LM_PC_FundingPot_v1 is
         round.roundCap = roundCap_;
         round.hookContract = hookContract_;
         round.hookFunction = hookFunction_;
-        round.closureMechanism = closureMechanism_;
+        round.autoClosure = autoClosure_;
         round.globalAccumulativeCaps = globalAccumulativeCaps_;
 
         _validateRoundParameters(round);
@@ -259,7 +258,7 @@ contract LM_PC_FundingPot_v1 is
             roundEnd_,
             roundCap_,
             hookContract_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
     }
@@ -276,15 +275,15 @@ contract LM_PC_FundingPot_v1 is
 
         if (
             (
-                accessCriteria_.accessCriteriaId == AccessCriteriaId.NFT
+                accessCriteria_.accessCriteriaType == AccessCriteriaType.NFT
                     && accessCriteria_.nftContract == address(0)
             )
                 || (
-                    accessCriteria_.accessCriteriaId == AccessCriteriaId.MERKLE
+                    accessCriteria_.accessCriteriaType == AccessCriteriaType.MERKLE
                         && accessCriteria_.merkleRoot == bytes32("")
                 )
                 || (
-                    accessCriteria_.accessCriteriaId == AccessCriteriaId.LIST
+                    accessCriteria_.accessCriteriaType == AccessCriteriaType.LIST
                         && accessCriteria_.allowedAddresses.length == 0
                 )
         ) {

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -134,12 +134,6 @@ contract LM_PC_FundingPot_v1 is
         bool _closureMechanism,
         bool _globalAccumulativeCaps
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (uint64) {
-        bool _isActive;
-        // @note: This logic is required if start time is set to block.timestamp
-        // if (_roundStart == block.timestamp) {
-        //     _isActive = true;
-        // }
-
         nextRoundId++;
 
         uint64 roundId = nextRoundId;
@@ -150,8 +144,7 @@ contract LM_PC_FundingPot_v1 is
             hookContract: _hookContract,
             hookFunction: _hookFunction,
             closureMechanism: _closureMechanism,
-            globalAccumulativeCaps: _globalAccumulativeCaps,
-            isActive: _isActive
+            globalAccumulativeCaps: _globalAccumulativeCaps
         });
 
         _validateRoundParameters(rounds[roundId]);
@@ -186,7 +179,7 @@ contract LM_PC_FundingPot_v1 is
             revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
 
-        if (block.timestamp > round.roundStart || round.isActive) {
+        if (block.timestamp > round.roundStart) {
             revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
         }
 
@@ -221,7 +214,6 @@ contract LM_PC_FundingPot_v1 is
     function _validateRoundParameters(Round memory round) internal view {
         // Validate round start time is in the future
         // @note: The below condition wont allow _roundStart == block.timestamp
-        // @note: If we allow if then _isActive should be set to true
         if (round.roundStart <= block.timestamp) {
             revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
         }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -87,6 +87,9 @@ contract LM_PC_FundingPot_v1 is
     /// @notice Stores all funding rounds by their unique ID.
     mapping(uint64 => Round) private rounds;
 
+    /// @notice Stores the access criteria ID for each round.
+    mapping(uint64 => uint8) private roundIdtoAccessId;
+
     /// @notice The next available round ID.
     uint64 private nextRoundId;
 
@@ -164,8 +167,7 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[id_];
 
-        bool isOpen =
-            (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN);
+        isOpen = (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN);
         return (
             isOpen,
             accessCriteria.nftContract,
@@ -175,8 +177,17 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundCount() external view returns (uint64) {
+    function getRoundCount() external view returns (uint64 roundCount_) {
         return nextRoundId;
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function getRoundAccessCriteriaCount(uint64 roundId_)
+        public
+        view
+        returns (uint8 accessCriteriaCount_)
+    {
+        return roundIdtoAccessId[roundId_];
     }
 
     // -------------------------------------------------------------------------
@@ -261,7 +272,6 @@ contract LM_PC_FundingPot_v1 is
     /// @inheritdoc ILM_PC_FundingPot_v1
     function setAccessCriteriaForRound(
         uint64 roundId_,
-        uint8 accessCriteriaId_,
         AccessCriteria memory accessCriteria_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
@@ -284,9 +294,30 @@ contract LM_PC_FundingPot_v1 is
         ) {
             revert Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
         }
+        uint8 accessCriteriaId = roundIdtoAccessId[roundId_];
+        round.accessCriterias[accessCriteriaId] = accessCriteria_;
+
+        emit AccessCriteriaSet(roundId_, accessCriteriaId, accessCriteria_);
+
+        roundIdtoAccessId[roundId_] += 1;
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function editAccessCriteriaForRound(
+        uint64 roundId_,
+        uint8 accessCriteriaId_,
+        AccessCriteria memory accessCriteria_
+    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
+        if (accessCriteriaId_ >= roundIdtoAccessId[roundId_]) {
+            revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
+        }
+        Round storage round = rounds[roundId_];
+
+        _validateEditRoundParameters(round);
 
         round.accessCriterias[accessCriteriaId_] = accessCriteria_;
-        emit AccessCriteriaSet(roundId_, accessCriteriaId_, accessCriteria_);
+
+        emit AccessCriteriaEdited(roundId_, accessCriteriaId_, accessCriteria_);
     }
     // -------------------------------------------------------------------------
     // Internal

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -164,21 +164,14 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[id_];
 
-        if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
-            return (
-                true,
-                accessCriteria.nftContract,
-                accessCriteria.merkleRoot,
-                accessCriteria.allowedAddresses
-            );
-        } else {
-            return (
-                false,
-                accessCriteria.nftContract,
-                accessCriteria.merkleRoot,
-                accessCriteria.allowedAddresses
-            );
-        }
+        bool isOpen =
+            (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN);
+        return (
+            isOpen,
+            accessCriteria.nftContract,
+            accessCriteria.merkleRoot,
+            accessCriteria.allowedAddresses
+        );
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -220,6 +213,7 @@ contract LM_PC_FundingPot_v1 is
             roundEnd_,
             roundCap_,
             hookContract_,
+            hookFunction_,
             autoClosure_,
             globalAccumulativeCaps_
         );
@@ -258,6 +252,7 @@ contract LM_PC_FundingPot_v1 is
             roundEnd_,
             roundCap_,
             hookContract_,
+            hookFunction_,
             autoClosure_,
             globalAccumulativeCaps_
         );
@@ -266,7 +261,7 @@ contract LM_PC_FundingPot_v1 is
     /// @inheritdoc ILM_PC_FundingPot_v1
     function setAccessCriteriaForRound(
         uint64 roundId_,
-        uint8 accessId_,
+        uint8 accessCriteriaId_,
         AccessCriteria memory accessCriteria_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
@@ -290,8 +285,8 @@ contract LM_PC_FundingPot_v1 is
             revert Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
         }
 
-        round.accessCriterias[accessId_] = accessCriteria_;
-        emit AccessCriteriaSet(roundId_, accessId_, accessCriteria_);
+        round.accessCriterias[accessCriteriaId_] = accessCriteria_;
+        emit AccessCriteriaSet(roundId_, accessCriteriaId_, accessCriteria_);
     }
     // -------------------------------------------------------------------------
     // Internal
@@ -307,7 +302,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         // Validate that either end time or cap is set
-        if (round_.roundEnd == 0 || round_.roundCap == 0) {
+        if (round_.roundEnd == 0 && round_.roundCap == 0) {
             revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
         }
 

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -126,7 +126,7 @@ contract LM_PC_FundingPot_v1 is
     // Public - Getters
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundGenericParameters(uint64 _roundId)
+    function getRoundGenericParameters(uint64 roundId_)
         external
         view
         returns (
@@ -139,7 +139,7 @@ contract LM_PC_FundingPot_v1 is
             bool globalAccumulativeCaps
         )
     {
-        Round storage round = rounds[_roundId];
+        Round storage round = rounds[roundId_];
         return (
             round.roundStart,
             round.roundEnd,
@@ -152,7 +152,7 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundAccessCriteria(uint64 _roundId, uint8 _id)
+    function getRoundAccessCriteria(uint64 roundId_, uint8 id_)
         external
         view
         returns (
@@ -162,8 +162,8 @@ contract LM_PC_FundingPot_v1 is
             address[] memory allowedAddresses
         )
     {
-        Round storage round = rounds[_roundId];
-        AccessCriteria storage accessCriteria = round.accessCriterias[_id];
+        Round storage round = rounds[roundId_];
+        AccessCriteria storage accessCriteria = round.accessCriterias[id_];
 
         if (accessCriteria.accessCriteriaId == AccessCriteriaId.OPEN) {
             return (
@@ -192,37 +192,37 @@ contract LM_PC_FundingPot_v1 is
 
     /// @inheritdoc ILM_PC_FundingPot_v1
     function createRound(
-        uint _roundStart,
-        uint _roundEnd,
-        uint _roundCap,
-        address _hookContract,
-        bytes memory _hookFunction,
-        bool _closureMechanism,
-        bool _globalAccumulativeCaps
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bytes memory hookFunction_,
+        bool closureMechanism_,
+        bool globalAccumulativeCaps_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (uint64) {
         nextRoundId++;
 
         uint64 roundId = nextRoundId;
 
         Round storage round = rounds[roundId];
-        round.roundStart = _roundStart;
-        round.roundEnd = _roundEnd;
-        round.roundCap = _roundCap;
-        round.hookContract = _hookContract;
-        round.hookFunction = _hookFunction;
-        round.closureMechanism = _closureMechanism;
-        round.globalAccumulativeCaps = _globalAccumulativeCaps;
+        round.roundStart = roundStart_;
+        round.roundEnd = roundEnd_;
+        round.roundCap = roundCap_;
+        round.hookContract = hookContract_;
+        round.hookFunction = hookFunction_;
+        round.closureMechanism = closureMechanism_;
+        round.globalAccumulativeCaps = globalAccumulativeCaps_;
 
         _validateRoundParameters(round);
 
         emit RoundCreated(
             roundId,
-            _roundStart,
-            _roundEnd,
-            _roundCap,
-            _hookContract,
-            _closureMechanism,
-            _globalAccumulativeCaps
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            closureMechanism_,
+            globalAccumulativeCaps_
         );
 
         return roundId;
@@ -230,115 +230,117 @@ contract LM_PC_FundingPot_v1 is
 
     /// @inheritdoc ILM_PC_FundingPot_v1
     function editRound(
-        uint64 _roundId,
-        uint _roundStart,
-        uint _roundEnd,
-        uint _roundCap,
-        address _hookContract,
-        bytes memory _hookFunction,
-        bool _closureMechanism,
-        bool _globalAccumulativeCaps
+        uint64 roundId_,
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bytes memory hookFunction_,
+        bool closureMechanism_,
+        bool globalAccumulativeCaps_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
-        Round storage round = rounds[_roundId];
+        Round storage round = rounds[roundId_];
 
         _validateEditRoundParameters(round);
 
-        round.roundStart = _roundStart;
-        round.roundEnd = _roundEnd;
-        round.roundCap = _roundCap;
-        round.hookContract = _hookContract;
-        round.hookFunction = _hookFunction;
-        round.closureMechanism = _closureMechanism;
-        round.globalAccumulativeCaps = _globalAccumulativeCaps;
+        round.roundStart = roundStart_;
+        round.roundEnd = roundEnd_;
+        round.roundCap = roundCap_;
+        round.hookContract = hookContract_;
+        round.hookFunction = hookFunction_;
+        round.closureMechanism = closureMechanism_;
+        round.globalAccumulativeCaps = globalAccumulativeCaps_;
 
         _validateRoundParameters(round);
 
         emit RoundEdited(
-            _roundId,
-            _roundStart,
-            _roundEnd,
-            _roundCap,
-            _hookContract,
-            _closureMechanism,
-            _globalAccumulativeCaps
+            roundId_,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            closureMechanism_,
+            globalAccumulativeCaps_
         );
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
     function setAccessCriteriaForRound(
-        uint64 _roundId,
-        uint8 _accessId,
-        AccessCriteria memory _accessCriteria
+        uint64 roundId_,
+        uint8 accessId_,
+        AccessCriteria memory accessCriteria_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
-        Round storage round = rounds[_roundId];
+        Round storage round = rounds[roundId_];
 
         _validateEditRoundParameters(round);
 
         if (
             (
-                _accessCriteria.accessCriteriaId == AccessCriteriaId.NFT
-                    && _accessCriteria.nftContract == address(0)
+                accessCriteria_.accessCriteriaId == AccessCriteriaId.NFT
+                    && accessCriteria_.nftContract == address(0)
             )
                 || (
-                    _accessCriteria.accessCriteriaId == AccessCriteriaId.MERKLE
-                        && _accessCriteria.merkleRoot == bytes32("")
+                    accessCriteria_.accessCriteriaId == AccessCriteriaId.MERKLE
+                        && accessCriteria_.merkleRoot == bytes32("")
                 )
                 || (
-                    _accessCriteria.accessCriteriaId == AccessCriteriaId.LIST
-                        && _accessCriteria.allowedAddresses.length == 0
+                    accessCriteria_.accessCriteriaId == AccessCriteriaId.LIST
+                        && accessCriteria_.allowedAddresses.length == 0
                 )
         ) {
             revert Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
         }
 
-        round.accessCriterias[_accessId] = _accessCriteria;
-        emit AccessCriteriaSet(_roundId, _accessId, _accessCriteria);
+        round.accessCriterias[accessId_] = accessCriteria_;
+        emit AccessCriteriaSet(roundId_, accessId_, accessCriteria_);
     }
     // -------------------------------------------------------------------------
     // Internal
 
     /// @notice Validates the round parameters.
-    /// @param  round The round to validate.
+    /// @param  round_ The round to validate.
     /// @dev    Reverts if the round parameters are invalid.
-    function _validateRoundParameters(Round storage round) internal view {
+    function _validateRoundParameters(Round storage round_) internal view {
         // Validate round start time is in the future
         // @note: The below condition wont allow _roundStart == block.timestamp
-        if (round.roundStart <= block.timestamp) {
+        if (round_.roundStart <= block.timestamp) {
             revert Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
         }
 
         // Validate that either end time or cap is set
-        if (round.roundEnd == 0 || round.roundCap == 0) {
+        if (round_.roundEnd == 0 || round_.roundCap == 0) {
             revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
         }
 
         // If end time is set, validate it's after start time
-        if (round.roundEnd > 0 && round.roundEnd <= round.roundStart) {
+        if (round_.roundEnd > 0 && round_.roundEnd <= round_.roundStart) {
             revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
         }
 
         // Validate hook contract and function consistency
-        if (round.hookContract != address(0) && round.hookFunction.length == 0)
-        {
+        if (
+            round_.hookContract != address(0) && round_.hookFunction.length == 0
+        ) {
             revert
                 Module__LM_PC_FundingPot__HookFunctionRequiredWithHookContract();
         }
 
-        if (round.hookContract == address(0) && round.hookFunction.length > 0) {
+        if (round_.hookContract == address(0) && round_.hookFunction.length > 0)
+        {
             revert
                 Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction();
         }
     }
 
     /// @notice Validates the round parameters.
-    /// @param  round The round to validate.
+    /// @param  round_ The round to validate.
     /// @dev    Reverts if the round parameters are invalid.
-    function _validateEditRoundParameters(Round storage round) internal view {
-        if (round.roundEnd == 0 && round.roundCap == 0) {
+    function _validateEditRoundParameters(Round storage round_) internal view {
+        if (round_.roundEnd == 0 && round_.roundCap == 0) {
             revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
 
-        if (block.timestamp > round.roundStart) {
+        if (block.timestamp > round_.roundStart) {
             revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
         }
     }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -126,6 +126,8 @@ contract LM_PC_FundingPot_v1 is
     // Public - Getters
 
     /// @inheritdoc ILM_PC_FundingPot_v1
+    /// @dev    Returns the generic parameters of a round.
+
     function getRoundGenericParameters(uint64 _roundId)
         external
         view
@@ -162,6 +164,7 @@ contract LM_PC_FundingPot_v1 is
     {
         Round storage round = rounds[_roundId];
         AccessCriteria storage accessCriteria = round.accessCriterias[_id];
+        //@todo : Waht if the round is open? add a bool? check what can be done !!!
         return (
             accessCriteria.nftContract,
             accessCriteria.merkleRoot,
@@ -259,6 +262,7 @@ contract LM_PC_FundingPot_v1 is
         return true;
     }
 
+    /// @inheritdoc ILM_PC_FundingPot_v1
     function setAccessCriteriaForRound(
         uint64 _roundId,
         uint8 _accessId,
@@ -288,7 +292,7 @@ contract LM_PC_FundingPot_v1 is
                         && _accessCriteria.allowedAddresses.length == 0
                 )
         ) {
-            revert Module__LM_PC_FundingPot__IncorrectAccessCriteria();
+            revert Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
         }
 
         round.accessCriterias[_accessId] = _accessCriteria;
@@ -308,7 +312,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         // Validate that either end time or cap is set
-        if (round.roundEnd == 0 && round.roundCap == 0) {
+        if (round.roundEnd == 0 || round.roundCap == 0) {
             revert Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
         }
 

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -167,7 +167,10 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[id_];
 
-        isOpen = (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN);
+        isOpen = (
+            accessCriteria.accessCriteriaType == AccessCriteriaType.UNSET
+                || accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN
+        );
         return (
             isOpen,
             accessCriteria.nftContract,
@@ -338,7 +341,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         // If end time is set, validate it's after start time
-        if (round_.roundEnd > 0 && round_.roundEnd <= round_.roundStart) {
+        if (round_.roundEnd > 0 && round_.roundEnd < round_.roundStart) {
             revert Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
         }
 

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -10,34 +10,34 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     // Structs
 
     /// @notice Struct used to store information about a funding round.
-    /// @param roundStart Timestamp indicating when the round starts.
-    /// @param roundEnd Timestamp indicating when the round ends. If set to `0`, the round operates only based on `roundCap`.
-    /// @param roundCap Maximum contribution cap in collateral tokens. If set to `0`, the round operates only based on `roundEnd`.
-    /// @param hookContract Address of an optional hook contract to be called after round closure.
-    /// @param hookFunction Encoded function call to be executed on the `hookContract` after round closure.
-    /// @param closureMechanism Indicates whether the hook closure coincides with the contribution span end.
-    /// @param globalAccumulativeCaps Indicates whether contribution caps accumulate globally across rounds.
-    /// @param accessCriterias Mapping of access criteria IDs to their respective access criteria.
+    /// @param  roundStart_ Timestamp indicating when the round starts.
+    /// @param  roundEnd_ Timestamp indicating when the round ends. If set to `0`, the round operates only based on `roundCap`.
+    /// @param  roundCap_ Maximum contribution cap in collateral tokens. If set to `0`, the round operates only based on `roundEnd`.
+    /// @param  hookContract_ Address of an optional hook contract to be called after round closure.
+    /// @param  hookFunction_ Encoded function call to be executed on the `hookContract` after round closure.
+    /// @param  closureMechanism_ Indicates whether the hook closure coincides with the contribution span end.
+    /// @param  globalAccumulativeCaps_ Indicates whether contribution caps accumulate globally across rounds.
+    /// @param  accessCriterias_ Mapping of access criteria IDs to their respective access criteria.
     struct Round {
-        uint roundStart;
-        uint roundEnd;
-        uint roundCap;
-        address hookContract;
-        bytes hookFunction;
-        bool closureMechanism;
-        bool globalAccumulativeCaps;
-        mapping(uint64 id => AccessCriteria) accessCriterias;
+        uint roundStart_;
+        uint roundEnd_;
+        uint roundCap_;
+        address hookContract_;
+        bytes hookFunction_;
+        bool closureMechanism_;
+        bool globalAccumulativeCaps_;
+        mapping(uint64 id => AccessCriteria) accessCriterias_;
     }
 
     /// @notice Struct used to store information about a funding round's access criteria.
-    /// @param nftContract Address of the NFT contract.
-    /// @param merkleRoot Merkle root for the access criteria.
-    /// @param allowedAddresses Mapping of addresses to their access status.
+    /// @param  nftContract_ Address of the NFT contract.
+    /// @param  merkleRoot_ Merkle root for the access criteria.
+    /// @param  allowedAddresses_ Mapping of addresses to their access status.
     struct AccessCriteria {
         AccessCriteriaId accessCriteriaId;
-        address nftContract; // NFT contract address (0x0 if unused)
-        bytes32 merkleRoot; // Merkle root (0x0 if unused)
-        address[] allowedAddresses; // Explicit allowlist
+        address nftContract_; // NFT contract address (0x0 if unused)
+        bytes32 merkleRoot_; // Merkle root (0x0 if unused)
+        address[] allowedAddresses_; // Explicit allowlist
     }
 
     // -------------------------------------------------------------------------
@@ -56,49 +56,49 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     // Events
 
     /// @notice Emitted when a new round is created.
-    /// @dev This event signals the creation of a new round with specific parameters.
-    /// @param roundId The unique identifier for the round.
-    /// @param roundStart The timestamp when the round starts.
-    /// @param roundEnd The timestamp when the round ends.
-    /// @param roundCap The maximum allocation or cap for the round.
-    /// @param hookContract The address of an optional hook contract for custom logic.
-    /// @param closureMechanism A boolean indicating whether a specific closure mechanism is enabled.
-    /// @param globalAccumulativeCaps A boolean indicating whether global accumulative caps are enforced.
+    /// @dev    This event signals the creation of a new round with specific parameters.
+    /// @param  roundId_ The unique identifier for the round.
+    /// @param  roundStart_ The timestamp when the round starts.
+    /// @param  roundEnd_ The timestamp when the round ends.
+    /// @param  roundCap_ The maximum allocation or cap for the round.
+    /// @param  hookContract_ The address of an optional hook contract for custom logic.
+    /// @param  closureMechanism_ A boolean indicating whether a specific closure mechanism is enabled.
+    /// @param  globalAccumulativeCaps_ A boolean indicating whether global accumulative caps are enforced.
     event RoundCreated(
-        uint indexed roundId,
-        uint roundStart,
-        uint roundEnd,
-        uint roundCap,
-        address hookContract,
-        bool closureMechanism,
-        bool globalAccumulativeCaps
+        uint indexed roundId_,
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bool closureMechanism_,
+        bool globalAccumulativeCaps_
     );
 
     /// @notice Emitted when an existing round is edited.
-    /// @dev This event signals modifications to an existing round's parameters.
-    /// @param roundId The unique identifier of the round being edited.
-    /// @param roundStart The updated timestamp for when the round starts.
-    /// @param roundEnd The updated timestamp for when the round ends.
-    /// @param roundCap The updated maximum allocation or cap for the round.
-    /// @param hookContract The address of an optional hook contract for custom logic.
-    /// @param closureMechanism A boolean indicating whether a specific closure mechanism is enabled.
-    /// @param globalAccumulativeCaps A boolean indicating whether global accumulative caps are enforced.
+    /// @dev    This event signals modifications to an existing round's parameters.
+    /// @param  roundId_ The unique identifier of the round being edited.
+    /// @param  roundStart_ The updated timestamp for when the round starts.
+    /// @param  roundEnd_ The updated timestamp for when the round ends.
+    /// @param  roundCap_ The updated maximum allocation or cap for the round.
+    /// @param  hookContract_ The address of an optional hook contract for custom logic.
+    /// @param  closureMechanism_ A boolean indicating whether a specific closure mechanism is enabled.
+    /// @param  globalAccumulativeCaps_ A boolean indicating whether global accumulative caps are enforced.
     event RoundEdited(
-        uint indexed roundId,
-        uint roundStart,
-        uint roundEnd,
-        uint roundCap,
-        address hookContract,
-        bool closureMechanism,
-        bool globalAccumulativeCaps
+        uint indexed roundId_,
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bool closureMechanism_,
+        bool globalAccumulativeCaps_
     );
 
     /// @notice Emitted when access criteria is set for a round.
-    /// @param roundId The unique identifier of the round.
-    /// @param accessId The identifier of the access criteria.
-    /// @param accessCriteria The access criteria.
+    /// @param  roundId_ The unique identifier of the round.
+    /// @param  accessId_ The identifier of the access criteria.
+    /// @param  accessCriteria_ The access criteria.
     event AccessCriteriaSet(
-        uint64 indexed roundId, uint8 accessId, AccessCriteria accessCriteria
+        uint64 indexed roundId_, uint8 accessId_, AccessCriteria accessCriteria_
     );
 
     // -------------------------------------------------------------------------
@@ -141,42 +141,42 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     // Public - Getters
 
     /// @notice Retrieves the generic parameters of a specific funding round.
-    /// @param _roundId The unique identifier of the round to retrieve.
-    /// @return roundStart The timestamp when the round starts
-    /// @return roundEnd The timestamp when the round ends
-    /// @return roundCap The maximum contribution cap for the round
-    /// @return hookContract The address of the hook contract
-    /// @return hookFunction The encoded function call for the hook
-    /// @return closureMechanism Whether hook closure coincides with contribution span end
-    /// @return globalAccumulativeCaps Whether caps accumulate globally across rounds
-    function getRoundGenericParameters(uint64 _roundId)
+    /// @param  roundId_ The unique identifier of the round to retrieve.
+    /// @return roundStart_ The timestamp when the round starts
+    /// @return roundEnd_ The timestamp when the round ends
+    /// @return roundCap_ The maximum contribution cap for the round
+    /// @return hookContract_ The address of the hook contract
+    /// @return hookFunction_ The encoded function call for the hook
+    /// @return closureMechanism_ Whether hook closure coincides with contribution span end
+    /// @return globalAccumulativeCaps_ Whether caps accumulate globally across rounds
+    function getRoundGenericParameters(uint64 roundId_)
         external
         view
         returns (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool closureMechanism,
-            bool globalAccumulativeCaps
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
         );
 
     /// @notice Retrieves the access criteria for a specific funding round.
-    /// @param _roundId The unique identifier of the round to retrieve.
-    /// @param _id The identifier of the access criteria to retrieve.
-    /// @return isOpen Whether the access criteria is open
-    /// @return nftContract The address of the NFT contract used for access control
-    /// @return merkleRoot The merkle root used for access verification
-    /// @return allowedAddresses The list of explicitly allowed addresses
-    function getRoundAccessCriteria(uint64 _roundId, uint8 _id)
+    /// @param  roundId_ The unique identifier of the round to retrieve.
+    /// @param  id_ The identifier of the access criteria to retrieve.
+    /// @return isOpen_ Whether the access criteria is open
+    /// @return nftContract_ The address of the NFT contract used for access control
+    /// @return merkleRoot_ The merkle root used for access verification
+    /// @return allowedAddresses_ The list of explicitly allowed addresses
+    function getRoundAccessCriteria(uint64 roundId_, uint8 id_)
         external
         view
         returns (
-            bool isOpen,
-            address nftContract,
-            bytes32 merkleRoot,
-            address[] memory allowedAddresses
+            bool isOpen_,
+            address nftContract_,
+            bytes32 merkleRoot_,
+            address[] memory allowedAddresses_
         );
 
     /// @notice Retrieves the total number of funding rounds.
@@ -187,54 +187,54 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     // Public - Mutating
 
     /// @notice Creates a new funding round
-    /// @dev Only callable by funding pot admin
-    /// @param _roundStart Start timestamp for the round
-    /// @param _roundEnd End timestamp for the round (0 if using roundCap only)
-    /// @param _roundCap Maximum contribution cap in collateral tokens (0 if using roundEnd only)
-    /// @param _hookContract Address of contract to call after round closure
-    /// @param _hookFunction Encoded function call for the hook
-    /// @param _closureMechanism Whether hook closure coincides with contribution span end
-    /// @param _globalAccumulativeCaps Whether caps accumulate globally
+    /// @dev    Only callable by funding pot admin
+    /// @param  roundStart_ Start timestamp for the round
+    /// @param  roundEnd_ End timestamp for the round (0 if using roundCap only)
+    /// @param  roundCap_ Maximum contribution cap in collateral tokens (0 if using roundEnd only)
+    /// @param  hookContract_ Address of contract to call after round closure
+    /// @param  hookFunction_ Encoded function call for the hook
+    /// @param  closureMechanism_ Whether hook closure coincides with contribution span end
+    /// @param  globalAccumulativeCaps_ Whether caps accumulate globally
     /// @return The ID of the newly created round
     function createRound(
-        uint _roundStart,
-        uint _roundEnd,
-        uint _roundCap,
-        address _hookContract,
-        bytes memory _hookFunction,
-        bool _closureMechanism,
-        bool _globalAccumulativeCaps
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bytes memory hookFunction_,
+        bool closureMechanism_,
+        bool globalAccumulativeCaps_
     ) external returns (uint64);
 
     /// @notice Edits an existing funding round
-    /// @dev Only callable by funding pot admin and only before the round has started
-    /// @param _roundId ID of the round to edit
-    /// @param _roundStart New start timestamp
-    /// @param _roundEnd New end timestamp
-    /// @param _roundCap New maximum contribution cap
-    /// @param _hookContract New hook contract address
-    /// @param _hookFunction New encoded function call
-    /// @param _closureMechanism New closure mechanism setting
-    /// @param _globalAccumulativeCaps New global accumulative caps setting
+    /// @dev    Only callable by funding pot admin and only before the round has started
+    /// @param  roundId_ ID of the round to edit
+    /// @param  roundStart_ New start timestamp
+    /// @param  roundEnd_ New end timestamp
+    /// @param  roundCap_ New maximum contribution cap
+    /// @param  hookContract_ New hook contract address
+    /// @param  hookFunction_ New encoded function call
+    /// @param  closureMechanism_ New closure mechanism setting
+    /// @param  globalAccumulativeCaps_ New global accumulative caps setting
     function editRound(
-        uint64 _roundId,
-        uint _roundStart,
-        uint _roundEnd,
-        uint _roundCap,
-        address _hookContract,
-        bytes memory _hookFunction,
-        bool _closureMechanism,
-        bool _globalAccumulativeCaps
+        uint64 roundId_,
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bytes memory hookFunction_,
+        bool closureMechanism_,
+        bool globalAccumulativeCaps_
     ) external;
 
     /// @notice Set Access Control Check
-    /// @dev Only callable by funding pot admin and only before the round has started
-    /// @param _roundId ID of the round
-    /// @param _accessId ID of the access criteria
-    /// @param _accessCriteria Access criteria to set
+    /// @dev    Only callable by funding pot admin and only before the round has started
+    /// @param  roundId_ ID of the round
+    /// @param  accessId_ ID of the access criteria
+    /// @param  accessCriteria_ Access criteria to set
     function setAccessCriteriaForRound(
-        uint64 _roundId,
-        uint8 _accessId,
-        AccessCriteria memory _accessCriteria
+        uint64 roundId_,
+        uint8 accessId_,
+        AccessCriteria memory accessCriteria_
     ) external;
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -6,7 +6,7 @@ import {IERC20PaymentClientBase_v2} from
     "@lm/interfaces/IERC20PaymentClientBase_v2.sol";
 
 interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
-    //--------------------------------------------------------------------------
+    // --------------------------------------------------------------------------
     // Structs
 
     /// @notice Struct used to store information about a funding round.
@@ -15,7 +15,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundCap Maximum contribution cap in collateral tokens. If set to `0`, the round operates only based on `roundEnd`.
     /// @param  hookContract Address of an optional hook contract to be called after round closure.
     /// @param  hookFunction Encoded function call to be executed on the `hookContract` after round closure.
-    /// @param  closureMechanism Indicates whether the hook closure coincides with the contribution span end.
+    /// @param  autoClosure Indicates whether the hook closure coincides with the contribution span end.
     /// @param  globalAccumulativeCaps Indicates whether contribution caps accumulate globally across rounds.
     /// @param  accessCriterias Mapping of access criteria IDs to their respective access criteria.
     struct Round {
@@ -24,17 +24,18 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint roundCap;
         address hookContract;
         bytes hookFunction;
-        bool closureMechanism;
+        bool autoClosure;
         bool globalAccumulativeCaps;
         mapping(uint64 id => AccessCriteria) accessCriterias;
     }
 
     /// @notice Struct used to store information about a funding round's access criteria.
+    /// @param  accessCriteriaType Type of access criteria.
     /// @param  nftContract Address of the NFT contract.
     /// @param  merkleRoot Merkle root for the access criteria.
     /// @param  allowedAddresses Mapping of addresses to their access status.
     struct AccessCriteria {
-        AccessCriteriaId accessCriteriaId;
+        AccessCriteriaType accessCriteriaType;
         address nftContract; // NFT contract address (0x0 if unused)
         bytes32 merkleRoot; // Merkle root (0x0 if unused)
         address[] allowedAddresses; // Explicit allowlist
@@ -44,7 +45,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     // Enums
 
     /// @notice Enum used to identify the type of access criteria.
-    enum AccessCriteriaId {
+    enum AccessCriteriaType {
         OPEN, // 0
         NFT, // 1
         MERKLE, // 2
@@ -107,22 +108,19 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Amount can not be zero.
     error Module__LM_PC_FundingPot__InvalidDepositAmount();
 
-    /// @notice Round does not exist
-    error Module__LM_PC_FundingPot__RoundDoesNotExist();
-
-    /// @notice Round start time must be in the future
+    /// @notice Round start time must be in the future.
     error Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
 
-    /// @notice Round must have either an end time or a funding cap
+    /// @notice Round must have either an end time or a funding cap.
     error Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
 
-    /// @notice Round end time must be after round start time
+    /// @notice Round end time must be after round start time.
     error Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
 
-    /// @notice Round has already started and cannot be modified
+    /// @notice Round has already started and cannot be modified.
     error Module__LM_PC_FundingPot__RoundAlreadyStarted();
 
-    /// @notice Hook function is required when a hook contract is provided
+    /// @notice Hook function is required when a hook contract is provided.
     error Module__LM_PC_FundingPot__HookFunctionRequiredWithContract();
 
     /// @notice Thrown when a hook contract is specified without a hook function.
@@ -131,10 +129,10 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Thrown when a hook function is specified without a hook contract.
     error Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction();
 
-    /// @notice Round does not exist
+    /// @notice Round does not exist.
     error Module__LM_PC_FundingPot__RoundNotCreated();
 
-    /// @notice Incorrect access criteria
+    /// @notice Incorrect access criteria.
     error Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
 
     // -------------------------------------------------------------------------
@@ -142,13 +140,13 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Retrieves the generic parameters of a specific funding round.
     /// @param  roundId_ The unique identifier of the round to retrieve.
-    /// @return roundStart_ The timestamp when the round starts
-    /// @return roundEnd_ The timestamp when the round ends
-    /// @return roundCap_ The maximum contribution cap for the round
-    /// @return hookContract_ The address of the hook contract
-    /// @return hookFunction_ The encoded function call for the hook
-    /// @return closureMechanism_ Whether hook closure coincides with contribution span end
-    /// @return globalAccumulativeCaps_ Whether caps accumulate globally across rounds
+    /// @return roundStart_ The timestamp when the round starts.
+    /// @return roundEnd_ The timestamp when the round ends.
+    /// @return roundCap_ The maximum contribution cap for the round.
+    /// @return hookContract_ The address of the hook contract.
+    /// @return hookFunction_ The encoded function call for the hook.
+    /// @return closureMechanism_ Whether hook closure coincides with contribution span end.
+    /// @return globalAccumulativeCaps_ Whether caps accumulate globally across rounds.
     function getRoundGenericParameters(uint64 roundId_)
         external
         view
@@ -165,10 +163,10 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Retrieves the access criteria for a specific funding round.
     /// @param  roundId_ The unique identifier of the round to retrieve.
     /// @param  id_ The identifier of the access criteria to retrieve.
-    /// @return isOpen_ Whether the access criteria is open
-    /// @return nftContract_ The address of the NFT contract used for access control
-    /// @return merkleRoot_ The merkle root used for access verification
-    /// @return allowedAddresses_ The list of explicitly allowed addresses
+    /// @return isOpen_ Whether the access criteria is open.
+    /// @return nftContract_ The address of the NFT contract used for access control.
+    /// @return merkleRoot_ The merkle root used for access verification.
+    /// @return allowedAddresses_ The list of explicitly allowed addresses.
     function getRoundAccessCriteria(uint64 roundId_, uint8 id_)
         external
         view
@@ -186,16 +184,16 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     // -------------------------------------------------------------------------
     // Public - Mutating
 
-    /// @notice Creates a new funding round
-    /// @dev    Only callable by funding pot admin
-    /// @param  roundStart_ Start timestamp for the round
-    /// @param  roundEnd_ End timestamp for the round (0 if using roundCap only)
-    /// @param  roundCap_ Maximum contribution cap in collateral tokens (0 if using roundEnd only)
-    /// @param  hookContract_ Address of contract to call after round closure
-    /// @param  hookFunction_ Encoded function call for the hook
-    /// @param  closureMechanism_ Whether hook closure coincides with contribution span end
-    /// @param  globalAccumulativeCaps_ Whether caps accumulate globally
-    /// @return The ID of the newly created round
+    /// @notice Creates a new funding round.
+    /// @dev    Only callable by funding pot admin.
+    /// @param  roundStart_ Start timestamp for the round.
+    /// @param  roundEnd_ End timestamp for the round (0 if using roundCap only).
+    /// @param  roundCap_ Maximum contribution cap in collateral tokens (0 if using roundEnd only).
+    /// @param  hookContract_ Address of contract to call after round closure.
+    /// @param  hookFunction_ Encoded function call for the hook.
+    /// @param  closureMechanism_ Whether hook closure coincides with contribution span end.
+    /// @param  globalAccumulativeCaps_ Whether caps accumulate globally.
+    /// @return The ID of the newly created round.
     function createRound(
         uint roundStart_,
         uint roundEnd_,
@@ -206,16 +204,16 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bool globalAccumulativeCaps_
     ) external returns (uint64);
 
-    /// @notice Edits an existing funding round
-    /// @dev    Only callable by funding pot admin and only before the round has started
-    /// @param  roundId_ ID of the round to edit
-    /// @param  roundStart_ New start timestamp
-    /// @param  roundEnd_ New end timestamp
-    /// @param  roundCap_ New maximum contribution cap
-    /// @param  hookContract_ New hook contract address
-    /// @param  hookFunction_ New encoded function call
-    /// @param  closureMechanism_ New closure mechanism setting
-    /// @param  globalAccumulativeCaps_ New global accumulative caps setting
+    /// @notice Edits an existing funding round.
+    /// @dev    Only callable by funding pot admin and only before the round has started.
+    /// @param  roundId_ ID of the round to edit.
+    /// @param  roundStart_ New start timestamp.
+    /// @param  roundEnd_ New end timestamp.
+    /// @param  roundCap_ New maximum contribution cap.
+    /// @param  hookContract_ New hook contract address.
+    /// @param  hookFunction_ New encoded function call.
+    /// @param  closureMechanism_ New closure mechanism setting.
+    /// @param  globalAccumulativeCaps_ New global accumulative caps setting.
     function editRound(
         uint64 roundId_,
         uint roundStart_,
@@ -227,11 +225,11 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bool globalAccumulativeCaps_
     ) external;
 
-    /// @notice Set Access Control Check
-    /// @dev    Only callable by funding pot admin and only before the round has started
-    /// @param  roundId_ ID of the round
-    /// @param  accessId_ ID of the access criteria
-    /// @param  accessCriteria_ Access criteria to set
+    /// @notice Set Access Control Check.
+    /// @dev    Only callable by funding pot admin and only before the round has started.
+    /// @param  roundId_ ID of the round.
+    /// @param  accessId_ ID of the access criteria.
+    /// @param  accessCriteria_ Access criteria to set.
     function setAccessCriteriaForRound(
         uint64 roundId_,
         uint8 accessId_,

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -6,15 +6,136 @@ import {IERC20PaymentClientBase_v2} from
     "@lm/interfaces/IERC20PaymentClientBase_v2.sol";
 
 interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
-// -------------------------------------------------------------------------
-// Events
+    //--------------------------------------------------------------------------
+    // Structs
 
-// -------------------------------------------------------------------------
-// Errors
+    /// @notice Struct used to store information about a funding round.
+    /// @param roundStart Timestamp indicating when the round starts.
+    /// @param roundEnd Timestamp indicating when the round ends. If set to `0`, the round operates only based on `roundCap`.
+    /// @param roundCap Maximum contribution cap in collateral tokens. If set to `0`, the round operates only based on `roundEnd`.
+    /// @param hookContract Address of an optional hook contract to be called after round closure.
+    /// @param hookFunction Encoded function call to be executed on the `hookContract` after round closure.
+    /// @param closureMechanism Indicates whether the hook closure coincides with the contribution span end.
+    /// @param globalAccumulativeCaps Indicates whether contribution caps accumulate globally across rounds.
+    /// @param isActive Indicates whether the round is currently active.
+    struct Round {
+        uint roundStart;
+        uint roundEnd;
+        uint roundCap;
+        address hookContract;
+        bytes hookFunction;
+        bool closureMechanism;
+        bool globalAccumulativeCaps;
+        bool isActive;
+    }
 
-// -------------------------------------------------------------------------
-// Public - Getters
+    // -------------------------------------------------------------------------
+    // Events
 
-// -------------------------------------------------------------------------
-// Public - Mutating
+    /// @notice Emitted when a new round is created.
+    /// @dev This event signals the creation of a new round with specific parameters.
+    /// @param roundId The unique identifier for the round.
+    /// @param roundStart The timestamp when the round starts.
+    /// @param roundEnd The timestamp when the round ends.
+    /// @param roundCap The maximum allocation or cap for the round.
+    /// @param hookContract The address of an optional hook contract for custom logic.
+    /// @param closureMechanism A boolean indicating whether a specific closure mechanism is enabled.
+    /// @param globalAccumulativeCaps A boolean indicating whether global accumulative caps are enforced.
+    event RoundCreated(
+        uint indexed roundId,
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
+    );
+
+    /// @notice Emitted when an existing round is edited.
+    /// @dev This event signals modifications to an existing round's parameters.
+    /// @param roundId The unique identifier of the round being edited.
+    /// @param roundStart The updated timestamp for when the round starts.
+    /// @param roundEnd The updated timestamp for when the round ends.
+    /// @param roundCap The updated maximum allocation or cap for the round.
+    /// @param hookContract The address of an optional hook contract for custom logic.
+    /// @param closureMechanism A boolean indicating whether a specific closure mechanism is enabled.
+    /// @param globalAccumulativeCaps A boolean indicating whether global accumulative caps are enforced.
+    event RoundEdited(
+        uint indexed roundId,
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
+    );
+
+    // -------------------------------------------------------------------------
+    // Errors
+
+    /// @notice Amount can not be zero.
+    error Module__LM_PC_FundingPot__InvalidDepositAmount();
+
+    /// @notice Round does not exist
+    error Module__LM_PC_FundingPot__RoundDoesNotExist();
+
+    /// @notice Round start time must be in the future
+    error Module__LM_PC_FundingPot__RoundStartMustBeInFuture();
+
+    /// @notice Round must have either an end time or a funding cap
+    error Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap();
+
+    /// @notice Round end time must be after round start time
+    error Module__LM_PC_FundingPot__RoundEndMustBeAfterStart();
+
+    /// @notice Round has already started and cannot be modified
+    error Module__LM_PC_FundingPot__RoundAlreadyStarted();
+
+    // -------------------------------------------------------------------------
+    // Public - Getters
+
+    // -------------------------------------------------------------------------
+    // Public - Mutating
+
+    /// @notice Creates a new funding round
+    /// @dev Only callable by funding pot admin
+    /// @param _roundStart Start timestamp for the round
+    /// @param _roundEnd End timestamp for the round (0 if using roundCap only)
+    /// @param _roundCap Maximum contribution cap in collateral tokens (0 if using roundEnd only)
+    /// @param _hookContract Address of contract to call after round closure
+    /// @param _hookFunction Encoded function call for the hook
+    /// @param _closureMechanism Whether hook closure coincides with contribution span end
+    /// @param _globalAccumulativeCaps Whether caps accumulate globally
+    /// @return The ID of the newly created round
+    function createRound(
+        uint _roundStart,
+        uint _roundEnd,
+        uint _roundCap,
+        address _hookContract,
+        bytes memory _hookFunction,
+        bool _closureMechanism,
+        bool _globalAccumulativeCaps
+    ) external returns (uint64);
+
+    /// @notice Edits an existing funding round
+    /// @dev Only callable by funding pot admin and only before the round has started
+    /// @param _roundId ID of the round to edit
+    /// @param _roundStart New start timestamp
+    /// @param _roundEnd New end timestamp
+    /// @param _roundCap New maximum contribution cap
+    /// @param _hookContract New hook contract address
+    /// @param _hookFunction New encoded function call
+    /// @param _closureMechanism New closure mechanism setting
+    /// @param _globalAccumulativeCaps New global accumulative caps setting
+    /// @return True if edit was successful
+    function editRound(
+        uint64 _roundId,
+        uint _roundStart,
+        uint _roundEnd,
+        uint _roundCap,
+        address _hookContract,
+        bytes memory _hookFunction,
+        bool _closureMechanism,
+        bool _globalAccumulativeCaps
+    ) external returns (bool);
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -10,34 +10,34 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     // Structs
 
     /// @notice Struct used to store information about a funding round.
-    /// @param  roundStart_ Timestamp indicating when the round starts.
-    /// @param  roundEnd_ Timestamp indicating when the round ends. If set to `0`, the round operates only based on `roundCap`.
-    /// @param  roundCap_ Maximum contribution cap in collateral tokens. If set to `0`, the round operates only based on `roundEnd`.
-    /// @param  hookContract_ Address of an optional hook contract to be called after round closure.
-    /// @param  hookFunction_ Encoded function call to be executed on the `hookContract` after round closure.
-    /// @param  closureMechanism_ Indicates whether the hook closure coincides with the contribution span end.
-    /// @param  globalAccumulativeCaps_ Indicates whether contribution caps accumulate globally across rounds.
-    /// @param  accessCriterias_ Mapping of access criteria IDs to their respective access criteria.
+    /// @param  roundStart Timestamp indicating when the round starts.
+    /// @param  roundEnd Timestamp indicating when the round ends. If set to `0`, the round operates only based on `roundCap`.
+    /// @param  roundCap Maximum contribution cap in collateral tokens. If set to `0`, the round operates only based on `roundEnd`.
+    /// @param  hookContract Address of an optional hook contract to be called after round closure.
+    /// @param  hookFunction Encoded function call to be executed on the `hookContract` after round closure.
+    /// @param  closureMechanism Indicates whether the hook closure coincides with the contribution span end.
+    /// @param  globalAccumulativeCaps Indicates whether contribution caps accumulate globally across rounds.
+    /// @param  accessCriterias Mapping of access criteria IDs to their respective access criteria.
     struct Round {
-        uint roundStart_;
-        uint roundEnd_;
-        uint roundCap_;
-        address hookContract_;
-        bytes hookFunction_;
-        bool closureMechanism_;
-        bool globalAccumulativeCaps_;
-        mapping(uint64 id => AccessCriteria) accessCriterias_;
+        uint roundStart;
+        uint roundEnd;
+        uint roundCap;
+        address hookContract;
+        bytes hookFunction;
+        bool closureMechanism;
+        bool globalAccumulativeCaps;
+        mapping(uint64 id => AccessCriteria) accessCriterias;
     }
 
     /// @notice Struct used to store information about a funding round's access criteria.
-    /// @param  nftContract_ Address of the NFT contract.
-    /// @param  merkleRoot_ Merkle root for the access criteria.
-    /// @param  allowedAddresses_ Mapping of addresses to their access status.
+    /// @param  nftContract Address of the NFT contract.
+    /// @param  merkleRoot Merkle root for the access criteria.
+    /// @param  allowedAddresses Mapping of addresses to their access status.
     struct AccessCriteria {
         AccessCriteriaId accessCriteriaId;
-        address nftContract_; // NFT contract address (0x0 if unused)
-        bytes32 merkleRoot_; // Merkle root (0x0 if unused)
-        address[] allowedAddresses_; // Explicit allowlist
+        address nftContract; // NFT contract address (0x0 if unused)
+        bytes32 merkleRoot; // Merkle root (0x0 if unused)
+        address[] allowedAddresses; // Explicit allowlist
     }
 
     // -------------------------------------------------------------------------

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -46,10 +46,11 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Enum used to identify the type of access criteria.
     enum AccessCriteriaType {
-        OPEN, // 0
-        NFT, // 1
-        MERKLE, // 2
-        LIST // 3
+        UNSET, // 0
+        OPEN, // 1
+        NFT, // 2
+        MERKLE, // 3
+        LIST // 4
 
     }
 

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -26,7 +26,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bytes hookFunction;
         bool closureMechanism;
         bool globalAccumulativeCaps;
-        bool isActive;
+        bool isActive; //@note: do we need this?
     }
 
     // -------------------------------------------------------------------------
@@ -91,8 +91,32 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Round has already started and cannot be modified
     error Module__LM_PC_FundingPot__RoundAlreadyStarted();
 
+    /// @notice Hook function is required when a hook contract is provided
+    error Module__LM_PC_FundingPot__HookFunctionRequiredWithContract();
+
+    /// @notice Thrown when a hook contract is specified without a hook function.
+    error Module__LM_PC_FundingPot__HookFunctionRequiredWithHookContract();
+
+    /// @notice Thrown when a hook function is specified without a hook contract.
+    error Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction();
+
+    /// @notice Round does not exist
+    error Module__LM_PC_FundingPot__RoundNotCreated();
+
     // -------------------------------------------------------------------------
     // Public - Getters
+
+    /// @notice Retrieves the details of a specific funding round.
+    /// @param _roundId The unique identifier of the round to retrieve.
+    /// @return A struct containing the round's details.
+    function getRoundDetails(uint64 _roundId)
+        external
+        view
+        returns (Round memory);
+
+    /// @notice Retrieves the total number of funding rounds.
+    /// @return The total number of funding rounds.
+    function getRoundCount() external view returns (uint64);
 
     // -------------------------------------------------------------------------
     // Public - Mutating

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -63,6 +63,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundEnd_ The timestamp when the round ends.
     /// @param  roundCap_ The maximum allocation or cap for the round.
     /// @param  hookContract_ The address of an optional hook contract for custom logic.
+    /// @param  hookFunction_ The encoded function call for the hook.
     /// @param  closureMechanism_ A boolean indicating whether a specific closure mechanism is enabled.
     /// @param  globalAccumulativeCaps_ A boolean indicating whether global accumulative caps are enforced.
     event RoundCreated(
@@ -71,6 +72,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint roundEnd_,
         uint roundCap_,
         address hookContract_,
+        bytes hookFunction_,
         bool closureMechanism_,
         bool globalAccumulativeCaps_
     );
@@ -82,6 +84,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundEnd_ The updated timestamp for when the round ends.
     /// @param  roundCap_ The updated maximum allocation or cap for the round.
     /// @param  hookContract_ The address of an optional hook contract for custom logic.
+    /// @param  hookFunction_ The updated encoded function call for the hook.
     /// @param  closureMechanism_ A boolean indicating whether a specific closure mechanism is enabled.
     /// @param  globalAccumulativeCaps_ A boolean indicating whether global accumulative caps are enforced.
     event RoundEdited(
@@ -90,6 +93,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint roundEnd_,
         uint roundCap_,
         address hookContract_,
+        bytes hookFunction_,
         bool closureMechanism_,
         bool globalAccumulativeCaps_
     );
@@ -228,11 +232,11 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Set Access Control Check.
     /// @dev    Only callable by funding pot admin and only before the round has started.
     /// @param  roundId_ ID of the round.
-    /// @param  accessId_ ID of the access criteria.
+    /// @param  accessCriteriaId_ ID of the access criteria.
     /// @param  accessCriteria_ Access criteria to set.
     function setAccessCriteriaForRound(
         uint64 roundId_,
-        uint8 accessId_,
+        uint8 accessCriteriaId_,
         AccessCriteria memory accessCriteria_
     ) external;
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -214,7 +214,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param _hookFunction New encoded function call
     /// @param _closureMechanism New closure mechanism setting
     /// @param _globalAccumulativeCaps New global accumulative caps setting
-    /// @return True if edit was successful
     function editRound(
         uint64 _roundId,
         uint _roundStart,
@@ -224,9 +223,13 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bytes memory _hookFunction,
         bool _closureMechanism,
         bool _globalAccumulativeCaps
-    ) external returns (bool);
+    ) external;
 
     /// @notice Set Access Control Check
+    /// @dev Only callable by funding pot admin and only before the round has started
+    /// @param _roundId ID of the round
+    /// @param _accessId ID of the access criteria
+    /// @param _accessCriteria Access criteria to set
     function setAccessCriteriaForRound(
         uint64 _roundId,
         uint8 _accessId,

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -165,13 +165,15 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Retrieves the access criteria for a specific funding round.
     /// @param _roundId The unique identifier of the round to retrieve.
     /// @param _id The identifier of the access criteria to retrieve.
+    /// @return isOpen Whether the access criteria is open
     /// @return nftContract The address of the NFT contract used for access control
     /// @return merkleRoot The merkle root used for access verification
     /// @return allowedAddresses The list of explicitly allowed addresses
-    function getRoundAccessCriteria(uint64 _roundId, uint64 _id)
+    function getRoundAccessCriteria(uint64 _roundId, uint8 _id)
         external
         view
         returns (
+            bool isOpen,
             address nftContract,
             bytes32 merkleRoot,
             address[] memory allowedAddresses

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -93,7 +93,10 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bool globalAccumulativeCaps
     );
 
-    /// @notice
+    /// @notice Emitted when access criteria is set for a round.
+    /// @param roundId The unique identifier of the round.
+    /// @param accessId The identifier of the access criteria.
+    /// @param accessCriteria The access criteria.
     event AccessCriteriaSet(
         uint64 indexed roundId, uint8 accessId, AccessCriteria accessCriteria
     );
@@ -131,8 +134,8 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Round does not exist
     error Module__LM_PC_FundingPot__RoundNotCreated();
 
-    /// @notice
-    error Module__LM_PC_FundingPot__IncorrectAccessCriteria();
+    /// @notice Incorrect access criteria
+    error Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
 
     // -------------------------------------------------------------------------
     // Public - Getters

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -65,7 +65,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundCap_ The maximum allocation or cap for the round.
     /// @param  hookContract_ The address of an optional hook contract for custom logic.
     /// @param  hookFunction_ The encoded function call for the hook.
-    /// @param  closureMechanism_ A boolean indicating whether a specific closure mechanism is enabled.
+    /// @param  autoClosure_ A boolean indicating whether a specific closure mechanism is enabled.
     /// @param  globalAccumulativeCaps_ A boolean indicating whether global accumulative caps are enforced.
     event RoundCreated(
         uint indexed roundId_,
@@ -74,7 +74,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint roundCap_,
         address hookContract_,
         bytes hookFunction_,
-        bool closureMechanism_,
+        bool autoClosure_,
         bool globalAccumulativeCaps_
     );
 
@@ -86,7 +86,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundCap_ The updated maximum allocation or cap for the round.
     /// @param  hookContract_ The address of an optional hook contract for custom logic.
     /// @param  hookFunction_ The updated encoded function call for the hook.
-    /// @param  closureMechanism_ A boolean indicating whether a specific closure mechanism is enabled.
+    /// @param  autoClosure_ A boolean indicating whether a specific closure mechanism is enabled.
     /// @param  globalAccumulativeCaps_ A boolean indicating whether global accumulative caps are enforced.
     event RoundEdited(
         uint indexed roundId_,
@@ -95,7 +95,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint roundCap_,
         address hookContract_,
         bytes hookFunction_,
-        bool closureMechanism_,
+        bool autoClosure_,
         bool globalAccumulativeCaps_
     );
 
@@ -161,7 +161,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @return roundCap_ The maximum contribution cap for the round.
     /// @return hookContract_ The address of the hook contract.
     /// @return hookFunction_ The encoded function call for the hook.
-    /// @return closureMechanism_ Whether hook closure coincides with contribution span end.
+    /// @return autoClosure_ Whether hook closure coincides with contribution span end.
     /// @return globalAccumulativeCaps_ Whether caps accumulate globally across rounds.
     function getRoundGenericParameters(uint64 roundId_)
         external
@@ -172,18 +172,18 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         );
 
     /// @notice Retrieves the access criteria for a specific funding round.
     /// @param  roundId_ The unique identifier of the round to retrieve.
-    /// @param  id_ The identifier of the access criteria to retrieve.
+    /// @param  accessCriteriaId_ The identifier of the access criteria to retrieve.
     /// @return isOpen_ Whether the access criteria is open.
     /// @return nftContract_ The address of the NFT contract used for access control.
     /// @return merkleRoot_ The merkle root used for access verification.
     /// @return allowedAddresses_ The list of explicitly allowed addresses.
-    function getRoundAccessCriteria(uint64 roundId_, uint8 id_)
+    function getRoundAccessCriteria(uint64 roundId_, uint8 accessCriteriaId_)
         external
         view
         returns (
@@ -215,7 +215,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundCap_ Maximum contribution cap in collateral tokens (0 if using roundEnd only).
     /// @param  hookContract_ Address of contract to call after round closure.
     /// @param  hookFunction_ Encoded function call for the hook.
-    /// @param  closureMechanism_ Whether hook closure coincides with contribution span end.
+    /// @param  autoClosure_ Whether hook closure coincides with contribution span end.
     /// @param  globalAccumulativeCaps_ Whether caps accumulate globally.
     /// @return The ID of the newly created round.
     function createRound(
@@ -224,7 +224,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint roundCap_,
         address hookContract_,
         bytes memory hookFunction_,
-        bool closureMechanism_,
+        bool autoClosure_,
         bool globalAccumulativeCaps_
     ) external returns (uint64);
 
@@ -236,7 +236,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundCap_ New maximum contribution cap.
     /// @param  hookContract_ New hook contract address.
     /// @param  hookFunction_ New encoded function call.
-    /// @param  closureMechanism_ New closure mechanism setting.
+    /// @param  autoClosure_ New closure mechanism setting.
     /// @param  globalAccumulativeCaps_ New global accumulative caps setting.
     function editRound(
         uint64 roundId_,
@@ -245,7 +245,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint roundCap_,
         address hookContract_,
         bytes memory hookFunction_,
-        bool closureMechanism_,
+        bool autoClosure_,
         bool globalAccumulativeCaps_
     ) external;
 

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -17,6 +17,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param hookFunction Encoded function call to be executed on the `hookContract` after round closure.
     /// @param closureMechanism Indicates whether the hook closure coincides with the contribution span end.
     /// @param globalAccumulativeCaps Indicates whether contribution caps accumulate globally across rounds.
+    /// @param accessCriterias Mapping of access criteria IDs to their respective access criteria.
     struct Round {
         uint roundStart;
         uint roundEnd;
@@ -25,6 +26,30 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bytes hookFunction;
         bool closureMechanism;
         bool globalAccumulativeCaps;
+        mapping(uint64 id => AccessCriteria) accessCriterias;
+    }
+
+    /// @notice Struct used to store information about a funding round's access criteria.
+    /// @param nftContract Address of the NFT contract.
+    /// @param merkleRoot Merkle root for the access criteria.
+    /// @param allowedAddresses Mapping of addresses to their access status.
+    struct AccessCriteria {
+        AccessCriteriaId accessCriteriaId;
+        address nftContract; // NFT contract address (0x0 if unused)
+        bytes32 merkleRoot; // Merkle root (0x0 if unused)
+        address[] allowedAddresses; // Explicit allowlist
+    }
+
+    // -------------------------------------------------------------------------
+    // Enums
+
+    /// @notice Enum used to identify the type of access criteria.
+    enum AccessCriteriaId {
+        OPEN, // 0
+        NFT, // 1
+        MERKLE, // 2
+        LIST // 3
+
     }
 
     // -------------------------------------------------------------------------
@@ -68,6 +93,11 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bool globalAccumulativeCaps
     );
 
+    /// @notice
+    event AccessCriteriaSet(
+        uint64 indexed roundId, uint8 accessId, AccessCriteria accessCriteria
+    );
+
     // -------------------------------------------------------------------------
     // Errors
 
@@ -101,16 +131,48 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Round does not exist
     error Module__LM_PC_FundingPot__RoundNotCreated();
 
+    /// @notice
+    error Module__LM_PC_FundingPot__IncorrectAccessCriteria();
+
     // -------------------------------------------------------------------------
     // Public - Getters
 
-    /// @notice Retrieves the details of a specific funding round.
+    /// @notice Retrieves the generic parameters of a specific funding round.
     /// @param _roundId The unique identifier of the round to retrieve.
-    /// @return A struct containing the round's details.
-    function getRoundDetails(uint64 _roundId)
+    /// @return roundStart The timestamp when the round starts
+    /// @return roundEnd The timestamp when the round ends
+    /// @return roundCap The maximum contribution cap for the round
+    /// @return hookContract The address of the hook contract
+    /// @return hookFunction The encoded function call for the hook
+    /// @return closureMechanism Whether hook closure coincides with contribution span end
+    /// @return globalAccumulativeCaps Whether caps accumulate globally across rounds
+    function getRoundGenericParameters(uint64 _roundId)
         external
         view
-        returns (Round memory);
+        returns (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        );
+
+    /// @notice Retrieves the access criteria for a specific funding round.
+    /// @param _roundId The unique identifier of the round to retrieve.
+    /// @param _id The identifier of the access criteria to retrieve.
+    /// @return nftContract The address of the NFT contract used for access control
+    /// @return merkleRoot The merkle root used for access verification
+    /// @return allowedAddresses The list of explicitly allowed addresses
+    function getRoundAccessCriteria(uint64 _roundId, uint64 _id)
+        external
+        view
+        returns (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        );
 
     /// @notice Retrieves the total number of funding rounds.
     /// @return The total number of funding rounds.
@@ -160,4 +222,11 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bool _closureMechanism,
         bool _globalAccumulativeCaps
     ) external returns (bool);
+
+    /// @notice Set Access Control Check
+    function setAccessCriteriaForRound(
+        uint64 _roundId,
+        uint8 _accessId,
+        AccessCriteria memory _accessCriteria
+    ) external;
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -17,7 +17,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param hookFunction Encoded function call to be executed on the `hookContract` after round closure.
     /// @param closureMechanism Indicates whether the hook closure coincides with the contribution span end.
     /// @param globalAccumulativeCaps Indicates whether contribution caps accumulate globally across rounds.
-    /// @param isActive Indicates whether the round is currently active.
     struct Round {
         uint roundStart;
         uint roundEnd;
@@ -26,7 +25,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bytes hookFunction;
         bool closureMechanism;
         bool globalAccumulativeCaps;
-        bool isActive; //@note: do we need this?
     }
 
     // -------------------------------------------------------------------------

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -106,6 +106,14 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint64 indexed roundId_, uint8 accessId_, AccessCriteria accessCriteria_
     );
 
+    /// @notice Emitted when access criteria is edited for a round.
+    /// @param  roundId_ The unique identifier of the round.
+    /// @param  accessId_ The identifier of the access criteria.
+    /// @param  accessCriteria_ The access criteria.
+    event AccessCriteriaEdited(
+        uint64 indexed roundId_, uint8 accessId_, AccessCriteria accessCriteria_
+    );
+
     // -------------------------------------------------------------------------
     // Errors
 
@@ -138,6 +146,9 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Incorrect access criteria.
     error Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
+
+    /// @notice Invalid access criteria ID.
+    error Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
 
     // -------------------------------------------------------------------------
     // Public - Getters
@@ -182,8 +193,16 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         );
 
     /// @notice Retrieves the total number of funding rounds.
-    /// @return The total number of funding rounds.
-    function getRoundCount() external view returns (uint64);
+    /// @return roundCount_ The total number of funding rounds.
+    function getRoundCount() external view returns (uint64 roundCount_);
+
+    /// @notice Retrieves the total number of access criteria for a specific round.
+    /// @param  roundId_ The unique identifier of the round.
+    /// @return accessCriteriaCount_ The total number of access criteria for the round.
+    function getRoundAccessCriteriaCount(uint64 roundId_)
+        external
+        view
+        returns (uint8 accessCriteriaCount_);
 
     // -------------------------------------------------------------------------
     // Public - Mutating
@@ -232,9 +251,18 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Set Access Control Check.
     /// @dev    Only callable by funding pot admin and only before the round has started.
     /// @param  roundId_ ID of the round.
-    /// @param  accessCriteriaId_ ID of the access criteria.
     /// @param  accessCriteria_ Access criteria to set.
     function setAccessCriteriaForRound(
+        uint64 roundId_,
+        AccessCriteria memory accessCriteria_
+    ) external;
+
+    /// @notice Edits an existing access criteria for a round.
+    /// @dev    Only callable by funding pot admin and only before the round has started.
+    /// @param  roundId_ ID of the round.
+    /// @param  accessCriteriaId_ ID of the access criteria.
+    /// @param  accessCriteria_ New access criteria.
+    function editAccessCriteriaForRound(
         uint64 roundId_,
         uint8 accessCriteriaId_,
         AccessCriteria memory accessCriteria_

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -141,10 +141,24 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        ILM_PC_FundingPot_v1.Round memory round =
-            _helper_createDefaultFundingRound();
-
-        _helper_callCreateRound(round);
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = _helper_createDefaultFundingRound();
+        _helper_callCreateRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
         vm.stopPrank();
     }
 
@@ -152,9 +166,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         public
     {
         vm.assume(roundStart_ < block.timestamp);
-        ILM_PC_FundingPot_v1.Round memory round =
-            _helper_createDefaultFundingRound();
-        round.roundStart = roundStart_;
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = _helper_createDefaultFundingRound();
+        roundStart = roundStart_;
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -162,16 +183,31 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(round);
+        _helper_callCreateRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
     }
 
     function testCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
         public
     {
-        ILM_PC_FundingPot_v1.Round memory round =
-            _helper_createDefaultFundingRound();
-        round.roundEnd = 0;
-        round.roundCap = 0;
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = _helper_createDefaultFundingRound();
+        roundEnd = 0;
+        roundCap = 0;
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -179,16 +215,31 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(round);
+        _helper_callCreateRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
     }
 
     function testCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
-        ILM_PC_FundingPot_v1.Round memory round =
-            _helper_createDefaultFundingRound();
-        vm.assume(roundEnd_ != 0 && roundEnd_ < round.roundStart);
-        round.roundEnd = roundEnd_;
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = _helper_createDefaultFundingRound();
+        vm.assume(roundEnd_ != 0 && roundEnd_ < roundStart);
+        roundEnd = roundEnd_;
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -196,15 +247,30 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(round);
+        _helper_callCreateRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
     }
 
     function testCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
     ) public {
-        ILM_PC_FundingPot_v1.Round memory round =
-            _helper_createDefaultFundingRound();
-        round.hookContract = address(1);
-        round.hookFunction = bytes("");
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = _helper_createDefaultFundingRound();
+        hookContract = address(1);
+        hookFunction = bytes("");
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -212,15 +278,30 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(round);
+        _helper_callCreateRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
     }
 
     function testCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
     ) public {
-        ILM_PC_FundingPot_v1.Round memory round =
-            _helper_createDefaultFundingRound();
-        round.hookContract = address(0);
-        round.hookFunction = bytes("test");
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = _helper_createDefaultFundingRound();
+        hookContract = address(0);
+        hookFunction = bytes("test");
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -228,31 +309,61 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(round);
+        _helper_callCreateRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
     }
 
     /* Test createRound()
-    ├── Given all the valid parameters are provided
-    │   └── When user attempts to create a round
-    │       └── Then it should not be active and should return the round id
-    */
+        ├── Given all the valid parameters are provided
+        │   └── When user attempts to create a round
+        │       └── Then it should not be active and should return the round id
+        */
 
     function testCreateRound() public {
-        ILM_PC_FundingPot_v1.Round memory round =
-            _helper_createDefaultFundingRound();
-        _helper_callCreateRound(round);
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = _helper_createDefaultFundingRound();
+        _helper_callCreateRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
 
         uint64 lastRoundId = fundingPot.getRoundCount();
-        ILM_PC_FundingPot_v1.Round memory lastRound =
-            fundingPot.getRoundDetails(lastRoundId);
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = fundingPot.getRoundGenericParameters(lastRoundId);
 
-        assertEq(lastRound.roundStart, round.roundStart);
-        assertEq(lastRound.roundEnd, round.roundEnd);
-        assertEq(lastRound.roundCap, round.roundCap);
-        assertEq(lastRound.hookContract, round.hookContract);
-        assertEq(lastRound.hookFunction, round.hookFunction);
-        assertEq(lastRound.closureMechanism, round.closureMechanism);
-        assertEq(lastRound.globalAccumulativeCaps, round.globalAccumulativeCaps);
+        assertEq(roundStart, roundStart_);
+        assertEq(roundEnd, roundEnd_);
+        assertEq(roundCap, roundCap_);
+        assertEq(hookContract, hookContract_);
+        assertEq(hookFunction, hookFunction_);
+        assertEq(closureMechanism, closureMechanism_);
+        assertEq(globalAccumulativeCaps, globalAccumulativeCaps_);
     }
 
     /* Test fuzzed editRound()
@@ -302,10 +413,26 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        ILM_PC_FundingPot_v1.Round memory editedRound =
-            _helper_createEditedRoundParams();
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = _helper_createEditedRoundParams();
 
-        _helper_callEditRound(roundId, editedRound);
+        _helper_callEditRound(
+            0,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
+        );
         vm.stopPrank();
     }
 
@@ -314,8 +441,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.Round memory editedRound =
-            _helper_createEditedRoundParams();
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = _helper_createEditedRoundParams();
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -324,7 +458,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callEditRound(roundId + 1, editedRound);
+        _helper_callEditRound(
+            roundId + 1,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
+        );
     }
 
     function testFuzzEditRound_revertsGivenRoundIsActive(uint roundStart_)
@@ -333,13 +476,26 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.Round memory roundDetails =
-            fundingPot.getRoundDetails(roundId);
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
 
-        vm.warp(roundDetails.roundStart + 1);
-
-        ILM_PC_FundingPot_v1.Round memory editedRound =
-            _helper_createEditedRoundParams();
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = _helper_createEditedRoundParams();
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -347,19 +503,35 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callEditRound(roundId, editedRound);
+        _helper_callEditRound(
+            roundId,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
+        );
     }
 
     function testFuzzEditRound_revertsGivenRoundStartIsInThePast(
-        uint roundStart_
+        uint roundStartP_
     ) public {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        vm.assume(roundStart_ < block.timestamp);
-        ILM_PC_FundingPot_v1.Round memory editedRound =
-            _helper_createEditedRoundParams();
-        editedRound.roundStart = roundStart_;
+        vm.assume(roundStartP_ < block.timestamp);
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = _helper_createEditedRoundParams();
+        roundStart_ = roundStartP_;
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -369,7 +541,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(roundId, editedRound);
+        _helper_callEditRound(
+            roundId,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
+        );
     }
 
     function testFuzzEditRound_revertsGivenRoundEndTimeAndCapAreBothZero()
@@ -378,10 +559,17 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.Round memory editedRound =
-            _helper_createEditedRoundParams();
-        editedRound.roundEnd = 0;
-        editedRound.roundCap = 0;
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = _helper_createEditedRoundParams();
+        roundEnd_ = 0;
+        roundCap_ = 0;
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -391,7 +579,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(roundId, editedRound);
+        _helper_callEditRound(
+            roundId,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
+        );
     }
 
     function testFuzzEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
@@ -400,10 +597,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.Round memory editedRound =
-            _helper_createEditedRoundParams();
-        vm.assume(roundEnd_ != 0 && roundEnd_ < editedRound.roundStart);
-        editedRound.roundEnd = roundEnd_;
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = _helper_createEditedRoundParams();
+        roundEnd_ = bound(roundEnd_, 0, roundStart_ - 1);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -413,7 +616,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(roundId, editedRound);
+        _helper_callEditRound(
+            roundId,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
+        );
     }
 
     function testFuzzEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
@@ -421,10 +633,17 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.Round memory editedRound =
-            _helper_createEditedRoundParams();
-        editedRound.hookContract = address(1);
-        editedRound.hookFunction = bytes("");
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = _helper_createEditedRoundParams();
+        hookContract_ = address(1);
+        hookFunction_ = bytes("");
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -434,7 +653,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(roundId, editedRound);
+        _helper_callEditRound(
+            roundId,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
+        );
     }
 
     function testFuzzEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
@@ -442,10 +670,17 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.Round memory editedRound =
-            _helper_createEditedRoundParams();
-        editedRound.hookContract = address(0);
-        editedRound.hookFunction = bytes("test");
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = _helper_createEditedRoundParams();
+        hookContract_ = address(0);
+        hookFunction_ = bytes("test");
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -455,7 +690,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(roundId, editedRound);
+        _helper_callEditRound(
+            roundId,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
+        );
     }
 
     /* Test editRound()
@@ -476,119 +720,163 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 lastRoundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.Round memory editedRound =
-            _helper_createEditedRoundParams();
+        (
+            uint roundStart_,
+            uint roundEnd_,
+            uint roundCap_,
+            address hookContract_,
+            bytes memory hookFunction_,
+            bool closureMechanism_,
+            bool globalAccumulativeCaps_
+        ) = _helper_createEditedRoundParams();
 
-        _helper_callEditRound(lastRoundId, editedRound);
-
-        ILM_PC_FundingPot_v1.Round memory updatedRound =
-            fundingPot.getRoundDetails(lastRoundId);
-
-        assertEq(updatedRound.roundStart, editedRound.roundStart);
-        assertEq(updatedRound.roundEnd, editedRound.roundEnd);
-        assertEq(updatedRound.roundCap, editedRound.roundCap);
-        assertEq(updatedRound.hookContract, editedRound.hookContract);
-        assertEq(
-            keccak256(updatedRound.hookFunction),
-            keccak256(editedRound.hookFunction)
+        _helper_callEditRound(
+            lastRoundId,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
         );
-        assertEq(updatedRound.closureMechanism, editedRound.closureMechanism);
-        assertEq(
-            updatedRound.globalAccumulativeCaps,
-            editedRound.globalAccumulativeCaps
-        );
+
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = fundingPot.getRoundGenericParameters(lastRoundId);
+
+        assertEq(roundStart, roundStart_);
+        assertEq(roundEnd, roundEnd_);
+        assertEq(roundCap, roundCap_);
+        assertEq(hookContract, hookContract_);
+        assertEq(hookFunction, hookFunction_);
+        assertEq(closureMechanism, closureMechanism_);
+        assertEq(globalAccumulativeCaps, globalAccumulativeCaps_);
     }
 
-    // -------------------------------------------------------------------------
-    // Test: Internal Functions
+    //     // -------------------------------------------------------------------------
+    //     // Test: Internal Functions
 
-    // Helper Functions
+    //     // Helper Functions
 
-    // @notice Creates a default funding round
-    function _generateFundingRoundParams(
-        uint roundStart_,
-        uint roundEnd_,
-        uint roundCap_,
-        address hookContract_,
-        bytes memory hookFunction_,
-        bool closureMechanism_,
-        bool globalAccumulativeCaps_
-    ) internal returns (ILM_PC_FundingPot_v1.Round memory) {
-        ILM_PC_FundingPot_v1.Round memory round = ILM_PC_FundingPot_v1.Round({
-            roundStart: roundStart_,
-            roundEnd: roundEnd_,
-            roundCap: roundCap_,
-            hookContract: hookContract_,
-            hookFunction: hookFunction_,
-            closureMechanism: closureMechanism_,
-            globalAccumulativeCaps: globalAccumulativeCaps_
-        });
-        return round;
-    }
+    //     // @notice Creates a default funding round
+    //     // @dev make the parameters fuzzable @TODO Jeffrey
+    //     function _generateFundingRoundParams(
+    //         uint roundStart_,
+    //         uint roundEnd_,
+    //         uint roundCap_,
+    //         address hookContract_,
+    //         bytes memory hookFunction_,
+    //         bool closureMechanism_,
+    //         bool globalAccumulativeCaps_
+    //     ) internal returns (ILM_PC_FundingPot_v1.Round memory) {
+    //         ILM_PC_FundingPot_v1.Round memory round = ILM_PC_FundingPot_v1.Round({
+    //             roundStart: roundStart_,
+    //             roundEnd: roundEnd_,
+    //             roundCap: roundCap_,
+    //             hookContract: hookContract_,
+    //             hookFunction: hookFunction_,
+    //             closureMechanism: closureMechanism_,
+    //             globalAccumulativeCaps: globalAccumulativeCaps_
+    //         });
+    //         return round;
+    //     }
 
     // @notice Creates a default funding round
     function _helper_createDefaultFundingRound()
         internal
-        returns (ILM_PC_FundingPot_v1.Round memory)
+        returns (uint, uint, uint, address, bytes memory, bool, bool)
     {
-        //@todo need to randomize the input using vm.bound or vm.assume, do the same for the edited round
-        //@33 do you have any input here?
-        return _generateFundingRoundParams(
-            block.timestamp + 1 days,
-            block.timestamp + 2 days,
-            1000,
-            address(0),
-            bytes(""),
-            false,
-            false
+        uint roundStart = block.timestamp + 1 days;
+        uint roundEnd = block.timestamp + 2 days;
+        uint roundCap = 1000;
+        address hookContract = address(0);
+        bytes memory hookFunction = bytes("");
+        bool closureMechanism = false;
+        bool globalAccumulativeCaps = false;
+
+        return (
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
         );
     }
 
     // @notice calls the create round function
-    function _helper_callCreateRound(ILM_PC_FundingPot_v1.Round memory round)
-        internal
-    {
+    function _helper_callCreateRound(
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bytes memory hookFunction,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
+    ) internal {
         fundingPot.createRound(
-            round.roundStart,
-            round.roundEnd,
-            round.roundCap,
-            round.hookContract,
-            round.hookFunction,
-            round.closureMechanism,
-            round.globalAccumulativeCaps
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
         );
     }
 
     // @notice Creates a predefined funding round with edited parameters for testing
     function _helper_createEditedRoundParams()
         internal
-        returns (ILM_PC_FundingPot_v1.Round memory)
+        returns (uint, uint, uint, address, bytes memory, bool, bool)
     {
-        return _generateFundingRoundParams(
-            block.timestamp + 150,
-            block.timestamp + 250,
-            20,
-            address(0x1),
-            hex"abcd",
-            true,
-            true
+        uint roundStart_ = block.timestamp + 3 days;
+        uint roundEnd_ = block.timestamp + 4 days;
+        uint roundCap_ = 2000;
+        address hookContract_ = address(0x1);
+        bytes memory hookFunction_ = bytes("test");
+        bool closureMechanism_ = true;
+        bool globalAccumulativeCaps_ = true;
+
+        return (
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            closureMechanism_,
+            globalAccumulativeCaps_
         );
     }
 
     // @notice calls the create round function
     function _helper_callEditRound(
         uint64 roundId,
-        ILM_PC_FundingPot_v1.Round memory round
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bytes memory hookFunction,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
     ) internal {
         fundingPot.editRound(
             roundId,
-            round.roundStart,
-            round.roundEnd,
-            round.roundCap,
-            round.hookContract,
-            round.hookFunction,
-            round.closureMechanism,
-            round.globalAccumulativeCaps
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
         );
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -290,6 +290,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         address user_
     ) public {
         testCreateRound();
+
+        uint64 roundId = fundingPot.getRoundCount();
+
         vm.startPrank(user_);
         bytes32 roleId = _authorizer.generateRoleId(
             address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
@@ -302,7 +305,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.Round memory editedRound =
             _helper_createEditedRoundParams();
 
-        _helper_callEditRound(0, editedRound);
+        _helper_callEditRound(roundId, editedRound);
         vm.stopPrank();
     }
 
@@ -481,36 +484,18 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.Round memory updatedRound =
             fundingPot.getRoundDetails(lastRoundId);
 
-        assertEq(
-            updatedRound.roundStart,
-            editedRound.roundStart,
-            "roundStart not updated"
-        );
-        assertEq(
-            updatedRound.roundEnd, editedRound.roundEnd, "roundEnd not updated"
-        );
-        assertEq(
-            updatedRound.roundCap, editedRound.roundCap, "roundCap not updated"
-        );
-        assertEq(
-            updatedRound.hookContract,
-            editedRound.hookContract,
-            "hookContract not updated"
-        );
+        assertEq(updatedRound.roundStart, editedRound.roundStart);
+        assertEq(updatedRound.roundEnd, editedRound.roundEnd);
+        assertEq(updatedRound.roundCap, editedRound.roundCap);
+        assertEq(updatedRound.hookContract, editedRound.hookContract);
         assertEq(
             keccak256(updatedRound.hookFunction),
-            keccak256(editedRound.hookFunction),
-            "hookFunction not updated"
+            keccak256(editedRound.hookFunction)
         );
-        assertEq(
-            updatedRound.closureMechanism,
-            editedRound.closureMechanism,
-            "closureMechanism not updated"
-        );
+        assertEq(updatedRound.closureMechanism, editedRound.closureMechanism);
         assertEq(
             updatedRound.globalAccumulativeCaps,
-            editedRound.globalAccumulativeCaps,
-            "globalAccumulativeCaps not updated"
+            editedRound.globalAccumulativeCaps
         );
     }
 

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+pragma solidity 0.8.23;
 
 // Internal
 import {
@@ -8,12 +8,11 @@ import {
     IOrchestrator_v1
 } from "test/modules/ModuleTest.sol";
 import {OZErrors} from "test/utils/errors/OZErrors.sol";
-import {ERC20Mock} from "test/utils/mocks/ERC20Mock.sol";
 
 // External
 import {Clones} from "@oz/proxy/Clones.sol";
 
-// Tests and Mocks
+// Mocks
 import {
     IERC20PaymentClientBase_v2,
     ERC20PaymentClientBaseV2Mock,
@@ -67,7 +66,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Initiate the Logic Module with the metadata and config data
         fundingPot.init(_orchestrator, _METADATA, abi.encode(""));
 
-        // Give test contract the DEPOSIT_ADMIN_ROLE.
+        // Give test contract the FUNDING_POT_ROLE.
         fundingPot.grantModuleRole(
             fundingPot.FUNDING_POT_ADMIN_ROLE(), address(this)
         );
@@ -101,30 +100,37 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // -------------------------------------------------------------------------
     // Test External (public + external)
 
-    /* Test createRound()
+    /* Test fuzzed createRound()
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    ├── Given round start time is in the past
+    └── Given user has FUNDING_POT_ADMIN_ROLE
+    ├── And round start < block.timestamp
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    ├── Given round end time is 0 and round cap is 0
+    ├── And round end time == 0 
+    │   ├── And round cap == 0
+    │   │   └── When user attempts to create a round
+    │   │       └── Then it should revert
+    ├── And round end time is set 
+    │   ├── And round end != 0
+    │   ├── And round end < round start
+    │   │   └── When user attempts to create a round
+    │   │       └── Then it should revert
+    ├── And hook contract is set but hook function is not set
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    ├── Given round end time is set and round end time is in the past
+    ├── And hook function is set but hook contract is not set
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    ├── Given hook contract is set but hook function is not set
-    │   └── When user attempts to create a round
-    │       └── Then it should revert
-    ├── Given hook function is set but hook contract is not set
-    │   └── When user attempts to create a round
-    │       └── Then it should revert
+    └── Given all the valid parameters are provided
+        └── When user attempts to create a round
+            └── Then it should not be active and should return the round id
     */
 
-    function testFuzzCreateRound_revertsGivenUserIsNotFundingPotAdmin(
-        address user_
-    ) public {
+    function testCreateRound_revertsGivenUserIsNotFundingPotAdmin(address user_)
+        public
+    {
         vm.assume(user_ != address(0) && user_ != address(this));
         vm.startPrank(user_);
         bytes32 roleId = _authorizer.generateRoleId(
@@ -137,13 +143,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
+
         _helper_callCreateRound(round);
         vm.stopPrank();
     }
 
-    function testFuzzCreateRound_revertsGivenRoundStartIsInThePast(
-        uint roundStart_
-    ) public {
+    function testCreateRound_revertsGivenRoundStartIsInThePast(uint roundStart_)
+        public
+    {
         vm.assume(roundStart_ < block.timestamp);
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
@@ -158,7 +165,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _helper_callCreateRound(round);
     }
 
-    function testFuzzCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
+    function testCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
         public
     {
         ILM_PC_FundingPot_v1.Round memory round =
@@ -175,7 +182,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _helper_callCreateRound(round);
     }
 
-    function testFuzzCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
+    function testCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
         ILM_PC_FundingPot_v1.Round memory round =
@@ -192,7 +199,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _helper_callCreateRound(round);
     }
 
-    function testFuzzCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
+    function testCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
     ) public {
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
@@ -208,7 +215,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _helper_callCreateRound(round);
     }
 
-    function testFuzzCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
+    function testCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
     ) public {
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
@@ -230,7 +237,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │       └── Then it should not be active and should return the round id
     */
 
-    function testFuzzCreateRound() public {
+    function testCreateRound() public {
         ILM_PC_FundingPot_v1.Round memory round =
             _helper_createDefaultFundingRound();
         _helper_callCreateRound(round);
@@ -248,9 +255,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(lastRound.globalAccumulativeCaps, round.globalAccumulativeCaps);
     }
 
-    /* Test editRound()
+    /* Test fuzzed editRound()
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round
     │       └── Then it should revert
     ├── Given round does not exist
     │   └── When user attempts to edit the round
@@ -261,24 +268,28 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     ├── Given round start time is in the past
     │   └── When user attempts to edit a round with the above parameter
     │       └── Then it should revert
-    ├── Given round end time is 0 and round cap is 0
-    │   └── When user attempts edit a round with the above parameters
-    │       └── Then it should revert
-    ├── Given round end time is set and round end time is in the past
+    ├── Given round end time == 0
+    │   ├── And round cap == 0
     │   └── When user attempts to edit a round with the above parameters
     │       └── Then it should revert
-    ├── Given hook contract is set but hook function is not set
-    │   └── When user attempts to edit a round with the above parameters
+    ├── Given round end time is set
+    │   ├── And round end is before round start
+    │   └── When user attempts to edit the round
     │       └── Then it should revert
-    ├── Given hook function is set but hook contract is not set
-    │   └── When user attempts to edit a round with the above parameters
+    ├── Given hook contract is set
+    │   ├── And hook function is empty
+    │   └── When user attempts to edit the round
     │       └── Then it should revert
+    └── Given hook function is set
+        ├── And hook contract is empty
+            └── When user attempts to edit the round
+                └── Then it should revert  
     */
 
     function testFuzzEditRound_revertsGivenUserIsNotFundingPotAdmin(
         address user_
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         vm.startPrank(user_);
         bytes32 roleId = _authorizer.generateRoleId(
             address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
@@ -296,11 +307,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testFuzzEditRound_revertsGivenRoundIsNotCreated() public {
-        testFuzzCreateRound();
+        testCreateRound();
+
+        uint64 roundId = fundingPot.getRoundCount();
+
         ILM_PC_FundingPot_v1.Round memory editedRound =
             _helper_createEditedRoundParams();
 
-        uint64 roundId = fundingPot.getRoundCount();
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -314,7 +327,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditRound_revertsGivenRoundIsActive(uint roundStart_)
         public
     {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory roundDetails =
@@ -337,7 +350,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditRound_revertsGivenRoundStartIsInThePast(
         uint roundStart_
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         vm.assume(roundStart_ < block.timestamp);
@@ -359,7 +372,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditRound_revertsGivenRoundEndTimeAndCapAreBothZero()
         public
     {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -381,7 +394,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -402,7 +415,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testFuzzEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -423,7 +436,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testFuzzEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
     ) public {
-        testFuzzCreateRound();
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -443,20 +456,21 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     /* Test editRound()
-    ├── Given a round has been created and is not active
-    │   └── When an admin provides valid parameters to edit the round
-    │       └── Then all the round details should be successfully updated
-    │           ├── roundStart should be updated to the new value
-    │           ├── roundEnd should be updated to the new value
-    │           ├── roundCap should be updated to the new value
-    │           ├── hookContract should be updated to the new value
-    │           ├── hookFunction should be updated to the new value
-    │           ├── closureMechanism should be updated to the new value
-    │           └── globalAccumulativeCaps should be updated to the new value
+    └── Given a round has been created
+    ├── And the round is not active
+    └── When an admin provides valid parameters to edit the round
+        └── Then all the round details should be successfully updated
+            ├── roundStart should be updated to the new value
+            ├── roundEnd should be updated to the new value
+            ├── roundCap should be updated to the new value
+            ├── hookContract should be updated to the new value
+            ├── hookFunction should be updated to the new value
+            ├── closureMechanism should be updated to the new value
+            └── globalAccumulativeCaps should be updated to the new value
     */
 
-    function testFuzzEditRound() public {
-        testFuzzCreateRound();
+    function testEditRound() public {
+        testCreateRound();
         uint64 lastRoundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
@@ -506,7 +520,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // Helper Functions
 
     // @notice Creates a default funding round
-    // @dev make the parameters fuzzable @TODO Jeffrey
     function _generateFundingRoundParams(
         uint roundStart_,
         uint roundEnd_,

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -120,7 +120,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertTrue(
             fundingPot.supportsInterface(type(ILM_PC_FundingPot_v1).interfaceId)
         );
-
     }
 
     function testReinitFails() public override(ModuleTest) {
@@ -317,7 +316,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testCreateRound() public {
         RoundParams memory params = _defaultRoundParams;
-        
+
         fundingPot.createRound(
             params.roundStart,
             params.roundEnd,
@@ -329,7 +328,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
 
         _testRoundId = fundingPot.getRoundCount();
-        
+
         // Retrieve the stored parameters
         (
             uint storedRoundStart,
@@ -587,12 +586,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         // Get the current round start time
-        (uint currentRoundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
-        
+        (uint currentRoundStart,,,,,,) =
+            fundingPot.getRoundGenericParameters(roundId);
+
         // Ensure roundEnd_ is less than current round start
         vm.assume(roundEnd_ < currentRoundStart);
         vm.assume(roundEnd_ != 0);
-        
+
         RoundParams memory params = _helper_createEditRoundParams(
             currentRoundStart,
             roundEnd_,

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -97,26 +97,32 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
     │   └── When user attempts to create a round
     │       └── Then it should revert
+    │
     └── Given user has FUNDING_POT_ADMIN_ROLE
     ├── And round start < block.timestamp
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    ├── And round end time == 0 
-    │   ├── And round cap == 0
-    │   │   └── When user attempts to create a round
-    │   │       └── Then it should revert
-    ├── And round end time is set 
-    │   ├── And round end != 0
-    │   ├── And round end < round start
-    │   │   └── When user attempts to create a round
-    │   │       └── Then it should revert
+    │
+    ├── And round end time == 0
+    ├── And round cap == 0
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    │
+    ├── And round end time is set
+    ├── And round end != 0
+    ├── And round end < round start
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    │
     ├── And hook contract is set but hook function is not set
     │   └── When user attempts to create a round
     │       └── Then it should revert
+    │
     ├── And hook function is set but hook contract is not set
     │   └── When user attempts to create a round
     │       └── Then it should revert
-    └── Given all the valid parameters are provided
+    │
+    └── And all the valid parameters are provided
         └── When user attempts to create a round
             └── Then it should not be active and should return the round id
     */
@@ -317,7 +323,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ├── Given all the valid parameters are provided
         │   └── When user attempts to create a round
         │       └── Then it should not be active and should return the round id
-        */
+    */
 
     function testCreateRound() public {
         (
@@ -363,31 +369,39 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
     │   └── When user attempts to edit a round
     │       └── Then it should revert
-    ├── Given round does not exist
-    │   └── When user attempts to edit the round
-    │       └── Then it should revert
-    ├── Given round is active
-    │   └── When user attempts to edit the round
-    │       └── Then it should revert
-    ├── Given round start time is in the past
-    │   └── When user attempts to edit a round with the above parameter
-    │       └── Then it should revert
-    ├── Given round end time == 0
-    │   ├── And round cap == 0
-    │   └── When user attempts to edit a round with the above parameters
-    │       └── Then it should revert
-    ├── Given round end time is set
-    │   ├── And round end is before round start
-    │   └── When user attempts to edit the round
-    │       └── Then it should revert
-    ├── Given hook contract is set
-    │   ├── And hook function is empty
-    │   └── When user attempts to edit the round
-    │       └── Then it should revert
-    └── Given hook function is set
-        ├── And hook contract is empty
+    │
+    └── Given user has FUNDING_POT_ADMIN_ROLE
+        ├── Given round does not exist
+        │   └── When user attempts to edit the round
+        │       └── Then it should revert
+        │
+        ├── Given round is active
+        │   └── When user attempts to edit the round
+        │       └── Then it should revert
+        │
+        ├── Given round start time is in the past
+        │   └── When user attempts to edit a round with this parameter
+        │       └── Then it should revert
+        │
+        ├── Given round end time == 0 and round cap == 0
+        │   └── When user attempts to edit a round with these parameters
+        │       └── Then it should revert
+        │
+        ├── Given round end time is set and round end < round start
+        │   └── When user attempts to edit the round
+        │       └── Then it should revert
+        │
+        ├── Given hook contract is set but hook function is empty
+        │   └── When user attempts to edit the round
+        │       └── Then it should revert
+        │
+        ├── Given hook function is set but hook contract is empty
+        │   └── When user attempts to edit the round
+        │       └── Then it should revert
+        │
+        └── Given all valid parameters are provided
             └── When user attempts to edit the round
-                └── Then it should revert  
+                └── Then all round details should be successfully updated
     */
 
     function testEditRound_revertsGivenUserIsNotFundingPotAdmin(address user_)
@@ -698,7 +712,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     └── Given a round has been created
     ├── And the round is not active
     └── When an admin provides valid parameters to edit the round
-        └── Then all the round details should be successfully updated
+        └── Then all round details should be successfully updated
             ├── roundStart should be updated to the new value
             ├── roundEnd should be updated to the new value
             ├── roundCap should be updated to the new value
@@ -756,24 +770,31 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
     │   └── When user attempts to set access criteria
     │       └── Then it should revert
-    ├── Given round does not exist
-    │   └── When user attempts to set access criteria
-    │       └── Then it should revert
-    ├── Given round is active
-    │   └── When user attempts to set access criteria
-    │       └── Then it should revert
-    ├── Given AccessCriteriaId is NFT and nftContract is 0x0
-    │   └── When user attempts to set access criteria
-    │       └── Then it should revert
-    ├── Given AccessCriteriaId is MERKLE and merkleRoot is 0x0
-    │   └── When user attempts to set access criteria
-    │       └── Then it should revert
-    ├── Given AccessCriteriaId is LIST and allowedAddresses is empty
-    │   └── When user attempts to set access criteria
-    │       └── Then it should revert
-    └── Given all the valid parameters are provided
-        └── When user attempts to set access criteria
-            └── Then it should not revert
+    │
+    └── Given user has FUNDING_POT_ADMIN_ROLE
+        ├── Given round does not exist
+        │   └── When user attempts to set access criteria
+        │       └── Then it should revert
+        │
+        ├── Given round is active
+        │   └── When user attempts to set access criteria
+        │       └── Then it should revert
+        │
+        ├── Given AccessCriteriaId is NFT and nftContract is 0x0
+        │   └── When user attempts to set access criteria
+        │       └── Then it should revert
+        │
+        ├── Given AccessCriteriaId is MERKLE and merkleRoot is 0x0
+        │   └── When user attempts to set access criteria
+        │       └── Then it should revert
+        │
+        ├── Given AccessCriteriaId is LIST and allowedAddresses is empty
+        │   └── When user attempts to set access criteria
+        │       └── Then it should revert
+        │
+        └── Given all the valid parameters are provided
+            └── When user attempts to set access criteria
+                └── Then it should not revert
     */
 
     function testFuzzSetAccessCriteria_revertsGivenUserDoesNotHaveFundingPotAdminRole(
@@ -805,7 +826,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzSetAccessCriteria_revertsGivenRoundDoesNotExist(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
 
         uint64 roundId = fundingPot.getRoundCount();
 
@@ -825,7 +846,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzSetAccessCriteria_revertsGivenRoundIsActive(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
 
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
@@ -913,7 +934,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testFuzzSetAccessCriteria(uint8 accessCriteriaEnum) public {
-        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
 
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
@@ -931,37 +952,41 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address[] memory allowedAddresses
         ) = fundingPot.getRoundAccessCriteria(roundId, accessCriteriaId);
 
-        assertEq(isOpen, accessCriteriaEnum == 0);
+        assertEq(isOpen, accessCriteriaEnum == 1);
         assertEq(nftContract, accessCriteria.nftContract);
         assertEq(merkleRoot, accessCriteria.merkleRoot);
         assertEq(allowedAddresses, accessCriteria.allowedAddresses);
     }
 
-    /* test editAccessCriteriaForRound()
+    /* Test editAccessCriteriaForRound()
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
     │   └── When user attempts to edit access criteria
     │       └── Then it should revert
-    ├── Given access criteria id is greater than the number of access criteria for the round
-    │   └── When user attempts to edit access criteria
-    │       └── Then it should revert
-    ├── Given round does not exist
-    │   └── When user attempts to set access criteria
-    │       └── Then it should revert
-    ├── Given round is active
-    │   └── When user attempts to set access criteria
-    │       └── Then it should revert
-    └── Given all the valid parameters are provided
-        └── When user attempts to edit access criteria
-            └── Then it should not revert
-            └── Then the access criteria should be updated
-
+    │
+    └── Given user has FUNDING_POT_ADMIN_ROLE
+        ├── Given access criteria id is greater than the number of access criteria for the round
+        │   └── When user attempts to edit access criteria
+        │       └── Then it should revert
+        │
+        ├── Given round does not exist
+        │   └── When user attempts to edit access criteria
+        │       └── Then it should revert
+        │
+        ├── Given round is active
+        │   └── When user attempts to edit access criteria
+        │       └── Then it should revert
+        │
+        └── Given all valid parameters are provided
+            └── When user attempts to edit access criteria
+                ├── Then it should not revert
+                └── Then the access criteria should be updated
     */
 
     function testFuzzEditAccessCriteriaForRound_revertsGivenUserDoesNotHaveFundingPotAdminRole(
         uint8 accessCriteriaEnum,
         address user_
     ) public {
-        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
         vm.assume(user_ != address(0) && user_ != address(this));
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
@@ -989,7 +1014,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditAccessCriteriaForRound_revertsGivenAccessCriteriaIdIsGreaterThanAccessCriteriaForTheRound(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
         uint64 roundId = fundingPot.getRoundCount();
@@ -1013,7 +1038,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditAccessCriteriaForRound_revertsGivenRoundDoesNotExist(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessCriteriaId = 0;
 
@@ -1029,7 +1054,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditAccessCriteriaForRound_revertsGivenRoundIsActive(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
         uint64 roundId = fundingPot.getRoundCount();
@@ -1058,10 +1083,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessCriteriaEnumOld,
         uint8 accessCriteriaEnumNew
     ) public {
-        vm.assume(accessCriteriaEnumOld >= 0 && accessCriteriaEnumOld <= 3);
+        vm.assume(accessCriteriaEnumOld >= 1 && accessCriteriaEnumOld <= 4);
         vm.assume(
             accessCriteriaEnumNew != accessCriteriaEnumOld
-                && accessCriteriaEnumNew >= 0 && accessCriteriaEnumNew <= 3
+                && accessCriteriaEnumNew >= 1 && accessCriteriaEnumNew <= 4
         );
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnumOld);
@@ -1084,7 +1109,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address[] memory allowedAddresses
         ) = fundingPot.getRoundAccessCriteria(roundId, accessCriteriaId);
 
-        assertEq(isOpen, accessCriteriaEnumNew == 0);
+        assertEq(isOpen, accessCriteriaEnumNew == 1);
         assertEq(nftContract, newAccessCriteria.nftContract);
         assertEq(merkleRoot, newAccessCriteria.merkleRoot);
         assertEq(allowedAddresses, newAccessCriteria.allowedAddresses);

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -52,7 +52,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     // SuT
     LM_PC_FundingPot_v1_Exposed fundingPot;
-    address public fundingPotAdmin = makeAddr("FundingPotAdmin");
 
     // -------------------------------------------------------------------------
     // Setup
@@ -70,8 +69,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Give test contract the DEPOSIT_ADMIN_ROLE.
         fundingPot.grantModuleRole(
-            fundingPot.FUNDING_POT_ADMIN_ROLE(), fundingPotAdmin
+            fundingPot.FUNDING_POT_ADMIN_ROLE(), address(this)
         );
+        _authorizer.setIsAuthorized(address(this), true);
+
+        // Set the block timestamp
+        vm.warp(block.timestamp + _orchestrator.MODULE_UPDATE_TIMELOCK());
     }
 
     // -------------------------------------------------------------------------
@@ -95,206 +98,261 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.init(_orchestrator, _METADATA, abi.encode(""));
     }
 
-    function test_fundingPotAdminRoleGranted() public {
-        bytes32 roleId = _orchestrator.authorizer().generateRoleId(
-            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
-        );
-        assertTrue(_orchestrator.authorizer().hasRole(roleId, fundingPotAdmin));
-    }
-
     // -------------------------------------------------------------------------
     // Test External (public + external)
 
-    /* Test fuzzed createRound()
-        ├── Given a round start time is in the future
-        │   ├── And the round end time is either after the start or the round has a cap
-        │   │   └── When a new round is created with the given parameters
-        │   │       └── Then the stored round details should match the provided values
+    /* Test createRound()
+    ├── Given user does not have FUNDING_POT_ADMIN_ROLE
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round start time is in the past
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round end time is 0 and round cap is 0
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round end time is set and round end time is in the past
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given hook contract is set but hook function is not set
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given hook function is set but hook contract is not set
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
     */
-    function testFuzz_createRound(
-        uint roundStart,
-        uint roundEnd,
-        uint roundCap,
-        address hookContract,
-        bytes memory hookFunction,
-        bool closureMechanism,
-        bool globalAccumulativeCaps
+
+    function testFuzzCreateRound_revertsGivenUserIsNotFundingPotAdmin(
+        address user_
     ) public {
-        vm.assume(roundStart > block.timestamp);
-        vm.assume(roundEnd > roundStart || roundCap > 0);
-        if (roundEnd > 0) {
-            vm.assume(roundEnd > roundStart);
-        }
-
-        uint64 roundId = fundingPot.createRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
+        vm.assume(user_ != address(0) && user_ != address(this));
+        vm.startPrank(user_);
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
         );
-
-        (uint storedStart, uint storedEnd, uint storedCap,,,,, bool isActive) =
-            fundingPot.rounds(roundId);
-
-        assertEq(storedStart, roundStart, "Round start mismatch");
-        assertEq(storedEnd, roundEnd, "Round end mismatch");
-        assertEq(storedCap, roundCap, "Round cap mismatch");
-        assertTrue(isActive, "Round should be active");
-    }
-
-    /* Test createRound() with invalid start time
-        ├── Given a start time that is in the past
-        │   └── When attempting to create a round with this past start time
-        │       └── Then it should revert with "Round start must be in the future"
-    */
-    function test_createRound_invalidStart() public {
-        uint pastTime = block.timestamp - 1;
         vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__RoundStartMustBeInFuture
-                .selector
+            abi.encodeWithSelector(
+                IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
+            )
         );
-        fundingPot.createRound(
-            pastTime, block.timestamp + 10, 1000, address(0), "", false, false
-        );
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        _callCreateRound(round);
+        vm.stopPrank();
     }
 
-    /* Test createRound() with invalid end time
-        ├── Given a future start time
-        │   └── When attempting to create a round where end time is before start time and cap is zero
-        │       └── Then it should revert with "Round must have either end time or cap"
-    */
-    function test_createRound_invalidEnd() public {
-        uint futureTime = block.timestamp + 100;
-        vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap
-                .selector
-        );
-        fundingPot.createRound(
-            futureTime, futureTime - 1, 0, address(0), "", false, false
-        );
-    }
-
-    /* Test fuzzed editRound()
-        ├── Given a round start time is in the future
-        │   ├── And the round end time is greater than zero and after the start time
-        │   │   └── When editing the round with new parameters
-        │   │       ├── Then the update should be successful
-        │   │       └── And the stored values should match the new parameters
-    */
-    function testFuzz_editRound(
-        uint roundStart,
-        uint roundEnd,
-        uint roundCap,
-        address hookContract,
-        bytes memory hookFunction,
-        bool closureMechanism,
-        bool globalAccumulativeCaps
+    function testFuzzCreateRound_revertsGivenRoundStartIsInThePast(
+        uint roundStart_
     ) public {
-        vm.assume(roundStart > block.timestamp);
-        vm.assume(roundStart < type(uint).max - 100);
-        vm.assume(roundEnd > 0);
-        vm.assume(roundEnd > roundStart);
-        vm.assume(roundEnd <= type(uint).max - 100);
-        vm.assume(roundCap <= type(uint).max - 100);
-
-        uint64 roundId = fundingPot.createRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
+        vm.assume(roundStart_ < block.timestamp);
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        round.roundStart = roundStart_;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundStartMustBeInFuture
+                    .selector
+            )
         );
-
-        uint newStart = roundStart + 100;
-        uint newEnd = roundEnd + 100;
-        uint newCap = roundCap + 100;
-
-        bool success = fundingPot.editRound(
-            roundId,
-            newStart,
-            newEnd,
-            newCap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
-        );
-
-        assertTrue(success, "Round edit failed");
-
-        (uint storedStart, uint storedEnd, uint storedCap,,,,,) =
-            fundingPot.rounds(roundId);
-        assertEq(storedStart, newStart, "Updated round start mismatch");
-        assertEq(storedEnd, newEnd, "Updated round end mismatch");
-        assertEq(storedCap, newCap, "Updated round cap mismatch");
+        _callCreateRound(round);
     }
 
-    /* Test editRound() on nonexistent round
-        ├── Given a round does not exist
-        │   └── When attempting to edit the round
-        │       └── Then it should revert with "Round does not exist"
-    */
-    function test_editRound_nonexistent() public {
+    function testFuzzCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
+        public
+    {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        round.roundEnd = 0;
+        round.roundCap = 0;
         vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__RoundDoesNotExist
-                .selector
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap
+                    .selector
+            )
         );
-        fundingPot.editRound(
-            9999,
-            block.timestamp + 100,
-            block.timestamp + 200,
-            1000,
-            address(0),
-            "",
-            false,
-            false
-        );
+        _callCreateRound(round);
     }
 
-    /* Test editRound() after round has started
-        ├── Given a round has been created with a future start time
-        │   ├── And time has advanced beyond the start time
-        │   │   └── When attempting to edit the round
-        │   │       └── Then it should revert with "Round has already started"
-    */
-    function test_editRound_afterStart() public {
-        uint64 roundId = fundingPot.createRound(
-            block.timestamp + 10,
-            block.timestamp + 100,
-            1000,
-            address(0),
-            "",
-            false,
-            false
-        );
-
-        vm.warp(block.timestamp + 11);
-
+    function testFuzzCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
+        uint roundEnd_
+    ) public {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        vm.assume(roundEnd_ != 0 && roundEnd_ < round.roundStart);
+        round.roundEnd = roundEnd_;
         vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__RoundAlreadyStarted
-                .selector
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundEndMustBeAfterStart
+                    .selector
+            )
         );
-        fundingPot.editRound(
-            roundId,
-            block.timestamp + 20,
-            block.timestamp + 200,
-            2000,
-            address(0),
-            "",
-            false,
-            false
+        _callCreateRound(round);
+    }
+
+    function testFuzzCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
+    ) public {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        round.hookContract = address(1);
+        round.hookFunction = bytes("");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__HookFunctionRequiredWithHookContract
+                    .selector
+            )
         );
+        _callCreateRound(round);
+    }
+
+    function testFuzzCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
+    ) public {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        round.hookContract = address(0);
+        round.hookFunction = bytes("test");
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction
+                    .selector
+            )
+        );
+        _callCreateRound(round);
+    }
+
+    /* Test createRound()
+    ├── Given all the valid parameters are provided
+    │   └── When user attempts to create a round
+    │       └── Then it should not be active and should return the round id
+    */
+
+    function testFuzzCreateRound() public {
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        _callCreateRound(round);
+
+        uint64 lastRoundId = fundingPot.getRoundCount();
+        ILM_PC_FundingPot_v1.Round memory lastRound =
+            fundingPot.getRoundDetails(lastRoundId);
+
+        assertEq(lastRound.isActive, false);
+        assertEq(lastRound.roundStart, round.roundStart);
+        assertEq(lastRound.roundEnd, round.roundEnd);
+        assertEq(lastRound.roundCap, round.roundCap);
+        assertEq(lastRound.hookContract, round.hookContract);
+        assertEq(lastRound.hookFunction, round.hookFunction);
+        assertEq(lastRound.closureMechanism, round.closureMechanism);
+        assertEq(lastRound.globalAccumulativeCaps, round.globalAccumulativeCaps);
+    }
+
+    /* Test editRound()
+    ├── Given user does not have FUNDING_POT_ADMIN_ROLE
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round does not exist
+    │   └── When user attempts to edit the round
+    │       └── Then it should revert
+    ├── Given round is active
+    │   └── When user attempts to edit the round
+    │       └── Then it should revert
+    ├── Given round start time is in the past
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round end time is 0 and round cap is 0
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given round end time is set and round end time is in the past
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given hook contract is set but hook function is not set
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    ├── Given hook function is set but hook contract is not set
+    │   └── When user attempts to create a round
+    │       └── Then it should revert
+    */
+
+    function testFuzzEditRound_revertsGivenUserIsNotFundingPotAdmin(
+        address user_
+    ) public {
+        testFuzzCreateRound();
+        vm.startPrank(user_);
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
+            )
+        );
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        _callEditRound(0, round);
+        vm.stopPrank();
+    }
+
+    function testFuzzEditRound_revertsGivenRoundIsNotCreated() public {
+        testFuzzCreateRound();
+        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+
+        uint64 roundId = fundingPot.getRoundCount();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundNotCreated
+                    .selector
+            )
+        );
+        _callEditRound(roundId + 1, round);
     }
 
     // -------------------------------------------------------------------------
     // Test: Internal Functions
+
+    // Helper Functions
+
+    // @notice Creates a default funding round
+    // @dev make the parameters fuzzable @TODO Jeffrey
+    function _createDefaultFundingRound()
+        internal
+        returns (ILM_PC_FundingPot_v1.Round memory)
+    {
+        ILM_PC_FundingPot_v1.Round memory round = ILM_PC_FundingPot_v1.Round({
+            roundStart: block.timestamp + 1 days,
+            roundEnd: block.timestamp + 2 days,
+            roundCap: 1000,
+            hookContract: address(0),
+            hookFunction: bytes(""),
+            closureMechanism: false,
+            globalAccumulativeCaps: false,
+            isActive: false
+        });
+        return round;
+    }
+
+    function _callCreateRound(ILM_PC_FundingPot_v1.Round memory round)
+        internal
+    {
+        fundingPot.createRound(
+            round.roundStart,
+            round.roundEnd,
+            round.roundCap,
+            round.hookContract,
+            round.hookFunction,
+            round.closureMechanism,
+            round.globalAccumulativeCaps
+        );
+    }
+
+    function _callEditRound(
+        uint64 roundId,
+        ILM_PC_FundingPot_v1.Round memory round
+    ) internal {
+        fundingPot.editRound(
+            roundId,
+            round.roundStart,
+            round.roundEnd,
+            round.roundCap,
+            round.hookContract,
+            round.hookFunction,
+            round.closureMechanism,
+            round.globalAccumulativeCaps
+        );
+    }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -54,7 +54,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     // -------------------------------------------------------------------------
     // Setup
-
     function setUp() public {
         // Deploy the SuT
         address impl = address(new LM_PC_FundingPot_v1_Exposed());
@@ -66,10 +65,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Initiate the Logic Module with the metadata and config data
         fundingPot.init(_orchestrator, _METADATA, abi.encode(""));
 
-        // Give test contract the FUNDING_POT_ROLE.
-        fundingPot.grantModuleRole(
-            fundingPot.FUNDING_POT_ADMIN_ROLE(), address(this)
-        );
         _authorizer.setIsAuthorized(address(this), true);
 
         // Set the block timestamp
@@ -100,7 +95,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // -------------------------------------------------------------------------
     // Test External (public + external)
 
-    /* Test fuzzed createRound()
+    /* Test createRound()
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
     │   └── When user attempts to create a round
     │       └── Then it should revert
@@ -366,7 +361,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(globalAccumulativeCaps, globalAccumulativeCaps_);
     }
 
-    /* Test fuzzed editRound()
+    /* Test editRound()
     ├── Given user does not have FUNDING_POT_ADMIN_ROLE
     │   └── When user attempts to edit a round
     │       └── Then it should revert
@@ -397,9 +392,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 └── Then it should revert  
     */
 
-    function testFuzzEditRound_revertsGivenUserIsNotFundingPotAdmin(
-        address user_
-    ) public {
+    function testEditRound_revertsGivenUserIsNotFundingPotAdmin(address user_)
+        public
+    {
         testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
@@ -436,7 +431,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.stopPrank();
     }
 
-    function testFuzzEditRound_revertsGivenRoundIsNotCreated() public {
+    function testEditRound_revertsGivenRoundIsNotCreated() public {
         testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
@@ -470,9 +465,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzEditRound_revertsGivenRoundIsActive(uint roundStart_)
-        public
-    {
+    function testEditRound_revertsGivenRoundIsActive(uint roundStart_) public {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
@@ -515,9 +508,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzEditRound_revertsGivenRoundStartIsInThePast(
-        uint roundStartP_
-    ) public {
+    function testEditRound_revertsGivenRoundStartIsInThePast(uint roundStartP_)
+        public
+    {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
@@ -553,9 +546,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzEditRound_revertsGivenRoundEndTimeAndCapAreBothZero()
-        public
-    {
+    function testEditRound_revertsGivenRoundEndTimeAndCapAreBothZero() public {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
@@ -591,7 +582,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
+    function testEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
         testCreateRound();
@@ -628,8 +619,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
-    ) public {
+    function testEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty()
+        public
+    {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
@@ -665,8 +657,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
-    ) public {
+    function testEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty()
+        public
+    {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
@@ -760,33 +753,193 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(globalAccumulativeCaps, globalAccumulativeCaps_);
     }
 
-    //     // -------------------------------------------------------------------------
-    //     // Test: Internal Functions
+    /* Test setAccessCriteria()
+    ├── Given user does not have FUNDING_POT_ADMIN_ROLE
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
+    ├── Given round does not exist
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
+    ├── Given round is active
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
+    ├── Given AccessCriteriaId is NFT and nftContract is 0x0
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
+    ├── Given AccessCriteriaId is MERKLE and merkleRoot is 0x0
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
+    ├── Given AccessCriteriaId is LIST and allowedAddresses is empty
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
+    └── Given all the valid parameters are provided
+        └── When user attempts to set access criteria
+            └── Then it should not revert
+    */
 
-    //     // Helper Functions
+    function testFuzzSetAccessCriteria_revertsGivenUserDoesNotHaveFundingPotAdminRole(
+        uint8 accessCriteriaEnum_,
+        address user_
+    ) public {
+        vm.assume(accessCriteriaEnum_ >= 0 && accessCriteriaEnum_ <= 3);
+        vm.assume(user_ != address(0) && user_ != address(this));
 
-    //     // @notice Creates a default funding round
-    //     // @dev make the parameters fuzzable @TODO Jeffrey
-    //     function _generateFundingRoundParams(
-    //         uint roundStart_,
-    //         uint roundEnd_,
-    //         uint roundCap_,
-    //         address hookContract_,
-    //         bytes memory hookFunction_,
-    //         bool closureMechanism_,
-    //         bool globalAccumulativeCaps_
-    //     ) internal returns (ILM_PC_FundingPot_v1.Round memory) {
-    //         ILM_PC_FundingPot_v1.Round memory round = ILM_PC_FundingPot_v1.Round({
-    //             roundStart: roundStart_,
-    //             roundEnd: roundEnd_,
-    //             roundCap: roundCap_,
-    //             hookContract: hookContract_,
-    //             hookFunction: hookFunction_,
-    //             closureMechanism: closureMechanism_,
-    //             globalAccumulativeCaps: globalAccumulativeCaps_
-    //         });
-    //         return round;
-    //     }
+        testCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum_);
+
+        vm.startPrank(user_);
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
+            )
+        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+    }
+
+    function testFuzzSetAccessCriteria_revertsGivenRoundDoesNotExist(
+        uint8 accessCriteriaEnum
+    ) public {
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundNotCreated
+                    .selector
+            )
+        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+    }
+
+    function testFuzzSetAccessCriteria_revertsGivenRoundIsActive(
+        uint8 accessCriteriaEnum
+    ) public {
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        testCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundAlreadyStarted
+                    .selector
+            )
+        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+    }
+
+    function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsNFTAndNftContractIsZero(
+    ) public {
+        uint8 accessCriteriaEnum =
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.NFT);
+        testCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+        accessCriteria.nftContract = address(0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData
+                    .selector
+            )
+        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+    }
+
+    function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsMerkleAndMerkleRootIsZero(
+    ) public {
+        uint8 accessCriteriaEnum =
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.MERKLE);
+        testCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+        accessCriteria.merkleRoot = bytes32(uint(0x0));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData
+                    .selector
+            )
+        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+    }
+
+    function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsListAndAllowedAddressesIsEmpty(
+    ) public {
+        uint8 accessCriteriaEnum =
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.LIST);
+        testCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+        accessCriteria.allowedAddresses = new address[](0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData
+                    .selector
+            )
+        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+    }
+
+    function testFuzzSetAccessCriteria(uint8 accessCriteriaEnum) public {
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        testCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = fundingPot.getRoundAccessCriteria(roundId, accessId);
+
+        assertEq(nftContract, accessCriteria.nftContract);
+        assertEq(merkleRoot, accessCriteria.merkleRoot);
+        assertEq(allowedAddresses, accessCriteria.allowedAddresses);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test: Internal Functions
+
+    // -------------------------------------------------------------------------
+    // Helper Functions
 
     // @notice Creates a default funding round
     function _helper_createDefaultFundingRound()
@@ -878,5 +1031,63 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             closureMechanism,
             globalAccumulativeCaps
         );
+    }
+
+    function _helper_createAccessCriteria(uint8 accessCriteriaEnum)
+        internal
+        returns (ILM_PC_FundingPot_v1.AccessCriteria memory)
+    {
+        {
+            if (
+                accessCriteriaEnum
+                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.OPEN)
+            ) {
+                return ILM_PC_FundingPot_v1.AccessCriteria(
+                    ILM_PC_FundingPot_v1.AccessCriteriaId.OPEN,
+                    address(0x0),
+                    bytes32(uint(0x0)),
+                    new address[](0)
+                );
+            } else if (
+                accessCriteriaEnum
+                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.NFT)
+            ) {
+                address nftContract = address(0x1);
+
+                return ILM_PC_FundingPot_v1.AccessCriteria(
+                    ILM_PC_FundingPot_v1.AccessCriteriaId.NFT,
+                    nftContract,
+                    bytes32(uint(0x0)),
+                    new address[](0)
+                );
+            } else if (
+                accessCriteriaEnum
+                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.MERKLE)
+            ) {
+                bytes32 merkleRoot = bytes32(uint(0x1));
+
+                return ILM_PC_FundingPot_v1.AccessCriteria(
+                    ILM_PC_FundingPot_v1.AccessCriteriaId.MERKLE,
+                    address(0x0),
+                    merkleRoot,
+                    new address[](0)
+                );
+            } else if (
+                accessCriteriaEnum
+                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.LIST)
+            ) {
+                address[] memory allowedAddresses = new address[](3);
+                allowedAddresses[0] = address(0x1);
+                allowedAddresses[1] = address(0x2);
+                allowedAddresses[2] = address(0x3);
+
+                return ILM_PC_FundingPot_v1.AccessCriteria(
+                    ILM_PC_FundingPot_v1.AccessCriteriaId.LIST,
+                    address(0x0),
+                    bytes32(uint(0x0)),
+                    allowedAddresses
+                );
+            }
+        }
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -785,7 +785,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum_);
@@ -799,9 +798,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        fundingPot.setAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
-        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        vm.stopPrank();
     }
 
     function testFuzzSetAccessCriteria_revertsGivenRoundDoesNotExist(
@@ -810,7 +808,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
 
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -822,24 +819,23 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
-        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
     }
 
     function testFuzzSetAccessCriteria_revertsGivenRoundIsActive(
         uint8 accessCriteriaEnum
     ) public {
         vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
+
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -847,18 +843,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
-        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
     }
 
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsNFTAndNftContractIsZero(
     ) public {
         uint8 accessCriteriaEnum =
             uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.NFT);
+
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -871,18 +865,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
-        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
     }
 
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsMerkleAndMerkleRootIsZero(
     ) public {
         uint8 accessCriteriaEnum =
             uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE);
+
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -895,18 +887,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
-        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
     }
 
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsListAndAllowedAddressesIsEmpty(
     ) public {
         uint8 accessCriteriaEnum =
             uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.LIST);
+
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -919,23 +909,20 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
-        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
     }
 
     function testFuzzSetAccessCriteria(uint8 accessCriteriaEnum) public {
         vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 1;
+        uint8 accessCriteriaId = 0;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
 
-        fundingPot.setAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
-        );
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
 
         (
             bool isOpen,
@@ -948,6 +935,159 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(nftContract, accessCriteria.nftContract);
         assertEq(merkleRoot, accessCriteria.merkleRoot);
         assertEq(allowedAddresses, accessCriteria.allowedAddresses);
+    }
+
+    /* test editAccessCriteriaForRound()
+    ├── Given user does not have FUNDING_POT_ADMIN_ROLE
+    │   └── When user attempts to edit access criteria
+    │       └── Then it should revert
+    ├── Given access criteria id is greater than the number of access criteria for the round
+    │   └── When user attempts to edit access criteria
+    │       └── Then it should revert
+    ├── Given round does not exist
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
+    ├── Given round is active
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
+    └── Given all the valid parameters are provided
+        └── When user attempts to edit access criteria
+            └── Then it should not revert
+            └── Then the access criteria should be updated
+
+    */
+
+    function testFuzzEditAccessCriteriaForRound_revertsGivenUserDoesNotHaveFundingPotAdminRole(
+        uint8 accessCriteriaEnum,
+        address user_
+    ) public {
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        vm.assume(user_ != address(0) && user_ != address(this));
+
+        _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessCriteriaId = 0;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+
+        vm.startPrank(user_);
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
+            )
+        );
+        fundingPot.editAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
+        vm.stopPrank();
+    }
+
+    function testFuzzEditAccessCriteriaForRound_revertsGivenAccessCriteriaIdIsGreaterThanAccessCriteriaForTheRound(
+        uint8 accessCriteriaEnum
+    ) public {
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+
+        _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessCriteriaId = 1; // Invalid ID
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__InvalidAccessCriteriaId
+                    .selector
+            )
+        );
+        fundingPot.editAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
+    }
+
+    function testFuzzEditAccessCriteriaForRound_revertsGivenRoundDoesNotExist(
+        uint8 accessCriteriaEnum
+    ) public {
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessCriteriaId = 0;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+
+        vm.expectRevert();
+        fundingPot.editAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
+    }
+
+    function testFuzzEditAccessCriteriaForRound_revertsGivenRoundIsActive(
+        uint8 accessCriteriaEnum
+    ) public {
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
+
+        _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessCriteriaId = 0;
+
+        // Warp to make the round active
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundAlreadyStarted
+                    .selector
+            )
+        );
+        fundingPot.editAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
+    }
+
+    function testFuzzEditAccessCriteriaForRound(
+        uint8 accessCriteriaEnumOld,
+        uint8 accessCriteriaEnumNew
+    ) public {
+        vm.assume(accessCriteriaEnumOld >= 0 && accessCriteriaEnumOld <= 3);
+        vm.assume(
+            accessCriteriaEnumNew != accessCriteriaEnumOld
+                && accessCriteriaEnumNew >= 0 && accessCriteriaEnumNew <= 3
+        );
+
+        _helper_setupRoundWithAccessCriteria(accessCriteriaEnumOld);
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessCriteriaId = 0;
+
+        // Create and apply new access criteria
+        ILM_PC_FundingPot_v1.AccessCriteria memory newAccessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnumNew);
+
+        fundingPot.editAccessCriteriaForRound(
+            roundId, accessCriteriaId, newAccessCriteria
+        );
+
+        // Verify the access criteria was updated
+        (
+            bool isOpen,
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = fundingPot.getRoundAccessCriteria(roundId, accessCriteriaId);
+
+        assertEq(isOpen, accessCriteriaEnumNew == 0);
+        assertEq(nftContract, newAccessCriteria.nftContract);
+        assertEq(merkleRoot, newAccessCriteria.merkleRoot);
+        assertEq(allowedAddresses, newAccessCriteria.allowedAddresses);
     }
 
     // -------------------------------------------------------------------------
@@ -1104,5 +1244,18 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 );
             }
         }
+    }
+
+    // Helper function to set up a round with access criteria
+    function _helper_setupRoundWithAccessCriteria(uint8 accessCriteriaEnum)
+        internal
+    {
+        testCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnum);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -253,19 +253,19 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │   └── When user attempts to edit the round
     │       └── Then it should revert
     ├── Given round start time is in the past
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round with the above parameter
     │       └── Then it should revert
     ├── Given round end time is 0 and round cap is 0
-    │   └── When user attempts to create a round
+    │   └── When user attempts edit a round with the above parameters
     │       └── Then it should revert
     ├── Given round end time is set and round end time is in the past
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round with the above parameters
     │       └── Then it should revert
     ├── Given hook contract is set but hook function is not set
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round with the above parameters
     │       └── Then it should revert
     ├── Given hook function is set but hook contract is not set
-    │   └── When user attempts to create a round
+    │   └── When user attempts to edit a round with the above parameters
     │       └── Then it should revert
     */
 
@@ -282,14 +282,17 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
-        _callEditRound(0, round);
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+
+        _callEditRound(0, editedRound);
         vm.stopPrank();
     }
 
     function testFuzzEditRound_revertsGivenRoundIsNotCreated() public {
         testFuzzCreateRound();
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
 
         uint64 roundId = fundingPot.getRoundCount();
         vm.expectRevert(
@@ -299,7 +302,196 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callEditRound(roundId + 1, round);
+        _callEditRound(roundId + 1, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenRoundIsActive(uint roundStart_)
+        public
+    {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory roundDetails =
+            fundingPot.getRoundDetails(roundId);
+
+        vm.warp(roundDetails.roundStart + 1);
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundAlreadyStarted
+                    .selector
+            )
+        );
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenRoundStartIsInThePast(
+        uint roundStart_
+    ) public {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        vm.assume(roundStart_ < block.timestamp);
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        editedRound.roundStart = roundStart_;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundStartMustBeInFuture
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenRoundEndTimeAndCapAreBothZero()
+        public
+    {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        editedRound.roundEnd = 0;
+        editedRound.roundCap = 0;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
+        uint roundEnd_
+    ) public {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        vm.assume(roundEnd_ != 0 && roundEnd_ < editedRound.roundStart);
+        editedRound.roundEnd = roundEnd_;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundEndMustBeAfterStart
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
+    ) public {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        editedRound.hookContract = address(1);
+        editedRound.hookFunction = bytes("");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__HookFunctionRequiredWithHookContract
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    function testFuzzEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
+    ) public {
+        testFuzzCreateRound();
+        uint64 roundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+        editedRound.hookContract = address(0);
+        editedRound.hookFunction = bytes("test");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__HookContractRequiredWithHookFunction
+                    .selector
+            )
+        );
+
+        _callEditRound(roundId, editedRound);
+    }
+
+    /* Test editRound()
+    ├── Given a round has been created and is not active
+    │   └── When an admin provides valid parameters to edit the round
+    │       └── Then all the round details should be successfully updated
+    │           ├── roundStart should be updated to the new value
+    │           ├── roundEnd should be updated to the new value
+    │           ├── roundCap should be updated to the new value
+    │           ├── hookContract should be updated to the new value
+    │           ├── hookFunction should be updated to the new value
+    │           ├── closureMechanism should be updated to the new value
+    │           └── globalAccumulativeCaps should be updated to the new value
+    */
+
+    function testFuzzEditRound() public {
+        testFuzzCreateRound();
+        uint64 lastRoundId = fundingPot.getRoundCount();
+
+        ILM_PC_FundingPot_v1.Round memory editedRound =
+            _createEditedRoundParams();
+
+        _callEditRound(lastRoundId, editedRound);
+
+        ILM_PC_FundingPot_v1.Round memory updatedRound =
+            fundingPot.getRoundDetails(lastRoundId);
+
+        assertEq(
+            updatedRound.roundStart,
+            editedRound.roundStart,
+            "roundStart not updated"
+        );
+        assertEq(
+            updatedRound.roundEnd, editedRound.roundEnd, "roundEnd not updated"
+        );
+        assertEq(
+            updatedRound.roundCap, editedRound.roundCap, "roundCap not updated"
+        );
+        assertEq(
+            updatedRound.hookContract,
+            editedRound.hookContract,
+            "hookContract not updated"
+        );
+        assertEq(
+            keccak256(updatedRound.hookFunction),
+            keccak256(editedRound.hookFunction),
+            "hookFunction not updated"
+        );
+        assertEq(
+            updatedRound.closureMechanism,
+            editedRound.closureMechanism,
+            "closureMechanism not updated"
+        );
+        assertEq(
+            updatedRound.globalAccumulativeCaps,
+            editedRound.globalAccumulativeCaps,
+            "globalAccumulativeCaps not updated"
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -309,23 +501,45 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     // @notice Creates a default funding round
     // @dev make the parameters fuzzable @TODO Jeffrey
-    function _createDefaultFundingRound()
-        internal
-        returns (ILM_PC_FundingPot_v1.Round memory)
-    {
+    function _generateFundingRoundParams(
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bytes memory hookFunction_,
+        bool closureMechanism_,
+        bool globalAccumulativeCaps_
+    ) internal returns (ILM_PC_FundingPot_v1.Round memory) {
         ILM_PC_FundingPot_v1.Round memory round = ILM_PC_FundingPot_v1.Round({
-            roundStart: block.timestamp + 1 days,
-            roundEnd: block.timestamp + 2 days,
-            roundCap: 1000,
-            hookContract: address(0),
-            hookFunction: bytes(""),
-            closureMechanism: false,
-            globalAccumulativeCaps: false,
+            roundStart: roundStart_,
+            roundEnd: roundEnd_,
+            roundCap: roundCap_,
+            hookContract: hookContract_,
+            hookFunction: hookFunction_,
+            closureMechanism: closureMechanism_,
+            globalAccumulativeCaps: globalAccumulativeCaps_,
             isActive: false
         });
         return round;
     }
 
+    // @notice Creates a default funding round
+    function _createDefaultFundingRound()
+        internal
+        returns (ILM_PC_FundingPot_v1.Round memory)
+    {
+        return _generateFundingRoundParams(
+            block.timestamp + 1 days,
+            block.timestamp + 2 days,
+            1000,
+            address(0),
+            bytes(""),
+            false,
+            false
+        );
+    }
+
+    // @notice calls the create round function
     function _callCreateRound(ILM_PC_FundingPot_v1.Round memory round)
         internal
     {
@@ -340,6 +554,23 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
+    // @notice Creates a predefined funding round with edited parameters for testing
+    function _createEditedRoundParams()
+        internal
+        returns (ILM_PC_FundingPot_v1.Round memory)
+    {
+        return _generateFundingRoundParams(
+            block.timestamp + 150,
+            block.timestamp + 250,
+            20,
+            address(0x1),
+            hex"abcd",
+            true,
+            true
+        );
+    }
+
+    // @notice calls the create round function
     function _callEditRound(
         uint64 roundId,
         ILM_PC_FundingPot_v1.Round memory round

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -105,6 +105,196 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // -------------------------------------------------------------------------
     // Test External (public + external)
 
+    /* Test fuzzed createRound()
+        ├── Given a round start time is in the future
+        │   ├── And the round end time is either after the start or the round has a cap
+        │   │   └── When a new round is created with the given parameters
+        │   │       └── Then the stored round details should match the provided values
+    */
+    function testFuzz_createRound(
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bytes memory hookFunction,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
+    ) public {
+        vm.assume(roundStart > block.timestamp);
+        vm.assume(roundEnd > roundStart || roundCap > 0);
+        if (roundEnd > 0) {
+            vm.assume(roundEnd > roundStart);
+        }
+
+        uint64 roundId = fundingPot.createRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+
+        (uint storedStart, uint storedEnd, uint storedCap,,,,, bool isActive) =
+            fundingPot.rounds(roundId);
+
+        assertEq(storedStart, roundStart, "Round start mismatch");
+        assertEq(storedEnd, roundEnd, "Round end mismatch");
+        assertEq(storedCap, roundCap, "Round cap mismatch");
+        assertTrue(isActive, "Round should be active");
+    }
+
+    /* Test createRound() with invalid start time
+        ├── Given a start time that is in the past
+        │   └── When attempting to create a round with this past start time
+        │       └── Then it should revert with "Round start must be in the future"
+    */
+    function test_createRound_invalidStart() public {
+        uint pastTime = block.timestamp - 1;
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__RoundStartMustBeInFuture
+                .selector
+        );
+        fundingPot.createRound(
+            pastTime, block.timestamp + 10, 1000, address(0), "", false, false
+        );
+    }
+
+    /* Test createRound() with invalid end time
+        ├── Given a future start time
+        │   └── When attempting to create a round where end time is before start time and cap is zero
+        │       └── Then it should revert with "Round must have either end time or cap"
+    */
+    function test_createRound_invalidEnd() public {
+        uint futureTime = block.timestamp + 100;
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__RoundMustHaveEndTimeOrCap
+                .selector
+        );
+        fundingPot.createRound(
+            futureTime, futureTime - 1, 0, address(0), "", false, false
+        );
+    }
+
+    /* Test fuzzed editRound()
+        ├── Given a round start time is in the future
+        │   ├── And the round end time is greater than zero and after the start time
+        │   │   └── When editing the round with new parameters
+        │   │       ├── Then the update should be successful
+        │   │       └── And the stored values should match the new parameters
+    */
+    function testFuzz_editRound(
+        uint roundStart,
+        uint roundEnd,
+        uint roundCap,
+        address hookContract,
+        bytes memory hookFunction,
+        bool closureMechanism,
+        bool globalAccumulativeCaps
+    ) public {
+        vm.assume(roundStart > block.timestamp);
+        vm.assume(roundStart < type(uint).max - 100);
+        vm.assume(roundEnd > 0);
+        vm.assume(roundEnd > roundStart);
+        vm.assume(roundEnd <= type(uint).max - 100);
+        vm.assume(roundCap <= type(uint).max - 100);
+
+        uint64 roundId = fundingPot.createRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+
+        uint newStart = roundStart + 100;
+        uint newEnd = roundEnd + 100;
+        uint newCap = roundCap + 100;
+
+        bool success = fundingPot.editRound(
+            roundId,
+            newStart,
+            newEnd,
+            newCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+
+        assertTrue(success, "Round edit failed");
+
+        (uint storedStart, uint storedEnd, uint storedCap,,,,,) =
+            fundingPot.rounds(roundId);
+        assertEq(storedStart, newStart, "Updated round start mismatch");
+        assertEq(storedEnd, newEnd, "Updated round end mismatch");
+        assertEq(storedCap, newCap, "Updated round cap mismatch");
+    }
+
+    /* Test editRound() on nonexistent round
+        ├── Given a round does not exist
+        │   └── When attempting to edit the round
+        │       └── Then it should revert with "Round does not exist"
+    */
+    function test_editRound_nonexistent() public {
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__RoundDoesNotExist
+                .selector
+        );
+        fundingPot.editRound(
+            9999,
+            block.timestamp + 100,
+            block.timestamp + 200,
+            1000,
+            address(0),
+            "",
+            false,
+            false
+        );
+    }
+
+    /* Test editRound() after round has started
+        ├── Given a round has been created with a future start time
+        │   ├── And time has advanced beyond the start time
+        │   │   └── When attempting to edit the round
+        │   │       └── Then it should revert with "Round has already started"
+    */
+    function test_editRound_afterStart() public {
+        uint64 roundId = fundingPot.createRound(
+            block.timestamp + 10,
+            block.timestamp + 100,
+            1000,
+            address(0),
+            "",
+            false,
+            false
+        );
+
+        vm.warp(block.timestamp + 11);
+
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__RoundAlreadyStarted
+                .selector
+        );
+        fundingPot.editRound(
+            roundId,
+            block.timestamp + 20,
+            block.timestamp + 200,
+            2000,
+            address(0),
+            "",
+            false,
+            false
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Test: Internal Functions
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -142,7 +142,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         ) = _helper_createDefaultFundingRound();
         _helper_callCreateRound(
@@ -151,7 +151,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
         vm.stopPrank();
@@ -167,7 +167,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         ) = _helper_createDefaultFundingRound();
         roundStart = roundStart_;
@@ -184,7 +184,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
     }
@@ -198,7 +198,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         ) = _helper_createDefaultFundingRound();
         roundEnd = 0;
@@ -216,7 +216,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
     }
@@ -230,7 +230,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         ) = _helper_createDefaultFundingRound();
         vm.assume(roundEnd_ != 0 && roundEnd_ < roundStart);
@@ -248,7 +248,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
     }
@@ -261,7 +261,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         ) = _helper_createDefaultFundingRound();
         hookContract = address(1);
@@ -279,7 +279,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
     }
@@ -292,7 +292,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         ) = _helper_createDefaultFundingRound();
         hookContract = address(0);
@@ -310,7 +310,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
     }
@@ -328,7 +328,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         ) = _helper_createDefaultFundingRound();
         _helper_callCreateRound(
@@ -337,7 +337,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
 
@@ -348,7 +348,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = fundingPot.getRoundGenericParameters(lastRoundId);
 
@@ -357,7 +357,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(roundCap, roundCap_);
         assertEq(hookContract, hookContract_);
         assertEq(hookFunction, hookFunction_);
-        assertEq(closureMechanism, closureMechanism_);
+        assertEq(autoClosure, autoClosure_);
         assertEq(globalAccumulativeCaps, globalAccumulativeCaps_);
     }
 
@@ -395,6 +395,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testEditRound_revertsGivenUserIsNotFundingPotAdmin(address user_)
         public
     {
+        vm.assume(user_ != address(0) && user_ != address(this));
         testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
@@ -414,7 +415,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = _helper_createEditedRoundParams();
 
@@ -425,7 +426,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
         vm.stopPrank();
@@ -442,7 +443,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = _helper_createEditedRoundParams();
 
@@ -460,7 +461,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
     }
@@ -475,7 +476,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         ) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
@@ -486,7 +487,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = _helper_createEditedRoundParams();
         vm.expectRevert(
@@ -503,7 +504,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
     }
@@ -521,7 +522,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = _helper_createEditedRoundParams();
         roundStart_ = roundStartP_;
@@ -541,7 +542,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
     }
@@ -556,7 +557,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = _helper_createEditedRoundParams();
         roundEnd_ = 0;
@@ -577,7 +578,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
     }
@@ -594,7 +595,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = _helper_createEditedRoundParams();
         roundEnd_ = bound(roundEnd_, 0, roundStart_ - 1);
@@ -614,7 +615,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
     }
@@ -631,7 +632,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = _helper_createEditedRoundParams();
         hookContract_ = address(1);
@@ -652,7 +653,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
     }
@@ -669,7 +670,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = _helper_createEditedRoundParams();
         hookContract_ = address(0);
@@ -690,7 +691,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
     }
@@ -705,7 +706,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             ├── roundCap should be updated to the new value
             ├── hookContract should be updated to the new value
             ├── hookFunction should be updated to the new value
-            ├── closureMechanism should be updated to the new value
+            ├── autoClosure should be updated to the new value
             └── globalAccumulativeCaps should be updated to the new value
     */
 
@@ -719,7 +720,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap_,
             address hookContract_,
             bytes memory hookFunction_,
-            bool closureMechanism_,
+            bool autoClosure_,
             bool globalAccumulativeCaps_
         ) = _helper_createEditedRoundParams();
 
@@ -730,7 +731,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
 
@@ -740,7 +741,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint roundCap,
             address hookContract,
             bytes memory hookFunction,
-            bool closureMechanism,
+            bool autoClosure,
             bool globalAccumulativeCaps
         ) = fundingPot.getRoundGenericParameters(lastRoundId);
 
@@ -749,7 +750,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(roundCap, roundCap_);
         assertEq(hookContract, hookContract_);
         assertEq(hookFunction, hookFunction_);
-        assertEq(closureMechanism, closureMechanism_);
+        assertEq(autoClosure, autoClosure_);
         assertEq(globalAccumulativeCaps, globalAccumulativeCaps_);
     }
 
@@ -850,7 +851,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsNFTAndNftContractIsZero(
     ) public {
         uint8 accessCriteriaEnum =
-            uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.NFT);
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.NFT);
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 1;
@@ -872,7 +873,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsMerkleAndMerkleRootIsZero(
     ) public {
         uint8 accessCriteriaEnum =
-            uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.MERKLE);
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE);
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 1;
@@ -894,7 +895,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsListAndAllowedAddressesIsEmpty(
     ) public {
         uint8 accessCriteriaEnum =
-            uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.LIST);
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.LIST);
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 1;
@@ -953,7 +954,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint roundCap = 1000;
         address hookContract = address(0);
         bytes memory hookFunction = bytes("");
-        bool closureMechanism = false;
+        bool autoClosure = false;
         bool globalAccumulativeCaps = false;
 
         return (
@@ -962,7 +963,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
     }
@@ -974,7 +975,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint roundCap,
         address hookContract,
         bytes memory hookFunction,
-        bool closureMechanism,
+        bool autoClosure,
         bool globalAccumulativeCaps
     ) internal {
         fundingPot.createRound(
@@ -983,7 +984,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
     }
@@ -998,7 +999,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint roundCap_ = 2000;
         address hookContract_ = address(0x1);
         bytes memory hookFunction_ = bytes("test");
-        bool closureMechanism_ = true;
+        bool autoClosure_ = true;
         bool globalAccumulativeCaps_ = true;
 
         return (
@@ -1007,7 +1008,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap_,
             hookContract_,
             hookFunction_,
-            closureMechanism_,
+            autoClosure_,
             globalAccumulativeCaps_
         );
     }
@@ -1020,7 +1021,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint roundCap,
         address hookContract,
         bytes memory hookFunction,
-        bool closureMechanism,
+        bool autoClosure,
         bool globalAccumulativeCaps
     ) internal {
         fundingPot.editRound(
@@ -1030,7 +1031,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundCap,
             hookContract,
             hookFunction,
-            closureMechanism,
+            autoClosure,
             globalAccumulativeCaps
         );
     }
@@ -1042,41 +1043,41 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         {
             if (
                 accessCriteriaEnum
-                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.OPEN)
+                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN)
             ) {
                 return ILM_PC_FundingPot_v1.AccessCriteria(
-                    ILM_PC_FundingPot_v1.AccessCriteriaId.OPEN,
+                    ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN,
                     address(0x0),
                     bytes32(uint(0x0)),
                     new address[](0)
                 );
             } else if (
                 accessCriteriaEnum
-                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.NFT)
+                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.NFT)
             ) {
                 address nftContract = address(0x1);
 
                 return ILM_PC_FundingPot_v1.AccessCriteria(
-                    ILM_PC_FundingPot_v1.AccessCriteriaId.NFT,
+                    ILM_PC_FundingPot_v1.AccessCriteriaType.NFT,
                     nftContract,
                     bytes32(uint(0x0)),
                     new address[](0)
                 );
             } else if (
                 accessCriteriaEnum
-                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.MERKLE)
+                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE)
             ) {
                 bytes32 merkleRoot = bytes32(uint(0x1));
 
                 return ILM_PC_FundingPot_v1.AccessCriteria(
-                    ILM_PC_FundingPot_v1.AccessCriteriaId.MERKLE,
+                    ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE,
                     address(0x0),
                     merkleRoot,
                     new address[](0)
                 );
             } else if (
                 accessCriteriaEnum
-                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaId.LIST)
+                    == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.LIST)
             ) {
                 address[] memory allowedAddresses = new address[](3);
                 allowedAddresses[0] = address(0x1);
@@ -1084,7 +1085,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 allowedAddresses[2] = address(0x3);
 
                 return ILM_PC_FundingPot_v1.AccessCriteria(
-                    ILM_PC_FundingPot_v1.AccessCriteriaId.LIST,
+                    ILM_PC_FundingPot_v1.AccessCriteriaType.LIST,
                     address(0x0),
                     bytes32(uint(0x0)),
                     allowedAddresses

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -135,8 +135,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
-        _callCreateRound(round);
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
+        _helper_callCreateRound(round);
         vm.stopPrank();
     }
 
@@ -144,7 +145,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint roundStart_
     ) public {
         vm.assume(roundStart_ < block.timestamp);
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         round.roundStart = roundStart_;
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -153,13 +155,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     function testFuzzCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
         public
     {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         round.roundEnd = 0;
         round.roundCap = 0;
         vm.expectRevert(
@@ -169,13 +172,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     function testFuzzCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         vm.assume(roundEnd_ != 0 && roundEnd_ < round.roundStart);
         round.roundEnd = roundEnd_;
         vm.expectRevert(
@@ -185,12 +189,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     function testFuzzCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
     ) public {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         round.hookContract = address(1);
         round.hookFunction = bytes("");
         vm.expectRevert(
@@ -200,12 +205,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     function testFuzzCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
     ) public {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
         round.hookContract = address(0);
         round.hookFunction = bytes("test");
         vm.expectRevert(
@@ -215,7 +221,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callCreateRound(round);
+        _helper_callCreateRound(round);
     }
 
     /* Test createRound()
@@ -225,14 +231,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     */
 
     function testFuzzCreateRound() public {
-        ILM_PC_FundingPot_v1.Round memory round = _createDefaultFundingRound();
-        _callCreateRound(round);
+        ILM_PC_FundingPot_v1.Round memory round =
+            _helper_createDefaultFundingRound();
+        _helper_callCreateRound(round);
 
         uint64 lastRoundId = fundingPot.getRoundCount();
         ILM_PC_FundingPot_v1.Round memory lastRound =
             fundingPot.getRoundDetails(lastRoundId);
 
-        assertEq(lastRound.isActive, false);
         assertEq(lastRound.roundStart, round.roundStart);
         assertEq(lastRound.roundEnd, round.roundEnd);
         assertEq(lastRound.roundCap, round.roundCap);
@@ -283,16 +289,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
 
-        _callEditRound(0, editedRound);
+        _helper_callEditRound(0, editedRound);
         vm.stopPrank();
     }
 
     function testFuzzEditRound_revertsGivenRoundIsNotCreated() public {
         testFuzzCreateRound();
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
 
         uint64 roundId = fundingPot.getRoundCount();
         vm.expectRevert(
@@ -302,7 +308,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callEditRound(roundId + 1, editedRound);
+        _helper_callEditRound(roundId + 1, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenRoundIsActive(uint roundStart_)
@@ -317,7 +323,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.warp(roundDetails.roundStart + 1);
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -325,7 +331,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenRoundStartIsInThePast(
@@ -336,7 +342,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.assume(roundStart_ < block.timestamp);
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         editedRound.roundStart = roundStart_;
 
         vm.expectRevert(
@@ -347,7 +353,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenRoundEndTimeAndCapAreBothZero()
@@ -357,7 +363,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         editedRound.roundEnd = 0;
         editedRound.roundCap = 0;
 
@@ -369,7 +375,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
@@ -379,7 +385,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         vm.assume(roundEnd_ != 0 && roundEnd_ < editedRound.roundStart);
         editedRound.roundEnd = roundEnd_;
 
@@ -391,7 +397,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
@@ -400,7 +406,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         editedRound.hookContract = address(1);
         editedRound.hookFunction = bytes("");
 
@@ -412,7 +418,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     function testFuzzEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
@@ -421,7 +427,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
         editedRound.hookContract = address(0);
         editedRound.hookFunction = bytes("test");
 
@@ -433,7 +439,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _callEditRound(roundId, editedRound);
+        _helper_callEditRound(roundId, editedRound);
     }
 
     /* Test editRound()
@@ -454,9 +460,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 lastRoundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.Round memory editedRound =
-            _createEditedRoundParams();
+            _helper_createEditedRoundParams();
 
-        _callEditRound(lastRoundId, editedRound);
+        _helper_callEditRound(lastRoundId, editedRound);
 
         ILM_PC_FundingPot_v1.Round memory updatedRound =
             fundingPot.getRoundDetails(lastRoundId);
@@ -517,17 +523,18 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             hookContract: hookContract_,
             hookFunction: hookFunction_,
             closureMechanism: closureMechanism_,
-            globalAccumulativeCaps: globalAccumulativeCaps_,
-            isActive: false
+            globalAccumulativeCaps: globalAccumulativeCaps_
         });
         return round;
     }
 
     // @notice Creates a default funding round
-    function _createDefaultFundingRound()
+    function _helper_createDefaultFundingRound()
         internal
         returns (ILM_PC_FundingPot_v1.Round memory)
     {
+        //@todo need to randomize the input using vm.bound or vm.assume, do the same for the edited round
+        //@33 do you have any input here?
         return _generateFundingRoundParams(
             block.timestamp + 1 days,
             block.timestamp + 2 days,
@@ -540,7 +547,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     // @notice calls the create round function
-    function _callCreateRound(ILM_PC_FundingPot_v1.Round memory round)
+    function _helper_callCreateRound(ILM_PC_FundingPot_v1.Round memory round)
         internal
     {
         fundingPot.createRound(
@@ -555,7 +562,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     // @notice Creates a predefined funding round with edited parameters for testing
-    function _createEditedRoundParams()
+    function _helper_createEditedRoundParams()
         internal
         returns (ILM_PC_FundingPot_v1.Round memory)
     {
@@ -571,7 +578,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     // @notice calls the create round function
-    function _callEditRound(
+    function _helper_callEditRound(
         uint64 roundId,
         ILM_PC_FundingPot_v1.Round memory round
     ) internal {

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -51,8 +51,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     LM_PC_FundingPot_v1_Exposed fundingPot;
 
     // Storage variables to avoid stack too deep
-    RoundParams private _testParams;
-    RoundParams private _storedParams;
     uint64 private _testRoundId;
 
     // Default round parameters for testing
@@ -100,15 +98,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         });
 
         // Initialize edited round parameters
-        _editedRoundParams = RoundParams({
-            roundStart: block.timestamp + 3 days,
-            roundEnd: block.timestamp + 4 days,
-            roundCap: 2000,
-            hookContract: address(0x1),
-            hookFunction: bytes("test"),
-            autoClosure: true,
-            globalAccumulativeCaps: true
-        });
+        _editedRoundParams = _helper_createEditRoundParams(
+            block.timestamp + 3 days,
+            block.timestamp + 4 days,
+            2000,
+            address(0x1),
+            bytes("test"),
+            true,
+            true
+        );
     }
 
     // -------------------------------------------------------------------------
@@ -122,9 +120,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertTrue(
             fundingPot.supportsInterface(type(ILM_PC_FundingPot_v1).interfaceId)
         );
-        assertTrue(
-            fundingPot.supportsInterface(type(ILM_PC_FundingPot_v1).interfaceId)
-        );
+
     }
 
     function testReinitFails() public override(ModuleTest) {
@@ -320,36 +316,39 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     */
 
     function testCreateRound() public {
-        _testParams = _defaultRoundParams;
+        RoundParams memory params = _defaultRoundParams;
         
         fundingPot.createRound(
-            _testParams.roundStart,
-            _testParams.roundEnd,
-            _testParams.roundCap,
-            _testParams.hookContract,
-            _testParams.hookFunction,
-            _testParams.autoClosure,
-            _testParams.globalAccumulativeCaps
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
 
         _testRoundId = fundingPot.getRoundCount();
+        
+        // Retrieve the stored parameters
         (
-            _storedParams.roundStart,
-            _storedParams.roundEnd,
-            _storedParams.roundCap,
-            _storedParams.hookContract,
-            _storedParams.hookFunction,
-            _storedParams.autoClosure,
-            _storedParams.globalAccumulativeCaps
+            uint storedRoundStart,
+            uint storedRoundEnd,
+            uint storedRoundCap,
+            address storedHookContract,
+            bytes memory storedHookFunction,
+            bool storedAutoClosure,
+            bool storedGlobalAccumulativeCaps
         ) = fundingPot.getRoundGenericParameters(_testRoundId);
 
-        assertEq(_storedParams.roundStart, _testParams.roundStart);
-        assertEq(_storedParams.roundEnd, _testParams.roundEnd);
-        assertEq(_storedParams.roundCap, _testParams.roundCap);
-        assertEq(_storedParams.hookContract, _testParams.hookContract);
-        assertEq(_storedParams.hookFunction, _testParams.hookFunction);
-        assertEq(_storedParams.autoClosure, _testParams.autoClosure);
-        assertEq(_storedParams.globalAccumulativeCaps, _testParams.globalAccumulativeCaps);
+        // Compare with expected values
+        assertEq(storedRoundStart, params.roundStart);
+        assertEq(storedRoundEnd, params.roundEnd);
+        assertEq(storedRoundCap, params.roundCap);
+        assertEq(storedHookContract, params.hookContract);
+        assertEq(storedHookFunction, params.hookFunction);
+        assertEq(storedAutoClosure, params.autoClosure);
+        assertEq(storedGlobalAccumulativeCaps, params.globalAccumulativeCaps);
     }
 
     /* Test editRound()
@@ -587,24 +586,22 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        RoundParams memory params = RoundParams({
-            roundStart: block.timestamp + 3 days,
-            roundEnd: roundEnd_,
-            roundCap: 2000,
-            hookContract: address(0x1),
-            hookFunction: bytes("test"),
-            autoClosure: true,
-            globalAccumulativeCaps: true
-        });
-
         // Get the current round start time
         (uint currentRoundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         
         // Ensure roundEnd_ is less than current round start
         vm.assume(roundEnd_ < currentRoundStart);
         vm.assume(roundEnd_ != 0);
-        params.roundEnd = roundEnd_;
-        params.roundStart = currentRoundStart;
+        
+        RoundParams memory params = _helper_createEditRoundParams(
+            currentRoundStart,
+            roundEnd_,
+            2000,
+            address(0x1),
+            bytes("test"),
+            true,
+            true
+        );
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -632,15 +629,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        RoundParams memory params = RoundParams({
-            roundStart: block.timestamp + 3 days,
-            roundEnd: block.timestamp + 4 days,
-            roundCap: 2000,
-            hookContract: address(1),
-            hookFunction: bytes(""),
-            autoClosure: true,
-            globalAccumulativeCaps: true
-        });
+        RoundParams memory params = _helper_createEditRoundParams(
+            block.timestamp + 3 days,
+            block.timestamp + 4 days,
+            2000,
+            address(1),
+            bytes(""),
+            true,
+            true
+        );
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -668,15 +665,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        RoundParams memory params = RoundParams({
-            roundStart: block.timestamp + 3 days,
-            roundEnd: block.timestamp + 4 days,
-            roundCap: 2000,
-            hookContract: address(0),
-            hookFunction: bytes("test"),
-            autoClosure: true,
-            globalAccumulativeCaps: true
-        });
+        RoundParams memory params = _helper_createEditRoundParams(
+            block.timestamp + 3 days,
+            block.timestamp + 4 days,
+            2000,
+            address(0),
+            bytes("test"),
+            true,
+            true
+        );
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -716,36 +713,38 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 lastRoundId = fundingPot.getRoundCount();
 
-        _testParams = _editedRoundParams;
+        RoundParams memory params = _editedRoundParams;
 
         fundingPot.editRound(
             lastRoundId,
-            _testParams.roundStart,
-            _testParams.roundEnd,
-            _testParams.roundCap,
-            _testParams.hookContract,
-            _testParams.hookFunction,
-            _testParams.autoClosure,
-            _testParams.globalAccumulativeCaps
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
 
+        // Retrieve the stored parameters
         (
-            _storedParams.roundStart,
-            _storedParams.roundEnd,
-            _storedParams.roundCap,
-            _storedParams.hookContract,
-            _storedParams.hookFunction,
-            _storedParams.autoClosure,
-            _storedParams.globalAccumulativeCaps
+            uint storedRoundStart,
+            uint storedRoundEnd,
+            uint storedRoundCap,
+            address storedHookContract,
+            bytes memory storedHookFunction,
+            bool storedAutoClosure,
+            bool storedGlobalAccumulativeCaps
         ) = fundingPot.getRoundGenericParameters(lastRoundId);
 
-        assertEq(_storedParams.roundStart, _testParams.roundStart);
-        assertEq(_storedParams.roundEnd, _testParams.roundEnd);
-        assertEq(_storedParams.roundCap, _testParams.roundCap);
-        assertEq(_storedParams.hookContract, _testParams.hookContract);
-        assertEq(_storedParams.hookFunction, _testParams.hookFunction);
-        assertEq(_storedParams.autoClosure, _testParams.autoClosure);
-        assertEq(_storedParams.globalAccumulativeCaps, _testParams.globalAccumulativeCaps);
+        // Compare with expected values
+        assertEq(storedRoundStart, params.roundStart);
+        assertEq(storedRoundEnd, params.roundEnd);
+        assertEq(storedRoundCap, params.roundCap);
+        assertEq(storedHookContract, params.hookContract);
+        assertEq(storedHookFunction, params.hookFunction);
+        assertEq(storedAutoClosure, params.autoClosure);
+        assertEq(storedGlobalAccumulativeCaps, params.globalAccumulativeCaps);
     }
 
     /* Test setAccessCriteria()
@@ -783,7 +782,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessCriteriaEnum_,
         address user_
     ) public {
-        vm.assume(accessCriteriaEnum_ >= 0 && accessCriteriaEnum_ <= 3);
+        vm.assume(accessCriteriaEnum_ >= 0 && accessCriteriaEnum_ <= 4);
         vm.assume(user_ != address(0) && user_ != address(this));
 
         testCreateRound();
@@ -808,7 +807,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzSetAccessCriteria_revertsGivenRoundDoesNotExist(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 4);
 
         uint64 roundId = fundingPot.getRoundCount();
 
@@ -828,7 +827,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzSetAccessCriteria_revertsGivenRoundIsActive(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 4);
 
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
@@ -916,7 +915,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testFuzzSetAccessCriteria(uint8 accessCriteriaEnum) public {
-        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 4);
 
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
@@ -968,7 +967,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessCriteriaEnum,
         address user_
     ) public {
-        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 4);
         vm.assume(user_ != address(0) && user_ != address(this));
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
@@ -996,11 +995,11 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditAccessCriteriaForRound_revertsGivenAccessCriteriaIdIsGreaterThanAccessCriteriaForTheRound(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 4);
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 1; // Invalid ID
+        uint8 accessCriteriaId = 10; // Invalid ID
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -1020,7 +1019,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditAccessCriteriaForRound_revertsGivenRoundDoesNotExist(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 4);
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessCriteriaId = 0;
 
@@ -1036,7 +1035,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzzEditAccessCriteriaForRound_revertsGivenRoundIsActive(
         uint8 accessCriteriaEnum
     ) public {
-        vm.assume(accessCriteriaEnum >= 1 && accessCriteriaEnum <= 4);
+        vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 4);
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
         uint64 roundId = fundingPot.getRoundCount();
@@ -1065,10 +1064,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessCriteriaEnumOld,
         uint8 accessCriteriaEnumNew
     ) public {
-        vm.assume(accessCriteriaEnumOld >= 1 && accessCriteriaEnumOld <= 4);
+        vm.assume(accessCriteriaEnumOld >= 0 && accessCriteriaEnumOld <= 4);
         vm.assume(
             accessCriteriaEnumNew != accessCriteriaEnumOld
-                && accessCriteriaEnumNew >= 1 && accessCriteriaEnumNew <= 4
+                && accessCriteriaEnumNew >= 0 && accessCriteriaEnumNew <= 4
         );
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnumOld);
@@ -1109,6 +1108,27 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         returns (RoundParams memory)
     {
         return _defaultRoundParams;
+    }
+
+    // @notice Creates edit round parameters with customizable values
+    function _helper_createEditRoundParams(
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bytes memory hookFunction_,
+        bool autoClosure_,
+        bool globalAccumulativeCaps_
+    ) internal returns (RoundParams memory) {
+        return RoundParams({
+            roundStart: roundStart_,
+            roundEnd: roundEnd_,
+            roundCap: roundCap_,
+            hookContract: hookContract_,
+            hookFunction: hookFunction_,
+            autoClosure: autoClosure_,
+            globalAccumulativeCaps: globalAccumulativeCaps_
+        });
     }
 
     function _helper_createAccessCriteria(uint8 accessCriteriaEnum)

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -925,11 +925,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
 
         (
+            bool isOpen,
             address nftContract,
             bytes32 merkleRoot,
             address[] memory allowedAddresses
         ) = fundingPot.getRoundAccessCriteria(roundId, accessId);
 
+        assertEq(isOpen, accessCriteriaEnum == 0);
         assertEq(nftContract, accessCriteria.nftContract);
         assertEq(merkleRoot, accessCriteria.merkleRoot);
         assertEq(allowedAddresses, accessCriteria.allowedAddresses);

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -50,6 +50,26 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // SuT
     LM_PC_FundingPot_v1_Exposed fundingPot;
 
+    // Storage variables to avoid stack too deep
+    RoundParams private _testParams;
+    RoundParams private _storedParams;
+    uint64 private _testRoundId;
+
+    // Default round parameters for testing
+    RoundParams private _defaultRoundParams;
+    RoundParams private _editedRoundParams;
+
+    // Struct to hold round parameters
+    struct RoundParams {
+        uint roundStart;
+        uint roundEnd;
+        uint roundCap;
+        address hookContract;
+        bytes hookFunction;
+        bool autoClosure;
+        bool globalAccumulativeCaps;
+    }
+
     // -------------------------------------------------------------------------
     // Setup
     function setUp() public {
@@ -67,6 +87,28 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Set the block timestamp
         vm.warp(block.timestamp + _orchestrator.MODULE_UPDATE_TIMELOCK());
+
+        // Initialize default round parameters
+        _defaultRoundParams = RoundParams({
+            roundStart: block.timestamp + 1 days,
+            roundEnd: block.timestamp + 2 days,
+            roundCap: 1000,
+            hookContract: address(0),
+            hookFunction: bytes(""),
+            autoClosure: false,
+            globalAccumulativeCaps: false
+        });
+
+        // Initialize edited round parameters
+        _editedRoundParams = RoundParams({
+            roundStart: block.timestamp + 3 days,
+            roundEnd: block.timestamp + 4 days,
+            roundCap: 2000,
+            hookContract: address(0x1),
+            hookFunction: bytes("test"),
+            autoClosure: true,
+            globalAccumulativeCaps: true
+        });
     }
 
     // -------------------------------------------------------------------------
@@ -140,23 +182,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool autoClosure,
-            bool globalAccumulativeCaps
-        ) = _helper_createDefaultFundingRound();
-        _helper_callCreateRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
+        RoundParams memory params = _helper_createDefaultFundingRound();
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
         vm.stopPrank();
     }
@@ -165,16 +199,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         public
     {
         vm.assume(roundStart_ < block.timestamp);
-        (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool autoClosure,
-            bool globalAccumulativeCaps
-        ) = _helper_createDefaultFundingRound();
-        roundStart = roundStart_;
+        RoundParams memory params = _helper_createDefaultFundingRound();
+        params.roundStart = roundStart_;
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -182,31 +208,23 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
     function testCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
         public
     {
-        (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool autoClosure,
-            bool globalAccumulativeCaps
-        ) = _helper_createDefaultFundingRound();
-        roundEnd = 0;
-        roundCap = 0;
+        RoundParams memory params = _helper_createDefaultFundingRound();
+        params.roundEnd = 0;
+        params.roundCap = 0;
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -214,31 +232,23 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
     function testCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
-        (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool autoClosure,
-            bool globalAccumulativeCaps
-        ) = _helper_createDefaultFundingRound();
-        vm.assume(roundEnd_ != 0 && roundEnd_ < roundStart);
-        roundEnd = roundEnd_;
+        RoundParams memory params = _helper_createDefaultFundingRound();
+        vm.assume(roundEnd_ != 0 && roundEnd_ < params.roundStart);
+        params.roundEnd = roundEnd_;
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -246,30 +256,22 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
     function testCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
     ) public {
-        (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool autoClosure,
-            bool globalAccumulativeCaps
-        ) = _helper_createDefaultFundingRound();
-        hookContract = address(1);
-        hookFunction = bytes("");
+        RoundParams memory params = _helper_createDefaultFundingRound();
+        params.hookContract = address(1);
+        params.hookFunction = bytes("");
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -277,30 +279,22 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
     function testCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
     ) public {
-        (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool autoClosure,
-            bool globalAccumulativeCaps
-        ) = _helper_createDefaultFundingRound();
-        hookContract = address(0);
-        hookFunction = bytes("test");
+        RoundParams memory params = _helper_createDefaultFundingRound();
+        params.hookContract = address(0);
+        params.hookFunction = bytes("test");
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -308,14 +302,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callCreateRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
@@ -326,43 +320,36 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     */
 
     function testCreateRound() public {
-        (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool autoClosure,
-            bool globalAccumulativeCaps
-        ) = _helper_createDefaultFundingRound();
-        _helper_callCreateRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
+        _testParams = _defaultRoundParams;
+        
+        fundingPot.createRound(
+            _testParams.roundStart,
+            _testParams.roundEnd,
+            _testParams.roundCap,
+            _testParams.hookContract,
+            _testParams.hookFunction,
+            _testParams.autoClosure,
+            _testParams.globalAccumulativeCaps
         );
 
-        uint64 lastRoundId = fundingPot.getRoundCount();
+        _testRoundId = fundingPot.getRoundCount();
         (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = fundingPot.getRoundGenericParameters(lastRoundId);
+            _storedParams.roundStart,
+            _storedParams.roundEnd,
+            _storedParams.roundCap,
+            _storedParams.hookContract,
+            _storedParams.hookFunction,
+            _storedParams.autoClosure,
+            _storedParams.globalAccumulativeCaps
+        ) = fundingPot.getRoundGenericParameters(_testRoundId);
 
-        assertEq(roundStart, roundStart_);
-        assertEq(roundEnd, roundEnd_);
-        assertEq(roundCap, roundCap_);
-        assertEq(hookContract, hookContract_);
-        assertEq(hookFunction, hookFunction_);
-        assertEq(autoClosure, autoClosure_);
-        assertEq(globalAccumulativeCaps, globalAccumulativeCaps_);
+        assertEq(_storedParams.roundStart, _testParams.roundStart);
+        assertEq(_storedParams.roundEnd, _testParams.roundEnd);
+        assertEq(_storedParams.roundCap, _testParams.roundCap);
+        assertEq(_storedParams.hookContract, _testParams.hookContract);
+        assertEq(_storedParams.hookFunction, _testParams.hookFunction);
+        assertEq(_storedParams.autoClosure, _testParams.autoClosure);
+        assertEq(_storedParams.globalAccumulativeCaps, _testParams.globalAccumulativeCaps);
     }
 
     /* Test editRound()
@@ -412,6 +399,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint64 roundId = fundingPot.getRoundCount();
 
+        RoundParams memory params = RoundParams({
+            roundStart: block.timestamp + 3 days,
+            roundEnd: block.timestamp + 4 days,
+            roundCap: 2000,
+            hookContract: address(0x1),
+            hookFunction: bytes("test"),
+            autoClosure: true,
+            globalAccumulativeCaps: true
+        });
+
         vm.startPrank(user_);
         bytes32 roleId = _authorizer.generateRoleId(
             address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
@@ -421,25 +418,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = _helper_createEditedRoundParams();
-
-        _helper_callEditRound(
-            0,
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
+        fundingPot.editRound(
+            roundId,
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
         vm.stopPrank();
     }
@@ -449,15 +436,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint64 roundId = fundingPot.getRoundCount();
 
-        (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = _helper_createEditedRoundParams();
+        RoundParams memory params = RoundParams({
+            roundStart: block.timestamp + 3 days,
+            roundEnd: block.timestamp + 4 days,
+            roundCap: 2000,
+            hookContract: address(0x1),
+            hookFunction: bytes("test"),
+            autoClosure: true,
+            globalAccumulativeCaps: true
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -466,15 +453,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callEditRound(
+        fundingPot.editRound(
             roundId + 1,
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
@@ -482,26 +469,28 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
+        RoundParams memory params;
         (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool autoClosure,
-            bool globalAccumulativeCaps
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         ) = fundingPot.getRoundGenericParameters(roundId);
-        vm.warp(roundStart + 1);
+        vm.warp(params.roundStart + 1);
 
-        (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = _helper_createEditedRoundParams();
+        RoundParams memory params_ = RoundParams({
+            roundStart: block.timestamp + 3 days,
+            roundEnd: block.timestamp + 4 days,
+            roundCap: 2000,
+            hookContract: address(0x1),
+            hookFunction: bytes("test"),
+            autoClosure: true,
+            globalAccumulativeCaps: true
+        });
+
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
@@ -509,15 +498,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        _helper_callEditRound(
+        fundingPot.editRound(
             roundId,
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
+            params_.roundStart,
+            params_.roundEnd,
+            params_.roundCap,
+            params_.hookContract,
+            params_.hookFunction,
+            params_.autoClosure,
+            params_.globalAccumulativeCaps
         );
     }
 
@@ -528,16 +517,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         vm.assume(roundStartP_ < block.timestamp);
-        (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = _helper_createEditedRoundParams();
-        roundStart_ = roundStartP_;
+        RoundParams memory params = RoundParams({
+            roundStart: roundStartP_,
+            roundEnd: block.timestamp + 4 days,
+            roundCap: 2000,
+            hookContract: address(0x1),
+            hookFunction: bytes("test"),
+            autoClosure: true,
+            globalAccumulativeCaps: true
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -547,15 +535,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(
+        fundingPot.editRound(
             roundId,
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
@@ -563,17 +551,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = _helper_createEditedRoundParams();
-        roundEnd_ = 0;
-        roundCap_ = 0;
+        RoundParams memory params = RoundParams({
+            roundStart: block.timestamp + 3 days,
+            roundEnd: 0,
+            roundCap: 0,
+            hookContract: address(0x1),
+            hookFunction: bytes("test"),
+            autoClosure: true,
+            globalAccumulativeCaps: true
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -583,15 +569,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(
+        fundingPot.editRound(
             roundId,
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
@@ -601,16 +587,24 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = _helper_createEditedRoundParams();
-        roundEnd_ = bound(roundEnd_, 0, roundStart_ - 1);
+        RoundParams memory params = RoundParams({
+            roundStart: block.timestamp + 3 days,
+            roundEnd: roundEnd_,
+            roundCap: 2000,
+            hookContract: address(0x1),
+            hookFunction: bytes("test"),
+            autoClosure: true,
+            globalAccumulativeCaps: true
+        });
+
+        // Get the current round start time
+        (uint currentRoundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        
+        // Ensure roundEnd_ is less than current round start
+        vm.assume(roundEnd_ < currentRoundStart);
+        vm.assume(roundEnd_ != 0);
+        params.roundEnd = roundEnd_;
+        params.roundStart = currentRoundStart;
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -620,15 +614,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(
+        fundingPot.editRound(
             roundId,
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
@@ -638,17 +632,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = _helper_createEditedRoundParams();
-        hookContract_ = address(1);
-        hookFunction_ = bytes("");
+        RoundParams memory params = RoundParams({
+            roundStart: block.timestamp + 3 days,
+            roundEnd: block.timestamp + 4 days,
+            roundCap: 2000,
+            hookContract: address(1),
+            hookFunction: bytes(""),
+            autoClosure: true,
+            globalAccumulativeCaps: true
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -658,15 +650,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(
+        fundingPot.editRound(
             roundId,
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
@@ -676,17 +668,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = _helper_createEditedRoundParams();
-        hookContract_ = address(0);
-        hookFunction_ = bytes("test");
+        RoundParams memory params = RoundParams({
+            roundStart: block.timestamp + 3 days,
+            roundEnd: block.timestamp + 4 days,
+            roundCap: 2000,
+            hookContract: address(0),
+            hookFunction: bytes("test"),
+            autoClosure: true,
+            globalAccumulativeCaps: true
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -696,15 +686,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        _helper_callEditRound(
+        fundingPot.editRound(
             roundId,
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
         );
     }
 
@@ -726,44 +716,36 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 lastRoundId = fundingPot.getRoundCount();
 
-        (
-            uint roundStart_,
-            uint roundEnd_,
-            uint roundCap_,
-            address hookContract_,
-            bytes memory hookFunction_,
-            bool autoClosure_,
-            bool globalAccumulativeCaps_
-        ) = _helper_createEditedRoundParams();
+        _testParams = _editedRoundParams;
 
-        _helper_callEditRound(
+        fundingPot.editRound(
             lastRoundId,
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
+            _testParams.roundStart,
+            _testParams.roundEnd,
+            _testParams.roundCap,
+            _testParams.hookContract,
+            _testParams.hookFunction,
+            _testParams.autoClosure,
+            _testParams.globalAccumulativeCaps
         );
 
         (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool autoClosure,
-            bool globalAccumulativeCaps
+            _storedParams.roundStart,
+            _storedParams.roundEnd,
+            _storedParams.roundCap,
+            _storedParams.hookContract,
+            _storedParams.hookFunction,
+            _storedParams.autoClosure,
+            _storedParams.globalAccumulativeCaps
         ) = fundingPot.getRoundGenericParameters(lastRoundId);
 
-        assertEq(roundStart, roundStart_);
-        assertEq(roundEnd, roundEnd_);
-        assertEq(roundCap, roundCap_);
-        assertEq(hookContract, hookContract_);
-        assertEq(hookFunction, hookFunction_);
-        assertEq(autoClosure, autoClosure_);
-        assertEq(globalAccumulativeCaps, globalAccumulativeCaps_);
+        assertEq(_storedParams.roundStart, _testParams.roundStart);
+        assertEq(_storedParams.roundEnd, _testParams.roundEnd);
+        assertEq(_storedParams.roundCap, _testParams.roundCap);
+        assertEq(_storedParams.hookContract, _testParams.hookContract);
+        assertEq(_storedParams.hookFunction, _testParams.hookFunction);
+        assertEq(_storedParams.autoClosure, _testParams.autoClosure);
+        assertEq(_storedParams.globalAccumulativeCaps, _testParams.globalAccumulativeCaps);
     }
 
     /* Test setAccessCriteria()
@@ -1124,93 +1106,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // @notice Creates a default funding round
     function _helper_createDefaultFundingRound()
         internal
-        returns (uint, uint, uint, address, bytes memory, bool, bool)
+        returns (RoundParams memory)
     {
-        uint roundStart = block.timestamp + 1 days;
-        uint roundEnd = block.timestamp + 2 days;
-        uint roundCap = 1000;
-        address hookContract = address(0);
-        bytes memory hookFunction = bytes("");
-        bool autoClosure = false;
-        bool globalAccumulativeCaps = false;
-
-        return (
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
-        );
-    }
-
-    // @notice calls the create round function
-    function _helper_callCreateRound(
-        uint roundStart,
-        uint roundEnd,
-        uint roundCap,
-        address hookContract,
-        bytes memory hookFunction,
-        bool autoClosure,
-        bool globalAccumulativeCaps
-    ) internal {
-        fundingPot.createRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
-        );
-    }
-
-    // @notice Creates a predefined funding round with edited parameters for testing
-    function _helper_createEditedRoundParams()
-        internal
-        returns (uint, uint, uint, address, bytes memory, bool, bool)
-    {
-        uint roundStart_ = block.timestamp + 3 days;
-        uint roundEnd_ = block.timestamp + 4 days;
-        uint roundCap_ = 2000;
-        address hookContract_ = address(0x1);
-        bytes memory hookFunction_ = bytes("test");
-        bool autoClosure_ = true;
-        bool globalAccumulativeCaps_ = true;
-
-        return (
-            roundStart_,
-            roundEnd_,
-            roundCap_,
-            hookContract_,
-            hookFunction_,
-            autoClosure_,
-            globalAccumulativeCaps_
-        );
-    }
-
-    // @notice calls the create round function
-    function _helper_callEditRound(
-        uint64 roundId,
-        uint roundStart,
-        uint roundEnd,
-        uint roundCap,
-        address hookContract,
-        bytes memory hookFunction,
-        bool autoClosure,
-        bool globalAccumulativeCaps
-    ) internal {
-        fundingPot.editRound(
-            roundId,
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            autoClosure,
-            globalAccumulativeCaps
-        );
+        return _defaultRoundParams;
     }
 
     function _helper_createAccessCriteria(uint8 accessCriteriaEnum)

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -44,8 +44,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // -------------------------------------------------------------------------
     // Constants
 
-    bytes32 internal constant FUNDING_POT_ADMIN_ROLE = "FUNDING_POT_ADMIN";
-
     // -------------------------------------------------------------------------
     // State
 
@@ -787,7 +785,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum_);
@@ -801,7 +799,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
     }
 
     function testFuzzSetAccessCriteria_revertsGivenRoundDoesNotExist(
@@ -810,7 +810,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
 
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -822,7 +822,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
     }
 
     function testFuzzSetAccessCriteria_revertsGivenRoundIsActive(
@@ -831,7 +833,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -845,7 +847,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
     }
 
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsNFTAndNftContractIsZero(
@@ -854,7 +858,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.NFT);
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -867,7 +871,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
     }
 
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsMerkleAndMerkleRootIsZero(
@@ -876,7 +882,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE);
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -889,7 +895,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
     }
 
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsListAndAllowedAddressesIsEmpty(
@@ -898,7 +906,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.LIST);
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -911,26 +919,30 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
     }
 
     function testFuzzSetAccessCriteria(uint8 accessCriteriaEnum) public {
         vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 3);
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessCriteriaId = 1;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessCriteriaId, accessCriteria
+        );
 
         (
             bool isOpen,
             address nftContract,
             bytes32 merkleRoot,
             address[] memory allowedAddresses
-        ) = fundingPot.getRoundAccessCriteria(roundId, accessId);
+        ) = fundingPot.getRoundAccessCriteria(roundId, accessCriteriaId);
 
         assertEq(isOpen, accessCriteriaEnum == 0);
         assertEq(nftContract, accessCriteria.nftContract);

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity 0.8.23;
 
 // Internal
 import {LM_PC_FundingPot_v1} from


### PR DESCRIPTION
## Pull Request Note

### Overview
This pull request is for the review of the `Funding_Pot_v1` contracts after adding implementation of `createRound()`, `editRound()` and `setAccessCriteriaForRound()`

### Key Changes
- **Funding Pot Admin:** Added logic to allow only the `FUNDING_POT_ADMIN_ROLE` to call `createRound()`, `editRound()` and `setAccessCriteriaForRound()`
- **Input Validation:** Added various custom errors to handle incorrect input validation and revert in case invalid input is passed
- **Unit Tests:**
  - Added unit and fuzz tests for `createRound()`, `editRound()` and `setAccessCriteriaForRound()` following the gherkin style method
- **Code Cleanup:** Removed unnecessary state variables and outdated templates to streamline the codebase.

### Notable Commits
- **Mar 17, 2025:** Create and Edit Round Implementation.
- **Mar 18, 2025:** Add tests related to create/edit round functionality.
- **Mar 24, 2025:** Implement the access control criteria 
- **Mar 25, 2025:** Add tests related to access control criteria.

### Focus Areas
- Provide feedback on implementation, unit tests and identifying any blind spots or areas where we can improve.
- If missing to handle any edge case or introduced a bug in our current implementation!
