### PR TITLE
Funding Pot V1: Round Contribution

### DIFF
--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -186,7 +186,8 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[id_];
 
-        isOpen = (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN);
+        bool isOpen =
+            (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN);
         return (
             isOpen,
             accessCriteria.nftContract,
@@ -211,7 +212,7 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[accessId_];
 
-        if (accessCriteria.accessCriteriaId == AccessCriteriaId.OPEN) {
+        if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
             return (true, 0, false, 0, 0, 0);
         }
 
@@ -393,15 +394,15 @@ contract LM_PC_FundingPot_v1 is
         _validateEditRoundParameters(round);
 
         if (
-            round.accessCriterias[accessId_].accessCriteriaId
-                == AccessCriteriaId.OPEN
+            round.accessCriterias[accessId_].accessCriteriaType
+                == AccessCriteriaType.OPEN
         ) {
             highestCap = personalCap_;
         }
 
         if (
-            round.accessCriterias[accessId_].accessCriteriaId
-                == AccessCriteriaId.NFT && capByNFT_ > 0
+            round.accessCriterias[accessId_].accessCriteriaType
+                == AccessCriteriaType.NFT && capByNFT_ > 0
         ) {
             uint nftCap = personalCap_ + capByNFT_;
             if (nftCap > highestCap) {
@@ -410,8 +411,8 @@ contract LM_PC_FundingPot_v1 is
         }
 
         if (
-            round.accessCriterias[accessId_].accessCriteriaId
-                == AccessCriteriaId.MERKLE && capByMerkle_ > 0
+            round.accessCriterias[accessId_].accessCriteriaType
+                == AccessCriteriaType.MERKLE && capByMerkle_ > 0
         ) {
             uint merkleCap = personalCap_ + capByMerkle_;
             if (merkleCap > highestCap) {
@@ -420,8 +421,8 @@ contract LM_PC_FundingPot_v1 is
         }
 
         if (
-            round.accessCriterias[accessId_].accessCriteriaId
-                == AccessCriteriaId.LIST && capByList_ > 0
+            round.accessCriterias[accessId_].accessCriteriaType
+                == AccessCriteriaType.LIST && capByList_ > 0
         ) {
             uint listCap = personalCap_ + capByList_;
             if (listCap > highestCap) {
@@ -668,19 +669,22 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[accessId_];
 
-        if (accessCriteria.accessCriteriaId == AccessCriteriaId.OPEN) {
+        if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
             return;
         }
 
         bool accessGranted = false;
-        if (accessCriteria.accessCriteriaId == AccessCriteriaId.NFT) {
+        if (accessCriteria.accessCriteriaType == AccessCriteriaType.NFT) {
             accessGranted =
                 _checkNftOwnership(accessCriteria.nftContract, msg.sender);
-        } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.MERKLE) {
+        } else if (
+            accessCriteria.accessCriteriaType == AccessCriteriaType.MERKLE
+        ) {
             accessGranted = _validateMerkleProof(
                 accessCriteria.merkleRoot, merkleProof_, msg.sender, roundId_
             );
-        } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.LIST) {
+        } else if (accessCriteria.accessCriteriaType == AccessCriteriaType.LIST)
+        {
             accessGranted = _checkAllowedAddressList(
                 accessCriteria.allowedAddresses, msg.sender
             );

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -17,9 +17,12 @@ import {
 
 // External
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {IERC721} from "@oz/token/ERC721/IERC721.sol";
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 import {ERC165Upgradeable} from
     "@oz-up/utils/introspection/ERC165Upgradeable.sol";
+
+import "@oz/utils/cryptography/MerkleProof.sol";
 
 /**
  * @title   Inverter Funding Pot Module
@@ -93,6 +96,12 @@ contract LM_PC_FundingPot_v1 is
     mapping(
         uint64 roundId => mapping(uint8 accessId => AccessCriteriaPrivilages)
     ) private accessCriteriaPrivilages;
+
+    /// @notice Maps round IDs to user addresses to contribution amounts
+    mapping(uint64 => mapping(address => uint)) private userContributions;
+
+    /// @notice Maps round IDs to total contributions
+    mapping(uint64 => uint) private roundTotalContributions;
 
     /// @notice The next available round ID.
     uint64 private nextRoundId;
@@ -398,6 +407,73 @@ contract LM_PC_FundingPot_v1 is
             _end
         );
     }
+
+    function contribute(
+        uint64 roundId_,
+        uint amount_,
+        uint8 accessId_,
+        address contributionToken_,
+        bytes32[] calldata merkleProof_
+    ) external {
+        // Validate input amount.
+        if (amount_ == 0) {
+            revert Module__LM_PC_FundingPot__InvalidDepositAmount();
+        }
+
+        Round storage round = rounds[roundId_];
+
+        // Validate round exists.
+        if (round.roundEnd == 0 && round.roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundNotCreated();
+        }
+
+        // Validate round timing.
+        uint currentTime = block.timestamp;
+        if (currentTime < round.roundStart) {
+            revert Module__LM_PC_FundingPot__RoundHasNotStarted();
+        }
+        if (round.roundEnd > 0 && currentTime > round.roundEnd) {
+            revert Module__LM_PC_FundingPot__RoundHasEnded();
+        }
+
+        // Validate access criteria.
+        _validateAccessCriteria(roundId_, accessId_, merkleProof_);
+
+        // Retrieve user's previous contribution and calculate the personal cap.
+        address user = msg.sender;
+        uint userPreviousContribution = _getUserContribution(roundId_, user);
+        uint userPersonalCap = _getUserPersonalCap(roundId_, user);
+
+        if (userPreviousContribution >= userPersonalCap) {
+            revert Module__LM_PC_FundingPot__PersonalCapReached();
+        }
+
+        // Adjust contribution if it would exceed the personal cap.
+        uint userRemainingCap = userPersonalCap - userPreviousContribution;
+        uint actualContributionAmount = amount_;
+        if (amount_ > userRemainingCap) {
+            actualContributionAmount = userRemainingCap;
+        }
+
+        uint totalRoundContribution = _getTotalRoundContribution(roundId_);
+        if (round.roundCap > 0 && totalRoundContribution >= round.roundCap) {
+            revert Module__LM_PC_FundingPot__RoundCapReached();
+        }
+        uint roundRemainingCap = round.roundCap - totalRoundContribution;
+        if (actualContributionAmount > roundRemainingCap) {
+            actualContributionAmount = roundRemainingCap;
+        }
+
+        // Transfer funds.
+        IERC20(contributionToken_).safeTransferFrom(
+            user, address(this), actualContributionAmount
+        );
+
+        // Record the contribution.
+        _recordContribution(roundId_, user, actualContributionAmount);
+        emit ContributionMade(roundId_, user, actualContributionAmount);
+    }
+
     // -------------------------------------------------------------------------
     // Internal
 
@@ -462,5 +538,124 @@ contract LM_PC_FundingPot_v1 is
         // _start + _cliff should be less or equal to _end
         // this already implies that _start is not greater than _end
         return _start + _cliff <= _end;
+    }
+
+    function _validateAccessCriteria(
+        uint64 roundId_,
+        uint8 accessId_,
+        bytes32[] calldata merkleProof_
+    ) internal view {
+        Round storage round = rounds[roundId_];
+        AccessCriteria storage accessCriteria = round.accessCriterias[accessId_];
+
+        if (accessCriteria.accessCriteriaId == AccessCriteriaId.OPEN) {
+            return;
+        }
+
+        bool accessGranted = false;
+        if (accessCriteria.accessCriteriaId == AccessCriteriaId.NFT) {
+            accessGranted =
+                _checkNftOwnership(accessCriteria.nftContract, msg.sender);
+        } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.MERKLE) {
+            //TODO: Should I move this into a helper function
+
+            bytes32 leaf = keccak256(abi.encodePacked(msg.sender, roundId_));
+            accessGranted = MerkleProof.verify(
+                merkleProof_, accessCriteria.merkleRoot, leaf
+            );
+        } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.LIST) {
+            accessGranted = _checkAllowedAddressList(
+                accessCriteria.allowedAddresses, msg.sender
+            );
+        }
+
+        if (!accessGranted) {
+            revert Module__LM_PC_FundingPot__AccessNotPermitted();
+        }
+    }
+
+    function _getTotalRoundContribution(uint64 roundId_)
+        internal
+        view
+        returns (uint)
+    {
+        return roundTotalContributions[roundId_];
+    }
+
+    function _getUserContribution(uint64 roundId_, address user_)
+        internal
+        view
+        returns (uint)
+    {
+        return userContributions[roundId_][user_];
+    }
+
+    function _getUserPersonalCap(uint64 roundId_, address user_)
+        internal
+        view
+        returns (uint)
+    {
+        uint basePersonalCap = 1000 ether;
+        Round storage round = rounds[roundId_];
+
+        if (round.globalAccumulativeCaps) {
+            uint unusedCapacity =
+                _getUnusedCapacityFromPreviousRounds(user_, roundId_);
+            return basePersonalCap + unusedCapacity;
+        }
+        return basePersonalCap;
+    }
+
+    function _getUnusedCapacityFromPreviousRounds(
+        address user_,
+        uint64 currentRoundId_
+    ) internal view returns (uint) {
+        uint totalUnusedCapacity = 0;
+        for (uint64 i = 1; i < currentRoundId_; i++) {
+            Round storage prevRound = rounds[i];
+            if (!prevRound.globalAccumulativeCaps) {
+                continue;
+            }
+            uint personalCap = 1000 ether;
+            uint userContribution = _getUserContribution(i, user_);
+            if (userContribution < personalCap) {
+                totalUnusedCapacity += (personalCap - userContribution);
+            }
+        }
+        return totalUnusedCapacity;
+    }
+
+    function _recordContribution(uint64 roundId_, address user_, uint amount_)
+        internal
+    {
+        userContributions[roundId_][user_] += amount_;
+        roundTotalContributions[roundId_] += amount_;
+    }
+
+    function _checkAllowedAddressList(
+        address[] memory allowedAddresses,
+        address sender
+    ) internal pure returns (bool) {
+        for (uint i = 0; i < allowedAddresses.length; i++) {
+            if (allowedAddresses[i] == sender) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _checkNftOwnership(address nftContract_, address user_)
+        internal
+        view
+        returns (bool)
+    {
+        if (nftContract_ == address(0) || user_ == address(0)) {
+            return false;
+        }
+        try IERC721(nftContract_).balanceOf(user_) returns (uint balance) {
+            return balance > 0;
+        } catch {
+            return false;
+        }
     }
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -89,6 +89,10 @@ contract LM_PC_FundingPot_v1 is
 
     /// @notice Stores the access criteria ID for each round.
     mapping(uint64 => uint8) private roundIdtoAccessId;
+    /// @notice Stores all access criteria privilages by their unique ID.
+    mapping(
+        uint64 roundId => mapping(uint8 accessId => AccessCriteriaPrivilages)
+    ) private accessCriteriaPrivilages;
 
     /// @notice The next available round ID.
     uint64 private nextRoundId;
@@ -158,10 +162,10 @@ contract LM_PC_FundingPot_v1 is
         external
         view
         returns (
-            bool isOpen,
-            address nftContract,
-            bytes32 merkleRoot,
-            address[] memory allowedAddresses
+            bool isRoundOpen_,
+            address nftContract_,
+            bytes32 merkleRoot_,
+            address[] memory allowedAddresses_
         )
     {
         Round storage round = rounds[roundId_];
@@ -177,7 +181,37 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundCount() external view returns (uint64 roundCount_) {
+    function getRoundAccessCriteriaPrivilages(uint64 roundId_, uint8 accessId_)
+        external
+        view
+        returns (
+            bool isRoundOpen_,
+            uint personalCap_,
+            bool overrideCap_,
+            uint start_,
+            uint cliff_,
+            uint end_
+        )
+    {
+        Round storage round = rounds[roundId_];
+        AccessCriteria storage accessCriteria = round.accessCriterias[accessId_];
+
+        if (accessCriteria.accessCriteriaId == AccessCriteriaId.OPEN) {
+            return (true, 0, false, 0, 0, 0);
+        }
+
+        return (
+            false,
+            accessCriteriaPrivilages[roundId_][accessId_].personalCap,
+            accessCriteriaPrivilages[roundId_][accessId_].overrideCap,
+            accessCriteriaPrivilages[roundId_][accessId_].start,
+            accessCriteriaPrivilages[roundId_][accessId_].cliff,
+            accessCriteriaPrivilages[roundId_][accessId_].end
+        );
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function getRoundCount() external view returns (uint64) {
         return nextRoundId;
     }
 
@@ -319,6 +353,51 @@ contract LM_PC_FundingPot_v1 is
 
         emit AccessCriteriaEdited(roundId_, accessCriteriaId_, accessCriteria_);
     }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function setAccessCriteriaPrivilages(
+        uint64 roundId_,
+        uint8 accessId_,
+        uint personalCap_,
+        bool overrideCap_,
+        uint _start,
+        uint _cliff,
+        uint _end
+    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
+        Round storage round = rounds[roundId_];
+
+        _validateEditRoundParameters(round);
+
+        if (
+            round.accessCriterias[accessId_].accessCriteriaId
+                == AccessCriteriaId.OPEN
+        ) {
+            revert
+                Module__LM_PC_FundingPot__CannotSetPrivilagesForOpenAccessCriteria();
+        }
+        if (!_validTimes(_start, _cliff, _end)) {
+            revert Module__LM_PC_FundingPot__InvalidTimes();
+        }
+
+        AccessCriteriaPrivilages storage accessCriteriaPrivilages =
+            accessCriteriaPrivilages[roundId_][accessId_];
+
+        accessCriteriaPrivilages.personalCap = personalCap_;
+        accessCriteriaPrivilages.overrideCap = overrideCap_;
+        accessCriteriaPrivilages.start = _start;
+        accessCriteriaPrivilages.cliff = _cliff;
+        accessCriteriaPrivilages.end = _end;
+
+        emit AccessCriteriaPrivilagesSet(
+            roundId_,
+            accessId_,
+            personalCap_,
+            overrideCap_,
+            _start,
+            _cliff,
+            _end
+        );
+    }
     // -------------------------------------------------------------------------
     // Internal
 
@@ -368,5 +447,20 @@ contract LM_PC_FundingPot_v1 is
         if (block.timestamp > round_.roundStart) {
             revert Module__LM_PC_FundingPot__RoundAlreadyStarted();
         }
+    }
+
+    /// @dev    Validate uint start input.
+    /// @param  _start uint to validate.
+    /// @param  _cliff uint to validate.
+    /// @param  _end uint to validate.
+    /// @return True if uint is valid.
+    function _validTimes(uint _start, uint _cliff, uint _end)
+        internal
+        pure
+        returns (bool)
+    {
+        // _start + _cliff should be less or equal to _end
+        // this already implies that _start is not greater than _end
+        return _start + _cliff <= _end;
     }
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -200,12 +200,8 @@ contract LM_PC_FundingPot_v1 is
             round.globalAccumulativeCaps
         );
     }
-    /// TODO should either have a param for a specifc address
-    /// and return whether they have access or not
-    /// or should not return anything related to allowed addresses
-    /// Though I think the first option is better
-    /// @inheritdoc ILM_PC_FundingPot_v1
 
+    /// @inheritdoc ILM_PC_FundingPot_v1
     function getRoundAccessCriteria(uint64 roundId_, uint8 id_, address user_)
         external
         view
@@ -224,15 +220,14 @@ contract LM_PC_FundingPot_v1 is
                 true,
                 accessCriteria.nftContract,
                 accessCriteria.merkleRoot,
-                //// This is wrong but gives you an idea of what you need to do
-                accessCriteria.allowedAddresses[user_]
+                true
             );
         } else {
             return (
                 false,
                 accessCriteria.nftContract,
                 accessCriteria.merkleRoot,
-                accessCriteria.allowedAddresses
+                accessCriteria.allowedAddresses[user_]
             );
         }
     }
@@ -363,46 +358,58 @@ contract LM_PC_FundingPot_v1 is
             globalAccumulativeCaps_
         );
     }
-    // TODO should take in nft merkle root and list of allowed addresses
-    // SHould loop through the array and set the access criteria for each address to true in the mapping
-    /// @inheritdoc ILM_PC_FundingPot_v1
 
+    /// @inheritdoc ILM_PC_FundingPot_v1
     function setAccessCriteriaForRound(
         uint64 roundId_,
-        AccessCriteria memory accessCriteria_
+        uint8 accessCriteriaId_,
+        address nftContract_,
+        bytes32 merkleRoot_,
+        address[] calldata allowedAddresses_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
 
         _validateEditRoundParameters(round);
 
         if (
-            /// TODO this would just check that the array being passed in is empty
             (
-                accessCriteria_.accessCriteriaType == AccessCriteriaType.NFT
-                    && accessCriteria_.nftContract == address(0)
+                accessCriteriaId_ == uint8(AccessCriteriaType.NFT)
+                    && nftContract_ == address(0)
             )
                 || (
-                    accessCriteria_.accessCriteriaType == AccessCriteriaType.MERKLE
-                        && accessCriteria_.merkleRoot == bytes32("")
+                    accessCriteriaId_ == uint8(AccessCriteriaType.MERKLE)
+                        && merkleRoot_ == bytes32("")
                 )
                 || (
-                    accessCriteria_.accessCriteriaType == AccessCriteriaType.LIST
-                        && accessCriteria_.allowedAddresses.length == 0
+                    accessCriteriaId_ == uint8(AccessCriteriaType.LIST)
+                        && allowedAddresses_.length == 0
                 )
         ) {
             revert Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
         }
-        uint8 accessCriteriaId_ = uint8(accessCriteria_.accessCriteriaType);
-        round.accessCriterias[accessCriteriaId_] = accessCriteria_;
 
-        emit AccessCriteriaSet(roundId_, accessCriteriaId_, accessCriteria_);
+        AccessCriteriaType accessCriteriaType =
+            AccessCriteriaType(accessCriteriaId_);
+        round.accessCriterias[accessCriteriaId_].accessCriteriaType =
+            accessCriteriaType;
+        round.accessCriterias[accessCriteriaId_].nftContract = nftContract_;
+        round.accessCriterias[accessCriteriaId_].merkleRoot = merkleRoot_;
+
+        for (uint i = 0; i < allowedAddresses_.length; i++) {
+            round.accessCriterias[accessCriteriaId_].allowedAddresses[allowedAddresses_[i]]
+            = true;
+        }
+
+        emit AccessCriteriaSet(roundId_, accessCriteriaId_);
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
     function editAccessCriteriaForRound(
         uint64 roundId_,
         uint8 accessCriteriaId_,
-        AccessCriteria memory accessCriteria_
+        address nftContract_,
+        bytes32 merkleRoot_,
+        address[] calldata allowedAddresses_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
         if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
@@ -411,9 +418,19 @@ contract LM_PC_FundingPot_v1 is
 
         _validateEditRoundParameters(round);
 
-        round.accessCriterias[accessCriteriaId_] = accessCriteria_;
+        AccessCriteriaType accessCriteriaType =
+            AccessCriteriaType(accessCriteriaId_);
+        round.accessCriterias[accessCriteriaId_].accessCriteriaType =
+            accessCriteriaType;
+        round.accessCriterias[accessCriteriaId_].nftContract = nftContract_;
+        round.accessCriterias[accessCriteriaId_].merkleRoot = merkleRoot_;
 
-        emit AccessCriteriaEdited(roundId_, accessCriteriaId_, accessCriteria_);
+        for (uint i = 0; i < allowedAddresses_.length; i++) {
+            round.accessCriterias[accessCriteriaId_].allowedAddresses[allowedAddresses_[i]]
+            = true;
+        }
+
+        emit AccessCriteriaEdited(roundId_, accessCriteriaId_);
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -784,8 +801,12 @@ contract LM_PC_FundingPot_v1 is
             );
         } else if (accessCriteria.accessCriteriaType == AccessCriteriaType.LIST)
         {
-            return
-                _checkAllowedAddressList(accessCriteria.allowedAddresses, user_);
+            if (!accessCriteria.allowedAddresses[user_]) {
+                revert Module__LM_PC_FundingPot__AccessCriteriaListFailed();
+                return false;
+            }
+
+            return true;
         }
 
         // For OPEN access criteria type, no validation needed
@@ -875,25 +896,6 @@ contract LM_PC_FundingPot_v1 is
             }
         }
         return totalUnusedCapacity;
-    }
-
-    ///@notice Checks if a sender is in a list of allowed addresses
-    /// @dev    Performs a linear search to validate address inclusion
-    /// @param  allowedAddresses_ Array of addresses permitted to participate
-    /// @param  sender_ Address to check for permission
-    /// @return Boolean indicating whether the sender is in the allowed list
-    /// TODO should check for address in mapping instead of looping through array
-    function _checkAllowedAddressList(
-        address[] memory allowedAddresses_,
-        address sender_
-    ) internal pure returns (bool) {
-        uint lengthOfAddresses = allowedAddresses_.length;
-        for (uint i = 0; i < lengthOfAddresses; ++i) {
-            if (allowedAddresses_[i] == sender_) {
-                return true;
-            }
-        }
-        revert Module__LM_PC_FundingPot__AccessCriteriaListFailed();
     }
 
     /// @notice Verifies NFT ownership for access control

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -84,6 +84,9 @@ contract LM_PC_FundingPot_v1 is
     /// @notice The payment processor flag for the end timestamp.
     uint8 internal constant FLAG_END = 3;
 
+    /// @notice The maximum valid access criteria ID.
+    uint8 internal constant MAX_ACCESS_CRITERIA_ID = 4;
+
     // -------------------------------------------------------------------------
     // State
 
@@ -230,16 +233,16 @@ contract LM_PC_FundingPot_v1 is
         }
 
         // Store the privileges in a local variable to reduce stack usage.
-        AccessCriteriaPrivileges storage privs =
+        AccessCriteriaPrivileges storage priviledges =
             accessCriteriaPrivileges[roundId_][accessCriteriaId__];
 
         return (
             false,
-            privs.personalCap,
-            privs.overrideContributionSpan,
-            privs.start,
-            privs.cliff,
-            privs.end
+            priviledges.personalCap,
+            priviledges.overrideContributionSpan,
+            priviledges.start,
+            priviledges.cliff,
+            priviledges.end
         );
     }
 
@@ -370,7 +373,7 @@ contract LM_PC_FundingPot_v1 is
         AccessCriteria memory accessCriteria_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
-        if (accessCriteriaId_ > 4) {
+        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
             revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
         }
 
@@ -396,7 +399,7 @@ contract LM_PC_FundingPot_v1 is
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
 
-        uint highestCap = 0;
+        uint highestCap;
 
         _validateEditRoundParameters(round);
 
@@ -600,7 +603,7 @@ contract LM_PC_FundingPot_v1 is
     ) internal view returns (uint adjustedAmount) {
         Round storage round = rounds[roundId_];
         uint currentTime = block.timestamp;
-        uint adjustedAmount = amount_;
+        adjustedAmount = amount_;
 
         if (amount_ == 0) {
             revert Module__LM_PC_FundingPot__InvalidDepositAmount();
@@ -661,17 +664,8 @@ contract LM_PC_FundingPot_v1 is
             // If global accumulative caps are enabled,
             // adjust the round cap to acommodate unused capacity from previous rounds
             if (round.globalAccumulativeCaps) {
-                uint unusedCapacityFromPrevious = 0;
-                for (uint64 i = 1; i < roundId_; ++i) {
-                    Round storage prevRound = rounds[i];
-                    if (!prevRound.globalAccumulativeCaps) continue;
-
-                    uint prevRoundTotal = _getTotalRoundContribution(i);
-                    if (prevRoundTotal < prevRound.roundCap) {
-                        unusedCapacityFromPrevious +=
-                            (prevRound.roundCap - prevRoundTotal);
-                    }
-                }
+                uint unusedCapacityFromPrevious =
+                    _calculateUnusedCapacityFromPreviousRounds(roundId_);
                 effectiveRoundCap += unusedCapacityFromPrevious;
             }
 
@@ -704,40 +698,66 @@ contract LM_PC_FundingPot_v1 is
         return adjustedAmount;
     }
 
+    /// @notice Calculates unused capacity from previous rounds
+    /// @param roundId_ The ID of the current round
+    /// @return unusedCapacityFromPrevious The total unused capacity from previous rounds
+    function _calculateUnusedCapacityFromPreviousRounds(uint64 roundId_)
+        internal
+        view
+        returns (uint unusedCapacityFromPrevious)
+    {
+        unusedCapacityFromPrevious = 0;
+        // Iterate through all previous rounds (1 to roundId_-1)
+        for (uint64 i = 1; i < roundId_; ++i) {
+            Round storage prevRound = rounds[i];
+            if (!prevRound.globalAccumulativeCaps) continue;
+
+            uint prevRoundTotal = _getTotalRoundContribution(i);
+            if (prevRoundTotal < prevRound.roundCap) {
+                unusedCapacityFromPrevious +=
+                    (prevRound.roundCap - prevRoundTotal);
+            }
+        }
+        return unusedCapacityFromPrevious;
+    }
+
     /// @notice Validates access criteria for a specific round and access type
     /// @dev    Checks if a user meets the access requirements based on the round's access criteria
     /// @param  roundId_ The ID of the round being validated
     /// @param  accessCriteriaId_ The ID of the specific access criteria
     /// @param  merkleProof_ Merkle proof for Merkle tree-based access (optional)
+    /// @param  user_ The address of the user to validate
+    /// @return True if the user meets the access criteria, reverts otherwise
     function _validateAccessCriteria(
         uint64 roundId_,
         uint8 accessCriteriaId_,
         bytes32[] calldata merkleProof_,
         address user_
-    ) internal view {
+    ) internal view returns (bool) {
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria =
             round.accessCriterias[accessCriteriaId_];
 
-        if (accessCriteriaId_ > 4) {
+        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
             revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
         }
 
-        bool accessGranted = false;
         if (accessCriteria.accessCriteriaType == AccessCriteriaType.NFT) {
-            accessGranted =
-                _checkNftOwnership(accessCriteria.nftContract, user_);
+            return _checkNftOwnership(accessCriteria.nftContract, user_);
         } else if (
             accessCriteria.accessCriteriaType == AccessCriteriaType.MERKLE
         ) {
-            accessGranted = _validateMerkleProof(
+            return _validateMerkleProof(
                 accessCriteria.merkleRoot, merkleProof_, user_, roundId_
             );
         } else if (accessCriteria.accessCriteriaType == AccessCriteriaType.LIST)
         {
-            accessGranted =
+            return
                 _checkAllowedAddressList(accessCriteria.allowedAddresses, user_);
         }
+
+        // For OPEN access criteria type, no validation needed
+        return true;
     }
 
     /// @notice Retrieves the total contribution for a specific round
@@ -806,10 +826,8 @@ contract LM_PC_FundingPot_v1 is
 
             uint personalCap = 0;
 
-            for (uint8 j = 0; j < 4; ++j) {
-                AccessCriteria storage accessCriteria =
-                    prevRound.accessCriterias[j];
-
+            // Iterate through all possible access criteria IDs (0 to MAX_ACCESS_CRITERIA_ID)
+            for (uint8 j = 0; j <= MAX_ACCESS_CRITERIA_ID; ++j) {
                 AccessCriteriaPrivileges storage privileges =
                     accessCriteriaPrivileges[i][j];
 

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -121,16 +121,17 @@ contract LM_PC_FundingPot_v1 is
     mapping(
         uint64 roundId
             => mapping(uint8 accessCriteriaId_ => AccessCriteriaPrivileges)
-    ) private accessCriteriaPrivileges;
+    ) private roundItToAccessCriteriaIdToPrivileges;
 
     /// @notice Maps round IDs to user addresses to contribution amounts
-    mapping(uint64 => mapping(address => uint)) private userContributions;
+    mapping(uint64 => mapping(address => uint)) private
+        roundIdToUserToContribution;
 
     /// @notice Maps round IDs to total contributions
-    mapping(uint64 => uint) private roundTotalContributions;
+    mapping(uint64 => uint) private roundIdToTotalContributions;
 
     /// @notice Maps round IDs to closed status
-    mapping(uint64 => bool) private roundClosed;
+    mapping(uint64 => bool) private roundIdToClosedStatus;
 
     /// @notice The current round count.
     uint64 private roundCount;
@@ -195,7 +196,11 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundAccessCriteria(uint64 roundId_, uint8 id_, address user_)
+    function getRoundAccessCriteria(
+        uint64 roundId_,
+        uint8 accessCriteriaId_,
+        address user_
+    )
         external
         view
         returns (
@@ -206,7 +211,8 @@ contract LM_PC_FundingPot_v1 is
         )
     {
         Round storage round = rounds[roundId_];
-        AccessCriteria storage accessCriteria = round.accessCriterias[id_];
+        AccessCriteria storage accessCriteria =
+            round.accessCriterias[accessCriteriaId_];
 
         if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
             return (
@@ -233,7 +239,6 @@ contract LM_PC_FundingPot_v1 is
         external
         view
         returns (
-            bool isRoundOpen_,
             uint personalCap_,
             bool overrideContributionSpan_,
             uint start_,
@@ -246,20 +251,19 @@ contract LM_PC_FundingPot_v1 is
             round.accessCriterias[accessCriteriaId__];
 
         if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
-            return (true, 0, false, 0, 0, 0);
+            return (0, false, 0, 0, 0);
         }
 
         // Store the privileges in a local variable to reduce stack usage.
-        AccessCriteriaPrivileges storage priviledges =
-            accessCriteriaPrivileges[roundId_][accessCriteriaId__];
+        AccessCriteriaPrivileges storage privileges =
+            roundItToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId__];
 
         return (
-            false,
-            priviledges.personalCap,
-            priviledges.overrideContributionSpan,
-            priviledges.start,
-            priviledges.cliff,
-            priviledges.end
+            privileges.personalCap,
+            privileges.overrideContributionSpan,
+            privileges.start,
+            privileges.cliff,
+            privileges.end
         );
     }
 
@@ -270,7 +274,7 @@ contract LM_PC_FundingPot_v1 is
 
     /// @inheritdoc ILM_PC_FundingPot_v1
     function isRoundClosed(uint64 roundId_) external view returns (bool) {
-        return roundClosed[roundId_];
+        return roundIdToClosedStatus[roundId_];
     }
 
     // -------------------------------------------------------------------------
@@ -426,14 +430,33 @@ contract LM_PC_FundingPot_v1 is
         emit AccessCriteriaEdited(roundId_, accessCriteriaId_);
     }
 
+    function removeAccessCriteriaAddressesForRound(
+        uint64 roundId_,
+        uint8 accessCriteriaId_,
+        address[] calldata addressesToRemove_
+    ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
+        Round storage round = rounds[roundId_];
+        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
+            revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
+        }
+
+        _validateEditRoundParameters(round);
+
+        for (uint i = 0; i < addressesToRemove_.length; i++) {
+            round.accessCriterias[accessCriteriaId_].allowedAddresses[addressesToRemove_[i]]
+            = false;
+        }
+
+        emit AccessCriteriaAddressesRemoved(
+            roundId_, accessCriteriaId_, addressesToRemove_
+        );
+    }
+
     /// @inheritdoc ILM_PC_FundingPot_v1
     function setAccessCriteriaPrivileges(
         uint64 roundId_,
-        uint8 accessCriteriaId__,
+        uint8 accessCriteriaId_,
         uint personalCap_,
-        uint capByNFT_,
-        uint capByMerkle_,
-        uint capByList_,
         bool overrideContributionSpan_,
         uint start_,
         uint cliff_,
@@ -441,53 +464,14 @@ contract LM_PC_FundingPot_v1 is
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
 
-        uint highestCap;
-
         _validateEditRoundParameters(round);
-
-        if (
-            round.accessCriterias[accessCriteriaId__].accessCriteriaType
-                == AccessCriteriaType.OPEN
-        ) {
-            highestCap = personalCap_;
-        }
-
-        if (
-            round.accessCriterias[accessCriteriaId__].accessCriteriaType
-                == AccessCriteriaType.NFT && capByNFT_ > 0
-        ) {
-            uint nftCap = personalCap_ + capByNFT_;
-            if (nftCap > highestCap) {
-                highestCap = nftCap;
-            }
-        }
-
-        if (
-            round.accessCriterias[accessCriteriaId__].accessCriteriaType
-                == AccessCriteriaType.MERKLE && capByMerkle_ > 0
-        ) {
-            uint merkleCap = personalCap_ + capByMerkle_;
-            if (merkleCap > highestCap) {
-                highestCap = merkleCap;
-            }
-        }
-
-        if (
-            round.accessCriterias[accessCriteriaId__].accessCriteriaType
-                == AccessCriteriaType.LIST && capByList_ > 0
-        ) {
-            uint listCap = personalCap_ + capByList_;
-            if (listCap > highestCap) {
-                highestCap = listCap;
-            }
-        }
 
         if (!_validTimes(start_, cliff_, end_)) {
             revert Module__LM_PC_FundingPot__InvalidTimes();
         }
 
         AccessCriteriaPrivileges storage accessCriteriaPrivileges =
-            accessCriteriaPrivileges[roundId_][accessCriteriaId__];
+            roundItToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId_];
 
         accessCriteriaPrivileges.personalCap = personalCap_;
         accessCriteriaPrivileges.overrideContributionSpan =
@@ -498,7 +482,7 @@ contract LM_PC_FundingPot_v1 is
 
         emit AccessCriteriaPrivilegesSet(
             roundId_,
-            accessCriteriaId__,
+            accessCriteriaId_,
             personalCap_,
             overrideContributionSpan_,
             start_,
@@ -528,7 +512,7 @@ contract LM_PC_FundingPot_v1 is
         bytes32[] memory merkleProof_,
         UnspentPersonalRoundCap[] calldata unspentPersonalRoundCaps_
     ) external {
-        uint unspentPersonalCap = 0;
+        uint unspentPersonalCap;
 
         // Process each previous round cap that the user wants to carry over
         for (uint i = 0; i < unspentPersonalRoundCaps_.length; i++) {
@@ -548,7 +532,7 @@ contract LM_PC_FundingPot_v1 is
 
             if (isEligible) {
                 AccessCriteriaPrivileges storage privileges =
-                accessCriteriaPrivileges[roundCap.roundId][roundCap
+                roundItToAccessCriteriaIdToPrivileges[roundCap.roundId][roundCap
                     .accessCriteriaId];
 
                 uint userContribution =
@@ -580,7 +564,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         // Check if round is already closed
-        if (roundClosed[roundId_]) {
+        if (roundIdToClosedStatus[roundId_]) {
             revert Module__LM_PC_FundingPot__RoundHasEnded();
         }
 
@@ -688,13 +672,17 @@ contract LM_PC_FundingPot_v1 is
             revert Module__LM_PC_FundingPot__RoundHasNotStarted();
         }
 
+        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
+            revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
+        }
+
         // Validate access criteria
         _validateAccessCriteria(
             roundId_, accessCriteriaId_, merkleProof_, _msgSender()
         );
 
         AccessCriteriaPrivileges storage privileges =
-            accessCriteriaPrivileges[roundId_][accessCriteriaId_];
+            roundItToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId_];
         bool canOverrideContributionSpan = privileges.overrideContributionSpan;
 
         // Allow contributions after the round end if the user can override the contribution span
@@ -715,8 +703,8 @@ contract LM_PC_FundingPot_v1 is
         );
 
         // Record contribution
-        userContributions[roundId_][_msgSender()] += adjustedAmount;
-        roundTotalContributions[roundId_] += adjustedAmount;
+        roundIdToUserToContribution[roundId_][_msgSender()] += adjustedAmount;
+        roundIdToTotalContributions[roundId_] += adjustedAmount;
 
         __Module_orchestrator.fundingManager().token().safeTransferFrom(
             _msgSender(), address(this), adjustedAmount
@@ -725,7 +713,7 @@ contract LM_PC_FundingPot_v1 is
         emit ContributionMade(roundId_, _msgSender(), adjustedAmount);
 
         // contribution triggers automatic closure
-        if (!roundClosed[roundId_] && round.autoClosure) {
+        if (!roundIdToClosedStatus[roundId_] && round.autoClosure) {
             bool readyToClose = _checkRoundClosureConditions(roundId_);
             if (readyToClose) {
                 _closeRound(roundId_);
@@ -754,10 +742,6 @@ contract LM_PC_FundingPot_v1 is
         );
 
         if (!isEligible) {
-            if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
-                revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
-            }
-
             if (accessCriteria.accessCriteriaType == AccessCriteriaType.NFT) {
                 revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
             }
@@ -818,7 +802,7 @@ contract LM_PC_FundingPot_v1 is
 
         // Get the base personal cap for this round and criteria
         AccessCriteriaPrivileges storage privileges =
-            accessCriteriaPrivileges[roundId_][accessCriteriaId__];
+            roundItToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId__];
         uint userPersonalCap = privileges.personalCap;
 
         // Add unspent capacity if global accumulative caps are enabled
@@ -850,10 +834,6 @@ contract LM_PC_FundingPot_v1 is
         bytes32[] memory merkleProof_,
         address user_
     ) internal view returns (bool isEligible) {
-        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
-            isEligible = false;
-        }
-
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria =
             round.accessCriterias[accessCriteriaId_];
@@ -909,7 +889,7 @@ contract LM_PC_FundingPot_v1 is
         view
         returns (uint)
     {
-        return roundTotalContributions[roundId_];
+        return roundIdToTotalContributions[roundId_];
     }
 
     /// @notice Retrieves the contribution amount for a specific user in a round
@@ -922,7 +902,7 @@ contract LM_PC_FundingPot_v1 is
         view
         returns (uint)
     {
-        return userContributions[roundId_][user_];
+        return roundIdToUserToContribution[roundId_][user_];
     }
 
     /// @notice Verifies NFT ownership for access control
@@ -981,7 +961,7 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
 
         // Mark round as closed
-        roundClosed[roundId_] = true;
+        roundIdToClosedStatus[roundId_] = true;
 
         // Execute hook if configured
         if (round.hookContract != address(0) && round.hookFunction.length > 0) {
@@ -993,7 +973,7 @@ contract LM_PC_FundingPot_v1 is
 
         // Emit event for round closure
         emit RoundClosed(
-            roundId_, block.timestamp, roundTotalContributions[roundId_]
+            roundId_, block.timestamp, roundIdToTotalContributions[roundId_]
         );
     }
 
@@ -1006,7 +986,7 @@ contract LM_PC_FundingPot_v1 is
         returns (bool)
     {
         Round storage round = rounds[roundId_];
-        uint totalContribution = roundTotalContributions[roundId_];
+        uint totalContribution = roundIdToTotalContributions[roundId_];
         bool capReached =
             round.roundCap > 0 && totalContribution == round.roundCap;
         bool timeEnded = round.roundEnd > 0 && block.timestamp >= round.roundEnd;

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -561,19 +561,13 @@ contract LM_PC_FundingPot_v1 is
             accessGranted =
                 _checkNftOwnership(accessCriteria.nftContract, msg.sender);
         } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.MERKLE) {
-            //TODO: Should I move this into a helper function
-            bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
-            accessGranted = MerkleProof.verify(
-                merkleProof_, accessCriteria.merkleRoot, leaf
+            accessGranted = _validateMerkleProof(
+                accessCriteria.merkleRoot, msg.sender, merkleProof_
             );
         } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.LIST) {
             accessGranted = _checkAllowedAddressList(
                 accessCriteria.allowedAddresses, msg.sender
             );
-        }
-
-        if (!accessGranted) {
-            revert Module__LM_PC_FundingPot__AccessNotPermitted();
         }
     }
 
@@ -673,6 +667,7 @@ contract LM_PC_FundingPot_v1 is
                 return true;
             }
         }
+        revert Module__LM_PC_FundingPot__AccessCriteriaListFailed();
         return false;
     }
 
@@ -689,10 +684,26 @@ contract LM_PC_FundingPot_v1 is
         if (nftContract_ == address(0) || user_ == address(0)) {
             return false;
         }
+
         try IERC721(nftContract_).balanceOf(user_) returns (uint balance) {
-            return balance > 0;
+            if (balance == 0) {
+                revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
+            }
+            return true;
         } catch {
-            return false;
+            revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
+        }
+    }
+
+    function _validateMerkleProof(
+        bytes32 root_,
+        address user_,
+        bytes32[] calldata merkleProof_
+    ) internal pure returns (bool) {
+        bytes32 leaf = keccak256(abi.encodePacked(user_));
+
+        if (!MerkleProof.verify(merkleProof_, root_, leaf)) {
+            revert Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();
         }
     }
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -209,13 +209,17 @@ contract LM_PC_FundingPot_v1 is
             return (true, 0, false, 0, 0, 0);
         }
 
+        // Store the privileges in a local variable to reduce stack usage.
+        AccessCriteriaPrivilages storage privs =
+            accessCriteriaPrivilages[roundId_][accessId_];
+
         return (
             false,
-            accessCriteriaPrivilages[roundId_][accessId_].personalCap,
-            accessCriteriaPrivilages[roundId_][accessId_].overrideCap,
-            accessCriteriaPrivilages[roundId_][accessId_].start,
-            accessCriteriaPrivilages[roundId_][accessId_].cliff,
-            accessCriteriaPrivilages[roundId_][accessId_].end
+            privs.personalCap,
+            privs.overrideCap,
+            privs.start,
+            privs.cliff,
+            privs.end
         );
     }
 
@@ -408,7 +412,8 @@ contract LM_PC_FundingPot_v1 is
         );
     }
 
-    function contribute(
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function contributeToRound(
         uint64 roundId_,
         uint amount_,
         uint8 accessId_,
@@ -440,38 +445,32 @@ contract LM_PC_FundingPot_v1 is
         _validateAccessCriteria(roundId_, accessId_, merkleProof_);
 
         // Retrieve user's previous contribution and calculate the personal cap.
-        address user = msg.sender;
-        uint userPreviousContribution = _getUserContribution(roundId_, user);
-        uint userPersonalCap = _getUserPersonalCap(roundId_, user);
+        uint userPreviousContribution =
+            _getUserContribution(roundId_, msg.sender);
+        uint userPersonalCap = _getUserPersonalCap(roundId_, msg.sender);
 
-        if (userPreviousContribution >= userPersonalCap) {
+        // Revert contribution if it would exceed the personal cap.
+        uint userRemainingCap = userPersonalCap - userPreviousContribution;
+        if (amount_ > userRemainingCap) {
             revert Module__LM_PC_FundingPot__PersonalCapReached();
         }
 
-        // Adjust contribution if it would exceed the personal cap.
-        uint userRemainingCap = userPersonalCap - userPreviousContribution;
-        uint actualContributionAmount = amount_;
-        if (amount_ > userRemainingCap) {
-            actualContributionAmount = userRemainingCap;
-        }
-
         uint totalRoundContribution = _getTotalRoundContribution(roundId_);
-        if (round.roundCap > 0 && totalRoundContribution >= round.roundCap) {
+        if (
+            round.roundCap > 0
+                && totalRoundContribution + amount_ >= round.roundCap
+        ) {
             revert Module__LM_PC_FundingPot__RoundCapReached();
-        }
-        uint roundRemainingCap = round.roundCap - totalRoundContribution;
-        if (actualContributionAmount > roundRemainingCap) {
-            actualContributionAmount = roundRemainingCap;
         }
 
         // Transfer funds.
         IERC20(contributionToken_).safeTransferFrom(
-            user, address(this), actualContributionAmount
+            msg.sender, address(this), amount_
         );
 
         // Record the contribution.
-        _recordContribution(roundId_, user, actualContributionAmount);
-        emit ContributionMade(roundId_, user, actualContributionAmount);
+        _recordContribution(roundId_, msg.sender, amount_);
+        emit ContributionMade(roundId_, msg.sender, amount_);
     }
 
     // -------------------------------------------------------------------------
@@ -540,6 +539,11 @@ contract LM_PC_FundingPot_v1 is
         return _start + _cliff <= _end;
     }
 
+    /// @notice Validates access criteria for a specific round and access type
+    /// @dev    Checks if a user meets the access requirements based on the round's access criteria
+    /// @param  roundId_ The ID of the round being validated
+    /// @param  accessId_ The ID of the specific access criteria
+    /// @param  merkleProof_ Merkle proof for Merkle tree-based access (optional)
     function _validateAccessCriteria(
         uint64 roundId_,
         uint8 accessId_,
@@ -558,8 +562,7 @@ contract LM_PC_FundingPot_v1 is
                 _checkNftOwnership(accessCriteria.nftContract, msg.sender);
         } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.MERKLE) {
             //TODO: Should I move this into a helper function
-
-            bytes32 leaf = keccak256(abi.encodePacked(msg.sender, roundId_));
+            bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
             accessGranted = MerkleProof.verify(
                 merkleProof_, accessCriteria.merkleRoot, leaf
             );
@@ -574,6 +577,10 @@ contract LM_PC_FundingPot_v1 is
         }
     }
 
+    /// @notice Retrieves the total contribution for a specific round
+    /// @dev    Returns the accumulated contributions for the given round
+    /// @param  roundId_ The ID of the round to check contributions for
+    /// @return The total contributions for the specified round
     function _getTotalRoundContribution(uint64 roundId_)
         internal
         view
@@ -582,6 +589,11 @@ contract LM_PC_FundingPot_v1 is
         return roundTotalContributions[roundId_];
     }
 
+    /// @notice Retrieves the contribution amount for a specific user in a round
+    /// @dev    Returns the individual user's contribution for the given round
+    /// @param  roundId_ The ID of the round to check contributions for
+    /// @param  user_ The address of the user
+    /// @return The user's contribution amount for the specified round
     function _getUserContribution(uint64 roundId_, address user_)
         internal
         view
@@ -590,12 +602,17 @@ contract LM_PC_FundingPot_v1 is
         return userContributions[roundId_][user_];
     }
 
+    /// @notice Calculates the personal contribution cap for a user in a specific round
+    /// @dev    Determines the maximum amount a user can contribute based on global or round-specific rules
+    /// @param  roundId_ The ID of the current round
+    /// @param  user_ The address of the user
+    /// @return The personal contribution cap for the user
     function _getUserPersonalCap(uint64 roundId_, address user_)
         internal
         view
         returns (uint)
     {
-        uint basePersonalCap = 1000 ether;
+        uint basePersonalCap = 500;
         Round storage round = rounds[roundId_];
 
         if (round.globalAccumulativeCaps) {
@@ -606,6 +623,11 @@ contract LM_PC_FundingPot_v1 is
         return basePersonalCap;
     }
 
+    /// @notice Calculates unused contribution capacity from previous rounds
+    /// @dev    Aggregates unused contribution caps from previous rounds with global accumulative caps
+    /// @param  user_ The address of the user
+    /// @param  currentRoundId_ The ID of the current round
+    /// @return Total unused contribution capacity from previous rounds
     function _getUnusedCapacityFromPreviousRounds(
         address user_,
         uint64 currentRoundId_
@@ -625,6 +647,11 @@ contract LM_PC_FundingPot_v1 is
         return totalUnusedCapacity;
     }
 
+    /// @notice Records a contribution for a user in a specific round
+    /// @dev    Updates the user's contribution and the total round contribution
+    /// @param  roundId_ The ID of the round
+    /// @param  user_ The address of the user making the contribution
+    /// @param  amount_ The amount of the contribution
     function _recordContribution(uint64 roundId_, address user_, uint amount_)
         internal
     {
@@ -632,6 +659,11 @@ contract LM_PC_FundingPot_v1 is
         roundTotalContributions[roundId_] += amount_;
     }
 
+    ///@notice Checks if a sender is in a list of allowed addresses
+    /// @dev    Performs a linear search to validate address inclusion
+    /// @param  allowedAddresses Array of addresses permitted to participate
+    /// @param  sender Address to check for permission
+    /// @return Boolean indicating whether the sender is in the allowed list
     function _checkAllowedAddressList(
         address[] memory allowedAddresses,
         address sender
@@ -644,6 +676,11 @@ contract LM_PC_FundingPot_v1 is
         return false;
     }
 
+    /// @notice Verifies NFT ownership for access control
+    /// @dev    Safely checks the NFT balance of a user using a try-catch block
+    /// @param  nftContract_ Address of the NFT contract
+    /// @param  user_ Address of the user to check for NFT ownership
+    /// @return Boolean indicating whether the user owns an NFT
     function _checkNftOwnership(address nftContract_, address user_)
         internal
         view

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -90,8 +90,6 @@ contract LM_PC_FundingPot_v1 is
     /// @notice Stores all funding rounds by their unique ID.
     mapping(uint64 => Round) private rounds;
 
-    /// @notice Stores the access criteria ID for each round.
-    mapping(uint64 => uint8) private roundIdtoAccessId;
     /// @notice Stores all access criteria privilages by their unique ID.
     mapping(
         uint64 roundId => mapping(uint8 accessId => AccessCriteriaPrivileges)
@@ -246,15 +244,6 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundAccessCriteriaCount(uint64 roundId_)
-        public
-        view
-        returns (uint8 accessCriteriaCount_)
-    {
-        return roundIdtoAccessId[roundId_];
-    }
-
-    /// @inheritdoc ILM_PC_FundingPot_v1
     function isRoundClosed(uint64 roundId_) external view returns (bool) {
         return roundClosed[roundId_];
     }
@@ -363,12 +352,10 @@ contract LM_PC_FundingPot_v1 is
         ) {
             revert Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
         }
-        uint8 accessCriteriaId = roundIdtoAccessId[roundId_];
-        round.accessCriterias[accessCriteriaId] = accessCriteria_;
+        uint8 accessID = uint8(accessCriteria_.accessCriteriaType);
+        round.accessCriterias[accessID] = accessCriteria_;
 
-        emit AccessCriteriaSet(roundId_, accessCriteriaId, accessCriteria_);
-
-        roundIdtoAccessId[roundId_] += 1;
+        emit AccessCriteriaSet(roundId_, accessID, accessCriteria_);
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -377,10 +364,10 @@ contract LM_PC_FundingPot_v1 is
         uint8 accessCriteriaId_,
         AccessCriteria memory accessCriteria_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
-        if (accessCriteriaId_ >= roundIdtoAccessId[roundId_]) {
+        Round storage round = rounds[roundId_];
+        if (accessCriteriaId_ > 4) {
             revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
         }
-        Round storage round = rounds[roundId_];
 
         _validateEditRoundParameters(round);
 
@@ -714,19 +701,20 @@ contract LM_PC_FundingPot_v1 is
     /// @notice Validates access criteria for a specific round and access type
     /// @dev    Checks if a user meets the access requirements based on the round's access criteria
     /// @param  roundId_ The ID of the round being validated
-    /// @param  accessId_ The ID of the specific access criteria
+    /// @param  accessCriteriaId_ The ID of the specific access criteria
     /// @param  merkleProof_ Merkle proof for Merkle tree-based access (optional)
     function _validateAccessCriteria(
         uint64 roundId_,
-        uint8 accessId_,
+        uint8 accessCriteriaId_,
         bytes32[] calldata merkleProof_,
         address user_
     ) internal view {
         Round storage round = rounds[roundId_];
-        AccessCriteria storage accessCriteria = round.accessCriterias[accessId_];
+        AccessCriteria storage accessCriteria =
+            round.accessCriterias[accessCriteriaId_];
 
-        if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
-            return;
+        if (accessCriteriaId_ > 4) {
+            revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
         }
 
         bool accessGranted = false;

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -284,58 +284,57 @@ contract LM_PC_FundingPot_v1 is
     /// @inheritdoc ILM_PC_FundingPot_v1
     function getUserEligibility(
         uint64 roundId_,
+        uint8 accessCriteriaId_,
         bytes32[] memory merkleProof_,
         address user_
-    ) external view returns (RoundUserEligibility memory eligibility) {
+    )
+        external
+        view
+        returns (bool isEligible, uint remainingAmountAllowedToContribute)
+    {
+        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
+            revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
+        }
+
         Round storage round = rounds[roundId_];
 
         if (round.roundEnd == 0 && round.roundCap == 0) {
             revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
 
-        for (uint8 i = 0; i <= MAX_ACCESS_CRITERIA_ID; i++) {
-            AccessCriteria storage accessCriteria = round.accessCriterias[i];
+        AccessCriteria storage accessCriteria =
+            round.accessCriterias[accessCriteriaId_];
 
-            if (accessCriteria.accessCriteriaType == AccessCriteriaType.UNSET) {
-                continue;
-            }
-
-            bool isEligible = _checkAccessCriteriaEligibility(
-                roundId_, i, merkleProof_, user_
-            );
-
-            if (isEligible) {
-                eligibility.isEligible = true;
-
-                if (accessCriteria.accessCriteriaType == AccessCriteriaType.NFT)
-                {
-                    eligibility.isNftHolder = true;
-                } else if (
-                    accessCriteria.accessCriteriaType
-                        == AccessCriteriaType.MERKLE
-                ) {
-                    eligibility.isInMerkleTree = true;
-                } else if (
-                    accessCriteria.accessCriteriaType == AccessCriteriaType.LIST
-                ) {
-                    eligibility.isInAllowlist = true;
-                }
-
-                // Check personal cap and contribution span override
-                AccessCriteriaPrivileges storage privileges =
-                    roundItToAccessCriteriaIdToPrivileges[roundId_][i];
-
-                if (privileges.personalCap > eligibility.highestPersonalCap) {
-                    eligibility.highestPersonalCap = privileges.personalCap;
-                }
-
-                if (privileges.overrideContributionSpan) {
-                    eligibility.canOverrideContributionSpan = true;
-                }
-            }
+        if (accessCriteria.accessCriteriaType == AccessCriteriaType.UNSET) {
+            return (false, 0);
         }
 
-        return eligibility;
+        isEligible = _checkAccessCriteriaEligibility(
+            roundId_, accessCriteriaId_, merkleProof_, user_
+        );
+
+        if (isEligible) {
+            AccessCriteriaPrivileges storage privileges =
+            roundItToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId_];
+            uint userPersonalCap = privileges.personalCap;
+            uint userContribution = _getUserContributionToRound(roundId_, user_);
+
+            uint personalCapRemaining = userPersonalCap > userContribution
+                ? userPersonalCap - userContribution
+                : 0;
+
+            uint totalContributions = roundIdToTotalContributions[roundId_];
+            uint roundCapRemaining = round.roundCap > totalContributions
+                ? round.roundCap - totalContributions
+                : 0;
+
+            remainingAmountAllowedToContribute = personalCapRemaining
+                < roundCapRemaining ? personalCapRemaining : roundCapRemaining;
+
+            return (true, remainingAmountAllowedToContribute);
+        } else {
+            return (false, 0);
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -196,18 +196,14 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundAccessCriteria(
-        uint64 roundId_,
-        uint8 accessCriteriaId_,
-        address user_
-    )
+    function getRoundAccessCriteria(uint64 roundId_, uint8 accessCriteriaId_)
         external
         view
         returns (
             bool isRoundOpen_,
             address nftContract_,
             bytes32 merkleRoot_,
-            bool hasAccess_
+            bool isList_
         )
     {
         Round storage round = rounds[roundId_];
@@ -221,12 +217,20 @@ contract LM_PC_FundingPot_v1 is
                 accessCriteria.merkleRoot,
                 true
             );
+        } else if (accessCriteria.accessCriteriaType == AccessCriteriaType.LIST)
+        {
+            return (
+                false,
+                accessCriteria.nftContract,
+                accessCriteria.merkleRoot,
+                true
+            );
         } else {
             return (
                 false,
                 accessCriteria.nftContract,
                 accessCriteria.merkleRoot,
-                accessCriteria.allowedAddresses[user_]
+                false
             );
         }
     }
@@ -275,6 +279,63 @@ contract LM_PC_FundingPot_v1 is
     /// @inheritdoc ILM_PC_FundingPot_v1
     function isRoundClosed(uint64 roundId_) external view returns (bool) {
         return roundIdToClosedStatus[roundId_];
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function getUserEligibility(
+        uint64 roundId_,
+        bytes32[] memory merkleProof_,
+        address user_
+    ) external view returns (RoundUserEligibility memory eligibility) {
+        Round storage round = rounds[roundId_];
+
+        if (round.roundEnd == 0 && round.roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundNotCreated();
+        }
+
+        for (uint8 i = 0; i <= MAX_ACCESS_CRITERIA_ID; i++) {
+            AccessCriteria storage accessCriteria = round.accessCriterias[i];
+
+            if (accessCriteria.accessCriteriaType == AccessCriteriaType.UNSET) {
+                continue;
+            }
+
+            bool isEligible = _checkAccessCriteriaEligibility(
+                roundId_, i, merkleProof_, user_
+            );
+
+            if (isEligible) {
+                eligibility.isEligible = true;
+
+                if (accessCriteria.accessCriteriaType == AccessCriteriaType.NFT)
+                {
+                    eligibility.isNftHolder = true;
+                } else if (
+                    accessCriteria.accessCriteriaType
+                        == AccessCriteriaType.MERKLE
+                ) {
+                    eligibility.isInMerkleTree = true;
+                } else if (
+                    accessCriteria.accessCriteriaType == AccessCriteriaType.LIST
+                ) {
+                    eligibility.isInAllowlist = true;
+                }
+
+                // Check personal cap and contribution span override
+                AccessCriteriaPrivileges storage privileges =
+                    roundItToAccessCriteriaIdToPrivileges[roundId_][i];
+
+                if (privileges.personalCap > eligibility.highestPersonalCap) {
+                    eligibility.highestPersonalCap = privileges.personalCap;
+                }
+
+                if (privileges.overrideContributionSpan) {
+                    eligibility.canOverrideContributionSpan = true;
+                }
+            }
+        }
+
+        return eligibility;
     }
 
     // -------------------------------------------------------------------------
@@ -430,7 +491,7 @@ contract LM_PC_FundingPot_v1 is
         emit AccessCriteriaEdited(roundId_, accessCriteriaId_);
     }
 
-    function removeAccessCriteriaAddressesForRound(
+    function removeAllowlistedAddresses(
         uint64 roundId_,
         uint8 accessCriteriaId_,
         address[] calldata addressesToRemove_
@@ -447,7 +508,7 @@ contract LM_PC_FundingPot_v1 is
             = false;
         }
 
-        emit AccessCriteriaAddressesRemoved(
+        emit AllowlistedAddressesRemoved(
             roundId_, accessCriteriaId_, addressesToRemove_
         );
     }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -25,15 +25,39 @@ import {ERC165Upgradeable} from
 import "@oz/utils/cryptography/MerkleProof.sol";
 
 /**
- * @title   Inverter Funding Pot Module
+ * @title   Inverter Funding Pot Logic Module
  *
- * @notice  The module allows project supporters to contribute during funding rounds.
+ * @notice  Manages contribution rounds for fundraising within the Inverter Network, enabling
+ *          configurable access control, contribution limits, and automated distribution.
+ *          Supports multiple concurrent access criteria per round with customizable privileges.
  *
- * @dev     Extends {ERC20PaymentClientBase_v2} and implements {ILM_PC_FundingPot_v1}.
- *          This contract manages funding rounds with configurable parameters including
- *          start/end times, funding caps, and hook contracts for custom logic.
- *          Uses timestamps as flags for payment processing via FLAG_START, FLAG_CLIFF,
- *          and FLAG_END constants.
+ * @dev     Implements a sophisticated round-based funding system with features including:
+ *          - Configurable round parameters (start/end times, caps, hooks)
+ *          - Multiple access criteria types (NFT holding, allowlist, Merkle proof)
+ *          - Customizable privileges per access criteria
+ *          - Global accumulative caps across rounds
+ *          - Automatic and manual round closure mechanisms
+ *          - Hook system for post-round actions
+ *
+ *          DISCLAIMER: Known Limitations
+ *          1. Storage Considerations:
+ *             The contract stores significant data per round (access criteria, privileges,
+ *             contributions). While this enables flexible round configuration, it may lead
+ *             to higher gas costs as the number of rounds and contributors increases.
+ *
+ *          2. Round Management:
+ *             Rounds cannot be modified once started. This is a security feature but
+ *             requires careful initial configuration. Additionally, rounds must be created
+ *             sequentially and cannot run concurrently.
+ *
+ *          3. Access Criteria:
+ *             The contract supports multiple access criteria per round, but each address
+ *             can only contribute under one access criteria type per round. This is to
+ *             prevent double-counting of privileges and caps.
+ *
+ *          CAUTION: Administrators should carefully consider round configurations,
+ *          particularly when using global accumulative caps and multiple access criteria,
+ *          as these features interact in complex ways that affect contribution limits.
  *
  * @custom:security-contact security@inverter.network
  *                          In case of any concerns or findings, please refer to our Security Policy

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -134,6 +134,7 @@ contract LM_PC_FundingPot_v1 is
     ) external override(Module_v1) initializer {
         __Module_init(orchestrator_, metadata_);
         address fundingPotToken;
+        (fundingPotToken) = abi.decode(configData_, (address));
         // Set the flags for the PaymentOrders (this module uses 3 flags).
         bytes32 flags;
         flags |= bytes32(1 << FLAG_START);

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -84,6 +84,9 @@ contract LM_PC_FundingPot_v1 is
     /// @notice The payment processor flag for the end timestamp.
     uint8 internal constant FLAG_END = 3;
 
+    /// @notice Maximum amount for the base personal cap
+    uint internal constant BASE_PERSONAL_CAP = 500;
+
     // -------------------------------------------------------------------------
     // State
 
@@ -425,52 +428,20 @@ contract LM_PC_FundingPot_v1 is
             revert Module__LM_PC_FundingPot__InvalidDepositAmount();
         }
 
-        Round storage round = rounds[roundId_];
+        // Validate round and access criteria
+        Round storage round =
+            _validateRoundAndAccessCriteria(roundId_, accessId_, merkleProof_);
 
-        // Validate round exists.
-        if (round.roundEnd == 0 && round.roundCap == 0) {
-            revert Module__LM_PC_FundingPot__RoundNotCreated();
-        }
+        // Check timing and caps based on privileges
+        (uint adjustedAmount, bool canOverrideTimeAndCap) =
+            _validateTimingAndCaps(roundId_, accessId_, amount_, round);
 
-        // Validate round timing.
-        uint currentTime = block.timestamp;
-        if (currentTime < round.roundStart) {
-            revert Module__LM_PC_FundingPot__RoundHasNotStarted();
-        }
-        if (round.roundEnd > 0 && currentTime > round.roundEnd) {
-            revert Module__LM_PC_FundingPot__RoundHasEnded();
-        }
-
-        // Validate access criteria.
-        _validateAccessCriteria(roundId_, accessId_, merkleProof_);
-
-        // Retrieve user's previous contribution and calculate the personal cap.
-        uint userPreviousContribution =
-            _getUserContribution(roundId_, msg.sender);
-        uint userPersonalCap = _getUserPersonalCap(roundId_, msg.sender);
-
-        // Revert contribution if it would exceed the personal cap.
-        uint userRemainingCap = userPersonalCap - userPreviousContribution;
-        if (amount_ > userRemainingCap) {
-            revert Module__LM_PC_FundingPot__PersonalCapReached();
-        }
-
-        uint totalRoundContribution = _getTotalRoundContribution(roundId_);
-        if (
-            round.roundCap > 0
-                && totalRoundContribution + amount_ >= round.roundCap
-        ) {
-            revert Module__LM_PC_FundingPot__RoundCapReached();
-        }
-
-        // Transfer funds.
         IERC20(contributionToken_).safeTransferFrom(
-            msg.sender, address(this), amount_
+            msg.sender, address(this), adjustedAmount
         );
 
-        // Record the contribution.
-        _recordContribution(roundId_, msg.sender, amount_);
-        emit ContributionMade(roundId_, msg.sender, amount_);
+        _recordContribution(roundId_, msg.sender, adjustedAmount);
+        emit ContributionMade(roundId_, msg.sender, adjustedAmount);
     }
 
     // -------------------------------------------------------------------------
@@ -539,6 +510,184 @@ contract LM_PC_FundingPot_v1 is
         return _start + _cliff <= _end;
     }
 
+    /// @notice Validates the round existence and access criteria
+    /// @param roundId_ ID of the round to validate
+    /// @param accessId_ ID of the access criteria to check
+    /// @param merkleProof_ Merkle proof for validation if needed
+    /// @return round The round storage object
+    function _validateRoundAndAccessCriteria(
+        uint64 roundId_,
+        uint8 accessId_,
+        bytes32[] calldata merkleProof_
+    ) internal view returns (Round storage round) {
+        round = rounds[roundId_];
+
+        // Validate round exists.
+        if (round.roundEnd == 0 && round.roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundNotCreated();
+        }
+
+        // Validate access criteria.
+        _validateAccessCriteria(roundId_, accessId_, merkleProof_);
+
+        return round;
+    }
+
+    /// @notice Validates timing and cap constraints, adjusts amount if needed
+    /// @param roundId_ ID of the round
+    /// @param accessId_ ID of the access criteria
+    /// @param amount_ Requested contribution amount
+    /// @param round Round storage object
+    /// @return adjustedAmount The potentially adjusted contribution amount
+    /// @return canOverrideTimeAndCap Whether the user can override time and cap constraints
+    function _validateTimingAndCaps(
+        uint64 roundId_,
+        uint8 accessId_,
+        uint amount_,
+        Round storage round
+    ) internal view returns (uint adjustedAmount, bool canOverrideTimeAndCap) {
+        adjustedAmount = amount_;
+
+        // Get access criteria privileges
+        AccessCriteriaPrivilages storage privileges =
+            accessCriteriaPrivilages[roundId_][accessId_];
+
+        canOverrideTimeAndCap = privileges.overrideCap;
+
+        _validateTiming(round, privileges, canOverrideTimeAndCap);
+
+        // Handle cap validation and amount adjustment
+        adjustedAmount = _validateAndAdjustCaps(
+            roundId_, amount_, round, privileges, canOverrideTimeAndCap
+        );
+
+        return (adjustedAmount, canOverrideTimeAndCap);
+    }
+
+    /// @notice Validates timing constraints based on privileges
+    /// @param round Round storage object
+    /// @param privileges Access criteria privileges
+    /// @param canOverrideTimeAndCap Whether the user can override time constraints
+    function _validateTiming(
+        Round storage round,
+        AccessCriteriaPrivilages storage privileges,
+        bool canOverrideTimeAndCap
+    ) internal view {
+        if (canOverrideTimeAndCap) {
+            return;
+        }
+
+        uint currentTime = block.timestamp;
+
+        // Check custom timing for this access level if defined
+        uint effectiveStart =
+            privileges.start > 0 ? privileges.start : round.roundStart;
+        uint effectiveEnd = privileges.end > 0 ? privileges.end : round.roundEnd;
+
+        if (currentTime < effectiveStart) {
+            revert Module__LM_PC_FundingPot__RoundHasNotStarted();
+        }
+        if (effectiveEnd > 0 && currentTime > effectiveEnd) {
+            revert Module__LM_PC_FundingPot__RoundHasEnded();
+        }
+    }
+
+    /// @notice Validates cap constraints and adjusts amount if needed
+    /// @param roundId_ ID of the round
+    /// @param amount_ Requested contribution amount
+    /// @param round Round storage object
+    /// @param privileges Access criteria privileges
+    /// @param canOverrideTimeAndCap Whether the user can override cap constraints
+    /// @return adjustedAmount The potentially adjusted contribution amount
+    function _validateAndAdjustCaps(
+        uint64 roundId_,
+        uint amount_,
+        Round storage round,
+        AccessCriteriaPrivilages storage privileges,
+        bool canOverrideTimeAndCap
+    ) internal view returns (uint adjustedAmount) {
+        adjustedAmount = amount_;
+
+        if (!canOverrideTimeAndCap && round.roundCap > 0) {
+            uint totalRoundContribution = _getTotalRoundContribution(roundId_);
+            uint effectiveRoundCap = round.roundCap;
+
+            // If global accumulative caps are enabled, add unused capacity from previous rounds
+            if (round.globalAccumulativeCaps) {
+                uint unusedCapacityFromPrevious = 0;
+                for (uint64 i = 1; i < roundId_; i++) {
+                    Round storage prevRound = rounds[i];
+                    if (!prevRound.globalAccumulativeCaps) continue;
+
+                    uint prevRoundTotal = _getTotalRoundContribution(i);
+                    if (prevRoundTotal < prevRound.roundCap) {
+                        unusedCapacityFromPrevious +=
+                            (prevRound.roundCap - prevRoundTotal);
+                    }
+                }
+                effectiveRoundCap += unusedCapacityFromPrevious;
+            }
+
+            if (totalRoundContribution >= effectiveRoundCap) {
+                revert Module__LM_PC_FundingPot__RoundCapReached();
+            }
+
+            // Adjust for remaining round cap
+            uint remainingRoundCap = effectiveRoundCap - totalRoundContribution;
+            if (adjustedAmount > remainingRoundCap) {
+                adjustedAmount = remainingRoundCap;
+            }
+        }
+
+        // Check and adjust for personal cap
+        uint userPreviousContribution =
+            _getUserContribution(roundId_, msg.sender);
+        uint userPersonalCap = privileges.personalCap > 0
+            ? privileges.personalCap
+            : _getUserPersonalCap(roundId_, msg.sender);
+
+        if (userPreviousContribution + adjustedAmount > userPersonalCap) {
+            if (userPreviousContribution < userPersonalCap) {
+                adjustedAmount = userPersonalCap - userPreviousContribution;
+            } else {
+                revert Module__LM_PC_FundingPot__PersonalCapReached();
+            }
+        }
+
+        return adjustedAmount;
+    }
+
+    /// @notice Helper function to check if a user meets specific access criteria
+    /// @param accessCriteria_ The access criteria to check against
+    /// @param user_ The user address to validate
+    /// @param merkleProof_ Optional merkle proof for merkle-based validation
+    /// @return (bool, AccessCriteriaId) Returns success and the access criteria type used
+    function _checkAccessCriteriaEligibility(
+        AccessCriteria storage accessCriteria_,
+        address user_,
+        bytes32[] memory merkleProof_
+    ) internal view returns (bool, AccessCriteriaId) {
+        AccessCriteriaId criteriaId = accessCriteria_.accessCriteriaId;
+
+        if (criteriaId == AccessCriteriaId.OPEN) {
+            return (true, criteriaId);
+        }
+        bool isValid;
+        if (criteriaId == AccessCriteriaId.NFT) {
+            isValid = _checkNftOwnership(accessCriteria_.nftContract, user_);
+        } else if (criteriaId == AccessCriteriaId.MERKLE) {
+            isValid = _validateMerkleProof(
+                accessCriteria_.merkleRoot, user_, merkleProof_
+            );
+        } else if (criteriaId == AccessCriteriaId.LIST) {
+            isValid = _checkAllowedAddressList(
+                accessCriteria_.allowedAddresses, user_
+            );
+        }
+
+        return (isValid, criteriaId);
+    }
+
     /// @notice Validates access criteria for a specific round and access type
     /// @dev    Checks if a user meets the access requirements based on the round's access criteria
     /// @param  roundId_ The ID of the round being validated
@@ -556,18 +705,19 @@ contract LM_PC_FundingPot_v1 is
             return;
         }
 
-        bool accessGranted = false;
-        if (accessCriteria.accessCriteriaId == AccessCriteriaId.NFT) {
-            accessGranted =
-                _checkNftOwnership(accessCriteria.nftContract, msg.sender);
-        } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.MERKLE) {
-            accessGranted = _validateMerkleProof(
-                accessCriteria.merkleRoot, msg.sender, merkleProof_
-            );
-        } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.LIST) {
-            accessGranted = _checkAllowedAddressList(
-                accessCriteria.allowedAddresses, msg.sender
-            );
+        (bool isValid, AccessCriteriaId criteriaId) =
+        _checkAccessCriteriaEligibility(
+            accessCriteria, msg.sender, merkleProof_
+        );
+
+        if (!isValid) {
+            if (criteriaId == AccessCriteriaId.NFT) {
+                revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
+            } else if (criteriaId == AccessCriteriaId.MERKLE) {
+                revert Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();
+            } else if (criteriaId == AccessCriteriaId.LIST) {
+                revert Module__LM_PC_FundingPot__AccessCriteriaListFailed();
+            }
         }
     }
 
@@ -606,15 +756,14 @@ contract LM_PC_FundingPot_v1 is
         view
         returns (uint)
     {
-        uint basePersonalCap = 500;
         Round storage round = rounds[roundId_];
 
         if (round.globalAccumulativeCaps) {
             uint unusedCapacity =
                 _getUnusedCapacityFromPreviousRounds(user_, roundId_);
-            return basePersonalCap + unusedCapacity;
+            return BASE_PERSONAL_CAP + unusedCapacity;
         }
-        return basePersonalCap;
+        return BASE_PERSONAL_CAP;
     }
 
     /// @notice Calculates unused contribution capacity from previous rounds
@@ -627,30 +776,37 @@ contract LM_PC_FundingPot_v1 is
         uint64 currentRoundId_
     ) internal view returns (uint) {
         uint totalUnusedCapacity = 0;
+        bytes32[] memory emptyProof = new bytes32[](0);
+
         for (uint64 i = 1; i < currentRoundId_; i++) {
             Round storage prevRound = rounds[i];
-            if (!prevRound.globalAccumulativeCaps) {
-                continue;
+            if (!prevRound.globalAccumulativeCaps) continue;
+
+            uint personalCap = BASE_PERSONAL_CAP;
+
+            // Check if there were specific privileges for this user in previous rounds
+            for (uint8 j = 0; j < 4; j++) {
+                AccessCriteria storage accessCriteria =
+                    prevRound.accessCriterias[j];
+                (bool isValid,) = _checkAccessCriteriaEligibility(
+                    accessCriteria, user_, emptyProof
+                );
+
+                if (isValid) {
+                    AccessCriteriaPrivilages storage privileges =
+                        accessCriteriaPrivilages[i][j];
+                    if (privileges.personalCap > personalCap) {
+                        personalCap = privileges.personalCap;
+                    }
+                }
             }
-            uint personalCap = 1000 ether;
+
             uint userContribution = _getUserContribution(i, user_);
             if (userContribution < personalCap) {
                 totalUnusedCapacity += (personalCap - userContribution);
             }
         }
         return totalUnusedCapacity;
-    }
-
-    /// @notice Records a contribution for a user in a specific round
-    /// @dev    Updates the user's contribution and the total round contribution
-    /// @param  roundId_ The ID of the round
-    /// @param  user_ The address of the user making the contribution
-    /// @param  amount_ The amount of the contribution
-    function _recordContribution(uint64 roundId_, address user_, uint amount_)
-        internal
-    {
-        userContributions[roundId_][user_] += amount_;
-        roundTotalContributions[roundId_] += amount_;
     }
 
     ///@notice Checks if a sender is in a list of allowed addresses
@@ -668,7 +824,6 @@ contract LM_PC_FundingPot_v1 is
             }
         }
         revert Module__LM_PC_FundingPot__AccessCriteriaListFailed();
-        return false;
     }
 
     /// @notice Verifies NFT ownership for access control
@@ -695,15 +850,35 @@ contract LM_PC_FundingPot_v1 is
         }
     }
 
+    /// @notice Verifies a Merkle proof for access control
+    /// @dev    Validates that the user's address is part of the Merkle tree
+    /// @param  root_ The Merkle root to validate against
+    /// @param  user_ The address of the user to check
+    /// @param  merkleProof_ The Merkle proof to verify
+    /// @return Boolean indicating whether the proof is valid
     function _validateMerkleProof(
         bytes32 root_,
         address user_,
-        bytes32[] calldata merkleProof_
+        bytes32[] memory merkleProof_
     ) internal pure returns (bool) {
         bytes32 leaf = keccak256(abi.encodePacked(user_));
 
         if (!MerkleProof.verify(merkleProof_, root_, leaf)) {
             revert Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();
         }
+
+        return true;
+    }
+
+    /// @notice Records a contribution for a user in a specific round
+    /// @dev    Updates the user's contribution and the total round contribution
+    /// @param  roundId_ The ID of the round
+    /// @param  user_ The address of the user making the contribution
+    /// @param  amount_ The amount of the contribution
+    function _recordContribution(uint64 roundId_, address user_, uint amount_)
+        internal
+    {
+        userContributions[roundId_][user_] += amount_;
+        roundTotalContributions[roundId_] += amount_;
     }
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -200,16 +200,20 @@ contract LM_PC_FundingPot_v1 is
             round.globalAccumulativeCaps
         );
     }
-
+    /// TODO should either have a param for a specifc address
+    /// and return whether they have access or not
+    /// or should not return anything related to allowed addresses
+    /// Though I think the first option is better
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundAccessCriteria(uint64 roundId_, uint8 id_)
+
+    function getRoundAccessCriteria(uint64 roundId_, uint8 id_, address user_)
         external
         view
         returns (
             bool isRoundOpen_,
             address nftContract_,
             bytes32 merkleRoot_,
-            address[] memory allowedAddresses_
+            bool hasAccess_
         )
     {
         Round storage round = rounds[roundId_];
@@ -220,7 +224,8 @@ contract LM_PC_FundingPot_v1 is
                 true,
                 accessCriteria.nftContract,
                 accessCriteria.merkleRoot,
-                accessCriteria.allowedAddresses
+                //// This is wrong but gives you an idea of what you need to do
+                accessCriteria.allowedAddresses[user_]
             );
         } else {
             return (
@@ -358,8 +363,10 @@ contract LM_PC_FundingPot_v1 is
             globalAccumulativeCaps_
         );
     }
-
+    // TODO should take in nft merkle root and list of allowed addresses
+    // SHould loop through the array and set the access criteria for each address to true in the mapping
     /// @inheritdoc ILM_PC_FundingPot_v1
+
     function setAccessCriteriaForRound(
         uint64 roundId_,
         AccessCriteria memory accessCriteria_
@@ -369,6 +376,7 @@ contract LM_PC_FundingPot_v1 is
         _validateEditRoundParameters(round);
 
         if (
+            /// TODO this would just check that the array being passed in is empty
             (
                 accessCriteria_.accessCriteriaType == AccessCriteriaType.NFT
                     && accessCriteria_.nftContract == address(0)
@@ -874,6 +882,7 @@ contract LM_PC_FundingPot_v1 is
     /// @param  allowedAddresses_ Array of addresses permitted to participate
     /// @param  sender_ Address to check for permission
     /// @return Boolean indicating whether the sender is in the allowed list
+    /// TODO should check for address in mapping instead of looping through array
     function _checkAllowedAddressList(
         address[] memory allowedAddresses_,
         address sender_

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -585,11 +585,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         adjustedAmount = _validateAndAdjustCaps(
-            roundId_,
-            amount_,
-            round,
-            accessCriteriaId_,
-            canOverrideContributionSpan
+            roundId_, amount_, accessCriteriaId_, canOverrideContributionSpan
         );
 
         return adjustedAmount;
@@ -598,25 +594,25 @@ contract LM_PC_FundingPot_v1 is
     /// @notice Validates cap constraints and adjusts amount if needed
     /// @param roundId_ ID of the round
     /// @param amount_ Requested contribution amount
-    /// @param round_ Round storage object
     /// @param canOverrideContributionSpan_ Whether the user can override cap constraints
     /// @return adjustedAmount The potentially adjusted contribution amount
     function _validateAndAdjustCaps(
         uint64 roundId_,
         uint amount_,
-        Round storage round_,
         uint8 accessId_,
         bool canOverrideContributionSpan_
     ) internal view returns (uint adjustedAmount) {
         adjustedAmount = amount_;
 
-        if (!canOverrideContributionSpan_ && round_.roundCap > 0) {
+        Round storage round = rounds[roundId_];
+
+        if (!canOverrideContributionSpan_ && round.roundCap > 0) {
             uint totalRoundContribution = _getTotalRoundContribution(roundId_);
-            uint effectiveRoundCap = round_.roundCap;
+            uint effectiveRoundCap = round.roundCap;
 
             // If global accumulative caps are enabled,
             // adjust the round cap to acommodate unused capacity from previous rounds
-            if (round_.globalAccumulativeCaps) {
+            if (round.globalAccumulativeCaps) {
                 uint unusedCapacityFromPrevious = 0;
                 for (uint64 i = 1; i < roundId_; ++i) {
                     Round storage prevRound = rounds[i];

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -97,8 +97,8 @@ contract LM_PC_FundingPot_v1 is
     mapping(uint64 => uint8) private roundIdtoAccessId;
     /// @notice Stores all access criteria privilages by their unique ID.
     mapping(
-        uint64 roundId => mapping(uint8 accessId => AccessCriteriaPrivilages)
-    ) private accessCriteriaPrivilages;
+        uint64 roundId => mapping(uint8 accessId => AccessCriteriaPrivileges)
+    ) private accessCriteriaPrivileges;
 
     /// @notice Maps round IDs to user addresses to contribution amounts
     mapping(uint64 => mapping(address => uint)) private userContributions;
@@ -106,8 +106,11 @@ contract LM_PC_FundingPot_v1 is
     /// @notice Maps round IDs to total contributions
     mapping(uint64 => uint) private roundTotalContributions;
 
-    /// @notice The next available round ID.
-    uint64 private nextRoundId;
+    /// @notice The current round count.
+    uint64 private roundCount;
+
+    /// @notice The token used for contributions.
+    IERC20 private contributionToken;
 
     /// @notice Storage gap for future upgrades.
     uint[50] private __gap;
@@ -130,7 +133,7 @@ contract LM_PC_FundingPot_v1 is
         bytes memory configData_
     ) external override(Module_v1) initializer {
         __Module_init(orchestrator_, metadata_);
-
+        address fundingPotToken;
         // Set the flags for the PaymentOrders (this module uses 3 flags).
         bytes32 flags;
         flags |= bytes32(1 << FLAG_START);
@@ -138,6 +141,8 @@ contract LM_PC_FundingPot_v1 is
         flags |= bytes32(1 << FLAG_END);
 
         __ERC20PaymentClientBase_v2_init(flags);
+
+        contributionToken = IERC20(address(fundingPotToken));
     }
 
     // -------------------------------------------------------------------------
@@ -193,7 +198,7 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundAccessCriteriaPrivilages(uint64 roundId_, uint8 accessId_)
+    function getRoundAccessCriteriaPrivileges(uint64 roundId_, uint8 accessId_)
         external
         view
         returns (
@@ -213,8 +218,8 @@ contract LM_PC_FundingPot_v1 is
         }
 
         // Store the privileges in a local variable to reduce stack usage.
-        AccessCriteriaPrivilages storage privs =
-            accessCriteriaPrivilages[roundId_][accessId_];
+        AccessCriteriaPrivileges storage privs =
+            accessCriteriaPrivileges[roundId_][accessId_];
 
         return (
             false,
@@ -228,7 +233,7 @@ contract LM_PC_FundingPot_v1 is
 
     /// @inheritdoc ILM_PC_FundingPot_v1
     function getRoundCount() external view returns (uint64) {
-        return nextRoundId;
+        return roundCount;
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -253,9 +258,9 @@ contract LM_PC_FundingPot_v1 is
         bool autoClosure_,
         bool globalAccumulativeCaps_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (uint64) {
-        nextRoundId++;
+        roundCount++;
 
-        uint64 roundId = nextRoundId;
+        uint64 roundId = roundCount;
 
         Round storage round = rounds[roundId];
         round.roundStart = roundStart_;
@@ -371,14 +376,14 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function setAccessCriteriaPrivilages(
+    function setAccessCriteriaPrivileges(
         uint64 roundId_,
         uint8 accessId_,
         uint personalCap_,
         bool overrideCap_,
-        uint _start,
-        uint _cliff,
-        uint _end
+        uint start_,
+        uint cliff_,
+        uint end_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
 
@@ -389,29 +394,29 @@ contract LM_PC_FundingPot_v1 is
                 == AccessCriteriaId.OPEN
         ) {
             revert
-                Module__LM_PC_FundingPot__CannotSetPrivilagesForOpenAccessCriteria();
+                Module__LM_PC_FundingPot__CannotSetPrivilegesForOpenAccessCriteria();
         }
-        if (!_validTimes(_start, _cliff, _end)) {
+        if (!_validTimes(start_, cliff_, end_)) {
             revert Module__LM_PC_FundingPot__InvalidTimes();
         }
 
-        AccessCriteriaPrivilages storage accessCriteriaPrivilages =
-            accessCriteriaPrivilages[roundId_][accessId_];
+        AccessCriteriaPrivileges storage accessCriteriaPrivileges =
+            accessCriteriaPrivileges[roundId_][accessId_];
 
-        accessCriteriaPrivilages.personalCap = personalCap_;
-        accessCriteriaPrivilages.overrideCap = overrideCap_;
-        accessCriteriaPrivilages.start = _start;
-        accessCriteriaPrivilages.cliff = _cliff;
-        accessCriteriaPrivilages.end = _end;
+        accessCriteriaPrivileges.personalCap = personalCap_;
+        accessCriteriaPrivileges.overrideCap = overrideCap_;
+        accessCriteriaPrivileges.start = start_;
+        accessCriteriaPrivileges.cliff = cliff_;
+        accessCriteriaPrivileges.end = end_;
 
-        emit AccessCriteriaPrivilagesSet(
+        emit AccessCriteriaPrivilegesSet(
             roundId_,
             accessId_,
             personalCap_,
             overrideCap_,
-            _start,
-            _cliff,
-            _end
+            start_,
+            cliff_,
+            end_
         );
     }
 
@@ -419,8 +424,7 @@ contract LM_PC_FundingPot_v1 is
     function contributeToRound(
         uint64 roundId_,
         uint amount_,
-        uint8 accessId_,
-        address contributionToken_,
+        uint8 accessCriteriaId_,
         bytes32[] calldata merkleProof_
     ) external {
         // Validate input amount.
@@ -429,18 +433,20 @@ contract LM_PC_FundingPot_v1 is
         }
 
         // Validate round and access criteria
-        Round storage round =
-            _validateRoundAndAccessCriteria(roundId_, accessId_, merkleProof_);
+        Round storage round = _validateRoundAndAccessCriteria(
+            roundId_, accessCriteriaId_, merkleProof_
+        );
 
         // Check timing and caps based on privileges
         (uint adjustedAmount, bool canOverrideTimeAndCap) =
-            _validateTimingAndCaps(roundId_, accessId_, amount_, round);
+            _validateTimingAndCaps(roundId_, accessCriteriaId_, amount_, round);
 
-        IERC20(contributionToken_).safeTransferFrom(
+        _recordContribution(roundId_, msg.sender, adjustedAmount);
+
+        IERC20(contributionToken).safeTransferFrom(
             msg.sender, address(this), adjustedAmount
         );
 
-        _recordContribution(roundId_, msg.sender, adjustedAmount);
         emit ContributionMade(roundId_, msg.sender, adjustedAmount);
     }
 
@@ -496,18 +502,18 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @dev    Validate uint start input.
-    /// @param  _start uint to validate.
-    /// @param  _cliff uint to validate.
-    /// @param  _end uint to validate.
+    /// @param  start_ uint to validate.
+    /// @param  cliff_ uint to validate.
+    /// @param  end_ uint to validate.
     /// @return True if uint is valid.
-    function _validTimes(uint _start, uint _cliff, uint _end)
+    function _validTimes(uint start_, uint cliff_, uint end_)
         internal
         pure
         returns (bool)
     {
-        // _start + _cliff should be less or equal to _end
-        // this already implies that _start is not greater than _end
-        return _start + _cliff <= _end;
+        // start_ + cliff_ should be less or equal to end_
+        // this already implies that start_ is not greater than end_
+        return start_ + cliff_ <= end_;
     }
 
     /// @notice Validates the round existence and access criteria
@@ -537,43 +543,43 @@ contract LM_PC_FundingPot_v1 is
     /// @param roundId_ ID of the round
     /// @param accessId_ ID of the access criteria
     /// @param amount_ Requested contribution amount
-    /// @param round Round storage object
+    /// @param round_ Round storage object
     /// @return adjustedAmount The potentially adjusted contribution amount
     /// @return canOverrideTimeAndCap Whether the user can override time and cap constraints
     function _validateTimingAndCaps(
         uint64 roundId_,
         uint8 accessId_,
         uint amount_,
-        Round storage round
+        Round storage round_
     ) internal view returns (uint adjustedAmount, bool canOverrideTimeAndCap) {
         adjustedAmount = amount_;
 
         // Get access criteria privileges
-        AccessCriteriaPrivilages storage privileges =
-            accessCriteriaPrivilages[roundId_][accessId_];
+        AccessCriteriaPrivileges storage privileges =
+            accessCriteriaPrivileges[roundId_][accessId_];
 
         canOverrideTimeAndCap = privileges.overrideCap;
 
-        _validateTiming(round, privileges, canOverrideTimeAndCap);
+        _validateTiming(round_, privileges, canOverrideTimeAndCap);
 
         // Handle cap validation and amount adjustment
         adjustedAmount = _validateAndAdjustCaps(
-            roundId_, amount_, round, privileges, canOverrideTimeAndCap
+            roundId_, amount_, round_, privileges, canOverrideTimeAndCap
         );
 
         return (adjustedAmount, canOverrideTimeAndCap);
     }
 
     /// @notice Validates timing constraints based on privileges
-    /// @param round Round storage object
-    /// @param privileges Access criteria privileges
-    /// @param canOverrideTimeAndCap Whether the user can override time constraints
+    /// @param round_ Round storage object
+    /// @param privileges_ Access criteria privileges
+    /// @param canOverrideTimeAndCap_ Whether the user can override time constraints
     function _validateTiming(
-        Round storage round,
-        AccessCriteriaPrivilages storage privileges,
-        bool canOverrideTimeAndCap
+        Round storage round_,
+        AccessCriteriaPrivileges storage privileges_,
+        bool canOverrideTimeAndCap_
     ) internal view {
-        if (canOverrideTimeAndCap) {
+        if (canOverrideTimeAndCap_) {
             return;
         }
 
@@ -581,8 +587,9 @@ contract LM_PC_FundingPot_v1 is
 
         // Check custom timing for this access level if defined
         uint effectiveStart =
-            privileges.start > 0 ? privileges.start : round.roundStart;
-        uint effectiveEnd = privileges.end > 0 ? privileges.end : round.roundEnd;
+            privileges_.start > 0 ? privileges_.start : round_.roundStart;
+        uint effectiveEnd =
+            privileges_.end > 0 ? privileges_.end : round_.roundEnd;
 
         if (currentTime < effectiveStart) {
             revert Module__LM_PC_FundingPot__RoundHasNotStarted();
@@ -595,27 +602,27 @@ contract LM_PC_FundingPot_v1 is
     /// @notice Validates cap constraints and adjusts amount if needed
     /// @param roundId_ ID of the round
     /// @param amount_ Requested contribution amount
-    /// @param round Round storage object
-    /// @param privileges Access criteria privileges
-    /// @param canOverrideTimeAndCap Whether the user can override cap constraints
+    /// @param round_ Round storage object
+    /// @param privileges_ Access criteria privileges
+    /// @param canOverrideTimeAndCap_ Whether the user can override cap constraints
     /// @return adjustedAmount The potentially adjusted contribution amount
     function _validateAndAdjustCaps(
         uint64 roundId_,
         uint amount_,
-        Round storage round,
-        AccessCriteriaPrivilages storage privileges,
-        bool canOverrideTimeAndCap
+        Round storage round_,
+        AccessCriteriaPrivileges storage privileges_,
+        bool canOverrideTimeAndCap_
     ) internal view returns (uint adjustedAmount) {
         adjustedAmount = amount_;
 
-        if (!canOverrideTimeAndCap && round.roundCap > 0) {
+        if (!canOverrideTimeAndCap_ && round_.roundCap > 0) {
             uint totalRoundContribution = _getTotalRoundContribution(roundId_);
-            uint effectiveRoundCap = round.roundCap;
+            uint effectiveRoundCap = round_.roundCap;
 
             // If global accumulative caps are enabled, add unused capacity from previous rounds
-            if (round.globalAccumulativeCaps) {
+            if (round_.globalAccumulativeCaps) {
                 uint unusedCapacityFromPrevious = 0;
-                for (uint64 i = 1; i < roundId_; i++) {
+                for (uint64 i = 1; i < roundId_; ++i) {
                     Round storage prevRound = rounds[i];
                     if (!prevRound.globalAccumulativeCaps) continue;
 
@@ -642,8 +649,8 @@ contract LM_PC_FundingPot_v1 is
         // Check and adjust for personal cap
         uint userPreviousContribution =
             _getUserContribution(roundId_, msg.sender);
-        uint userPersonalCap = privileges.personalCap > 0
-            ? privileges.personalCap
+        uint userPersonalCap = privileges_.personalCap > 0
+            ? privileges_.personalCap
             : _getUserPersonalCap(roundId_, msg.sender);
 
         if (userPreviousContribution + adjustedAmount > userPersonalCap) {
@@ -778,14 +785,14 @@ contract LM_PC_FundingPot_v1 is
         uint totalUnusedCapacity = 0;
         bytes32[] memory emptyProof = new bytes32[](0);
 
-        for (uint64 i = 1; i < currentRoundId_; i++) {
+        for (uint64 i = 1; i < currentRoundId_; ++i) {
             Round storage prevRound = rounds[i];
             if (!prevRound.globalAccumulativeCaps) continue;
 
             uint personalCap = BASE_PERSONAL_CAP;
 
             // Check if there were specific privileges for this user in previous rounds
-            for (uint8 j = 0; j < 4; j++) {
+            for (uint8 j = 0; j < 4; ++j) {
                 AccessCriteria storage accessCriteria =
                     prevRound.accessCriterias[j];
                 (bool isValid,) = _checkAccessCriteriaEligibility(
@@ -793,8 +800,8 @@ contract LM_PC_FundingPot_v1 is
                 );
 
                 if (isValid) {
-                    AccessCriteriaPrivilages storage privileges =
-                        accessCriteriaPrivilages[i][j];
+                    AccessCriteriaPrivileges storage privileges =
+                        accessCriteriaPrivileges[i][j];
                     if (privileges.personalCap > personalCap) {
                         personalCap = privileges.personalCap;
                     }
@@ -811,15 +818,16 @@ contract LM_PC_FundingPot_v1 is
 
     ///@notice Checks if a sender is in a list of allowed addresses
     /// @dev    Performs a linear search to validate address inclusion
-    /// @param  allowedAddresses Array of addresses permitted to participate
-    /// @param  sender Address to check for permission
+    /// @param  allowedAddresses_ Array of addresses permitted to participate
+    /// @param  sender_ Address to check for permission
     /// @return Boolean indicating whether the sender is in the allowed list
     function _checkAllowedAddressList(
-        address[] memory allowedAddresses,
-        address sender
+        address[] memory allowedAddresses_,
+        address sender_
     ) internal pure returns (bool) {
-        for (uint i = 0; i < allowedAddresses.length; i++) {
-            if (allowedAddresses[i] == sender) {
+        uint lengthOfAddresses = allowedAddresses_.length;
+        for (uint i = 0; i < lengthOfAddresses; ++i) {
+            if (allowedAddresses_[i] == sender_) {
                 return true;
             }
         }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -92,7 +92,8 @@ contract LM_PC_FundingPot_v1 is
 
     /// @notice Stores all access criteria privilages by their unique ID.
     mapping(
-        uint64 roundId => mapping(uint8 accessId => AccessCriteriaPrivileges)
+        uint64 roundId
+            => mapping(uint8 accessCriteriaId_ => AccessCriteriaPrivileges)
     ) private accessCriteriaPrivileges;
 
     /// @notice Maps round IDs to user addresses to contribution amounts
@@ -205,7 +206,10 @@ contract LM_PC_FundingPot_v1 is
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
-    function getRoundAccessCriteriaPrivileges(uint64 roundId_, uint8 accessId_)
+    function getRoundAccessCriteriaPrivileges(
+        uint64 roundId_,
+        uint8 accessCriteriaId__
+    )
         external
         view
         returns (
@@ -218,7 +222,8 @@ contract LM_PC_FundingPot_v1 is
         )
     {
         Round storage round = rounds[roundId_];
-        AccessCriteria storage accessCriteria = round.accessCriterias[accessId_];
+        AccessCriteria storage accessCriteria =
+            round.accessCriterias[accessCriteriaId__];
 
         if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
             return (true, 0, false, 0, 0, 0);
@@ -226,7 +231,7 @@ contract LM_PC_FundingPot_v1 is
 
         // Store the privileges in a local variable to reduce stack usage.
         AccessCriteriaPrivileges storage privs =
-            accessCriteriaPrivileges[roundId_][accessId_];
+            accessCriteriaPrivileges[roundId_][accessCriteriaId__];
 
         return (
             false,
@@ -352,10 +357,10 @@ contract LM_PC_FundingPot_v1 is
         ) {
             revert Module__LM_PC_FundingPot__MissingRequiredAccessCriteriaData();
         }
-        uint8 accessID = uint8(accessCriteria_.accessCriteriaType);
-        round.accessCriterias[accessID] = accessCriteria_;
+        uint8 accessCriteriaId_ = uint8(accessCriteria_.accessCriteriaType);
+        round.accessCriterias[accessCriteriaId_] = accessCriteria_;
 
-        emit AccessCriteriaSet(roundId_, accessID, accessCriteria_);
+        emit AccessCriteriaSet(roundId_, accessCriteriaId_, accessCriteria_);
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -379,7 +384,7 @@ contract LM_PC_FundingPot_v1 is
     /// @inheritdoc ILM_PC_FundingPot_v1
     function setAccessCriteriaPrivileges(
         uint64 roundId_,
-        uint8 accessId_,
+        uint8 accessCriteriaId__,
         uint personalCap_,
         uint capByNFT_,
         uint capByMerkle_,
@@ -396,14 +401,14 @@ contract LM_PC_FundingPot_v1 is
         _validateEditRoundParameters(round);
 
         if (
-            round.accessCriterias[accessId_].accessCriteriaType
+            round.accessCriterias[accessCriteriaId__].accessCriteriaType
                 == AccessCriteriaType.OPEN
         ) {
             highestCap = personalCap_;
         }
 
         if (
-            round.accessCriterias[accessId_].accessCriteriaType
+            round.accessCriterias[accessCriteriaId__].accessCriteriaType
                 == AccessCriteriaType.NFT && capByNFT_ > 0
         ) {
             uint nftCap = personalCap_ + capByNFT_;
@@ -413,7 +418,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         if (
-            round.accessCriterias[accessId_].accessCriteriaType
+            round.accessCriterias[accessCriteriaId__].accessCriteriaType
                 == AccessCriteriaType.MERKLE && capByMerkle_ > 0
         ) {
             uint merkleCap = personalCap_ + capByMerkle_;
@@ -423,7 +428,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         if (
-            round.accessCriterias[accessId_].accessCriteriaType
+            round.accessCriterias[accessCriteriaId__].accessCriteriaType
                 == AccessCriteriaType.LIST && capByList_ > 0
         ) {
             uint listCap = personalCap_ + capByList_;
@@ -437,7 +442,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         AccessCriteriaPrivileges storage accessCriteriaPrivileges =
-            accessCriteriaPrivileges[roundId_][accessId_];
+            accessCriteriaPrivileges[roundId_][accessCriteriaId__];
 
         accessCriteriaPrivileges.personalCap = personalCap_;
         accessCriteriaPrivileges.overrideContributionSpan =
@@ -448,7 +453,7 @@ contract LM_PC_FundingPot_v1 is
 
         emit AccessCriteriaPrivilegesSet(
             roundId_,
-            accessId_,
+            accessCriteriaId__,
             personalCap_,
             overrideContributionSpan_,
             start_,
@@ -642,7 +647,7 @@ contract LM_PC_FundingPot_v1 is
     function _validateAndAdjustCaps(
         uint64 roundId_,
         uint amount_,
-        uint8 accessId_,
+        uint8 accessCriteriaId__,
         bool canOverrideContributionSpan_
     ) internal view returns (uint adjustedAmount) {
         adjustedAmount = amount_;
@@ -684,8 +689,9 @@ contract LM_PC_FundingPot_v1 is
         // Check and adjust for personal cap
         uint userPreviousContribution =
             _getUserContributionToRound(roundId_, msg.sender);
-        uint userPersonalCap =
-            _getUserPersonalCapForRound(roundId_, accessId_, msg.sender);
+        uint userPersonalCap = _getUserPersonalCapForRound(
+            roundId_, accessCriteriaId__, msg.sender
+        );
 
         if (userPreviousContribution + adjustedAmount > userPersonalCap) {
             if (userPreviousContribution < userPersonalCap) {
@@ -766,11 +772,11 @@ contract LM_PC_FundingPot_v1 is
     /// @return The personal contribution cap for the user
     function _getUserPersonalCapForRound(
         uint64 roundId_,
-        uint8 accessId_,
+        uint8 accessCriteriaId__,
         address user_
     ) internal view returns (uint) {
         AccessCriteriaPrivileges storage privileges =
-            accessCriteriaPrivileges[roundId_][accessId_];
+            accessCriteriaPrivileges[roundId_][accessCriteriaId__];
 
         uint personalCap = privileges.personalCap;
 

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -135,9 +135,6 @@ contract LM_PC_FundingPot_v1 is
     /// @notice The current round count.
     uint64 private roundCount;
 
-    /// @notice The token used for contributions.
-    IERC20 private contributionToken;
-
     /// @notice Storage gap for future upgrades.
     uint[50] private __gap;
 
@@ -159,8 +156,6 @@ contract LM_PC_FundingPot_v1 is
         bytes memory configData_
     ) external override(Module_v1) initializer {
         __Module_init(orchestrator_, metadata_);
-        address fundingPotToken;
-        (fundingPotToken) = abi.decode(configData_, (address));
         // Set the flags for the PaymentOrders (this module uses 3 flags).
         bytes32 flags;
         flags |= bytes32(1 << FLAG_START);
@@ -168,8 +163,6 @@ contract LM_PC_FundingPot_v1 is
         flags |= bytes32(1 << FLAG_END);
 
         __ERC20PaymentClientBase_v2_init(flags);
-
-        contributionToken = IERC20(address(fundingPotToken));
     }
 
     // -------------------------------------------------------------------------
@@ -521,31 +514,60 @@ contract LM_PC_FundingPot_v1 is
         uint8 accessCriteriaId_,
         bytes32[] calldata merkleProof_
     ) external {
-        uint adjustedAmount = _validateRoundContribution(
-            roundId_, accessCriteriaId_, merkleProof_, amount_, _msgSender()
+        // Call the internal function with no additional unspent personal cap
+        _contributeToRound(
+            roundId_, amount_, accessCriteriaId_, merkleProof_, 0
         );
+    }
 
-        Round storage round = rounds[roundId_];
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function contributeToRound(
+        uint64 roundId_,
+        uint amount_,
+        uint8 accessCriteriaId_,
+        bytes32[] memory merkleProof_,
+        UnspentPersonalRoundCap[] calldata unspentPersonalRoundCaps_
+    ) external {
+        uint unspentPersonalCap = 0;
 
-        //Record contribution
-        userContributions[roundId_][_msgSender()] += adjustedAmount;
-        roundTotalContributions[roundId_] += adjustedAmount;
+        // Process each previous round cap that the user wants to carry over
+        for (uint i = 0; i < unspentPersonalRoundCaps_.length; i++) {
+            UnspentPersonalRoundCap memory roundCap =
+                unspentPersonalRoundCaps_[i];
 
-        IERC20(contributionToken).safeTransferFrom(
-            _msgSender(), address(this), adjustedAmount
-        );
+            Round storage prevRound = rounds[roundCap.roundId];
+            if (!prevRound.globalAccumulativeCaps) continue;
 
-        emit ContributionMade(roundId_, _msgSender(), adjustedAmount);
+            // Verify the user was eligible for this access criteria in the previous round
+            bool isEligible = _checkAccessCriteriaEligibility(
+                roundCap.roundId,
+                roundCap.accessCriteriaId,
+                roundCap.merkleProof,
+                _msgSender()
+            );
 
-        // contribution triggers automatic closure
-        if (!roundClosed[roundId_] && round.autoClosure) {
-            bool readyToClose = _checkRoundClosureConditions(roundId_);
-            if (readyToClose) {
-                _closeRound(roundId_);
-            } else {
-                revert Module__LM_PC_FundingPot__ClosureConditionsNotMet();
+            if (isEligible) {
+                AccessCriteriaPrivileges storage privileges =
+                accessCriteriaPrivileges[roundCap.roundId][roundCap
+                    .accessCriteriaId];
+
+                uint userContribution =
+                    _getUserContributionToRound(roundCap.roundId, _msgSender());
+                uint personalCap = privileges.personalCap;
+
+                if (userContribution < personalCap) {
+                    unspentPersonalCap += (personalCap - userContribution);
+                }
             }
         }
+
+        _contributeToRound(
+            roundId_,
+            amount_,
+            accessCriteriaId_,
+            merkleProof_,
+            unspentPersonalCap
+        );
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -636,28 +658,27 @@ contract LM_PC_FundingPot_v1 is
         return start_ + cliff_ <= end_;
     }
 
-    /// @notice Validates the round existence and access criteria
-    /// @param roundId_ ID of the round to validate
-    /// @param accessCriteriaId_ ID of the access criteria to check
-    /// @param merkleProof_ Merkle proof for validation if needed
-    /// @param amount_ The amount sent by the user
-    /// @param user_ The address of the user
-    /// @return adjustedAmount The potentially adjusted contribution amount based on personal and round caps
-    function _validateRoundContribution(
+    /// @notice Contributes to a round with unused capacity from previous rounds
+    /// @param roundId_ The ID of the round to contribute to
+    /// @param amount_ The amount to contribute
+    /// @param accessCriteriaId_ The ID of the access criteria to use for this contribution
+    /// @param merkleProof_ The Merkle proof for validation if needed
+    /// @param unspentPersonalCap_ The amount of unused capacity from previous rounds
+    function _contributeToRound(
         uint64 roundId_,
-        uint8 accessCriteriaId_,
-        bytes32[] calldata merkleProof_,
         uint amount_,
-        address user_
-    ) internal view returns (uint adjustedAmount) {
-        Round storage round = rounds[roundId_];
-        uint currentTime = block.timestamp;
-        adjustedAmount = amount_;
-
+        uint8 accessCriteriaId_,
+        bytes32[] memory merkleProof_,
+        uint unspentPersonalCap_
+    ) internal {
         if (amount_ == 0) {
             revert Module__LM_PC_FundingPot__InvalidDepositAmount();
         }
-        // Validate round exists.
+
+        Round storage round = rounds[roundId_];
+        uint currentTime = block.timestamp;
+
+        // Validate round exists
         if (round.roundEnd == 0 && round.roundCap == 0) {
             revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
@@ -667,13 +688,13 @@ contract LM_PC_FundingPot_v1 is
             revert Module__LM_PC_FundingPot__RoundHasNotStarted();
         }
 
+        // Validate access criteria
         _validateAccessCriteria(
-            roundId_, accessCriteriaId_, merkleProof_, user_
+            roundId_, accessCriteriaId_, merkleProof_, _msgSender()
         );
 
         AccessCriteriaPrivileges storage privileges =
             accessCriteriaPrivileges[roundId_][accessCriteriaId_];
-
         bool canOverrideContributionSpan = privileges.overrideContributionSpan;
 
         // Allow contributions after the round end if the user can override the contribution span
@@ -684,23 +705,87 @@ contract LM_PC_FundingPot_v1 is
             revert Module__LM_PC_FundingPot__RoundHasEnded();
         }
 
-        adjustedAmount = _validateAndAdjustCaps(
-            roundId_, amount_, accessCriteriaId_, canOverrideContributionSpan
+        // Calculate the adjusted amount considering caps
+        uint adjustedAmount = _validateAndAdjustCapsWithUnspentCap(
+            roundId_,
+            amount_,
+            accessCriteriaId_,
+            canOverrideContributionSpan,
+            unspentPersonalCap_
         );
 
-        return adjustedAmount;
+        // Record contribution
+        userContributions[roundId_][_msgSender()] += adjustedAmount;
+        roundTotalContributions[roundId_] += adjustedAmount;
+
+        __Module_orchestrator.fundingManager().token().safeTransferFrom(
+            _msgSender(), address(this), adjustedAmount
+        );
+
+        emit ContributionMade(roundId_, _msgSender(), adjustedAmount);
+
+        // contribution triggers automatic closure
+        if (!roundClosed[roundId_] && round.autoClosure) {
+            bool readyToClose = _checkRoundClosureConditions(roundId_);
+            if (readyToClose) {
+                _closeRound(roundId_);
+            } else {
+                revert Module__LM_PC_FundingPot__ClosureConditionsNotMet();
+            }
+        }
     }
 
-    /// @notice Validates cap constraints and adjusts amount if needed
-    /// @param roundId_ ID of the round
-    /// @param amount_ Requested contribution amount
-    /// @param canOverrideContributionSpan_ Whether the user can override cap constraints
-    /// @return adjustedAmount The potentially adjusted contribution amount
-    function _validateAndAdjustCaps(
+    /// @notice Validates access criteria for a specific round and access type
+    /// @dev    Checks if a user meets the access requirements based on the round's access criteria
+    /// @param  roundId_ The ID of the round being validated
+    /// @param  accessCriteriaId_ The ID of the specific access criteria
+    /// @param  merkleProof_ Merkle proof for Merkle tree-based access (optional)
+    /// @param  user_ The address of the user to validate
+    function _validateAccessCriteria(
+        uint64 roundId_,
+        uint8 accessCriteriaId_,
+        bytes32[] memory merkleProof_,
+        address user_
+    ) internal view {
+        Round storage round = rounds[roundId_];
+        AccessCriteria storage accessCriteria =
+            round.accessCriterias[accessCriteriaId_];
+
+        bool isEligible = _checkAccessCriteriaEligibility(
+            roundId_, accessCriteriaId_, merkleProof_, user_
+        );
+
+        if (!isEligible) {
+            if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
+                revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
+            }
+
+            if (accessCriteria.accessCriteriaType == AccessCriteriaType.NFT) {
+                revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
+            }
+            if (accessCriteria.accessCriteriaType == AccessCriteriaType.MERKLE)
+            {
+                revert Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();
+            }
+
+            if (accessCriteria.accessCriteriaType == AccessCriteriaType.LIST) {
+                revert Module__LM_PC_FundingPot__AccessCriteriaListFailed();
+            }
+        }
+    }
+
+    /// @notice Validates and adjusts the contribution amount considering caps and unspent capacity
+    /// @param roundId_ The ID of the round to contribute to
+    /// @param amount_ The amount to contribute
+    /// @param accessCriteriaId__ The ID of the access criteria to use for this contribution
+    /// @param canOverrideContributionSpan_ Whether the contribution span can be overridden
+    /// @param unspentPersonalCap_ The amount of unused capacity from previous rounds
+    function _validateAndAdjustCapsWithUnspentCap(
         uint64 roundId_,
         uint amount_,
         uint8 accessCriteriaId__,
-        bool canOverrideContributionSpan_
+        bool canOverrideContributionSpan_,
+        uint unspentPersonalCap_
     ) internal view returns (uint adjustedAmount) {
         adjustedAmount = amount_;
 
@@ -732,9 +817,16 @@ contract LM_PC_FundingPot_v1 is
         // Check and adjust for personal cap
         uint userPreviousContribution =
             _getUserContributionToRound(roundId_, _msgSender());
-        uint userPersonalCap = _getUserPersonalCapForRound(
-            roundId_, accessCriteriaId__, _msgSender()
-        );
+
+        // Get the base personal cap for this round and criteria
+        AccessCriteriaPrivileges storage privileges =
+            accessCriteriaPrivileges[roundId_][accessCriteriaId__];
+        uint userPersonalCap = privileges.personalCap;
+
+        // Add unspent capacity if global accumulative caps are enabled
+        if (round.globalAccumulativeCaps) {
+            userPersonalCap += unspentPersonalCap_;
+        }
 
         if (userPreviousContribution + adjustedAmount > userPersonalCap) {
             if (userPreviousContribution < userPersonalCap) {
@@ -745,6 +837,46 @@ contract LM_PC_FundingPot_v1 is
         }
 
         return adjustedAmount;
+    }
+
+    /// @notice Checks if a user meets the access criteria for a specific round and access type
+    /// @dev    Returns true if the user meets the access criteria, reverts otherwise
+    /// @param  roundId_ The ID of the round being validated
+    /// @param  accessCriteriaId_ The ID of the specific access criteria
+    /// @param  merkleProof_ Merkle proof for Merkle tree-based access (optional)
+    /// @param  user_ The address of the user to validate
+    /// @return isEligible True if the user meets the access criteria, false otherwise
+    function _checkAccessCriteriaEligibility(
+        uint64 roundId_,
+        uint8 accessCriteriaId_,
+        bytes32[] memory merkleProof_,
+        address user_
+    ) internal view returns (bool isEligible) {
+        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
+            isEligible = false;
+        }
+
+        Round storage round = rounds[roundId_];
+        AccessCriteria storage accessCriteria =
+            round.accessCriterias[accessCriteriaId_];
+
+        if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
+            isEligible = true;
+        }
+        if (accessCriteria.accessCriteriaType == AccessCriteriaType.NFT) {
+            isEligible = _checkNftOwnership(accessCriteria.nftContract, user_);
+        } else if (
+            accessCriteria.accessCriteriaType == AccessCriteriaType.MERKLE
+        ) {
+            isEligible = _validateMerkleProof(
+                accessCriteria.merkleRoot, merkleProof_, user_, roundId_
+            );
+        } else if (accessCriteria.accessCriteriaType == AccessCriteriaType.LIST)
+        {
+            isEligible = accessCriteria.allowedAddresses[user_];
+        }
+
+        return isEligible;
     }
 
     /// @notice Calculates unused capacity from previous rounds
@@ -768,48 +900,6 @@ contract LM_PC_FundingPot_v1 is
             }
         }
         return unusedCapacityFromPrevious;
-    }
-
-    /// @notice Validates access criteria for a specific round and access type
-    /// @dev    Checks if a user meets the access requirements based on the round's access criteria
-    /// @param  roundId_ The ID of the round being validated
-    /// @param  accessCriteriaId_ The ID of the specific access criteria
-    /// @param  merkleProof_ Merkle proof for Merkle tree-based access (optional)
-    /// @param  user_ The address of the user to validate
-    /// @return True if the user meets the access criteria, reverts otherwise
-    function _validateAccessCriteria(
-        uint64 roundId_,
-        uint8 accessCriteriaId_,
-        bytes32[] calldata merkleProof_,
-        address user_
-    ) internal view returns (bool) {
-        Round storage round = rounds[roundId_];
-        AccessCriteria storage accessCriteria =
-            round.accessCriterias[accessCriteriaId_];
-
-        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
-            revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
-        }
-
-        if (accessCriteria.accessCriteriaType == AccessCriteriaType.NFT) {
-            return _checkNftOwnership(accessCriteria.nftContract, user_);
-        } else if (
-            accessCriteria.accessCriteriaType == AccessCriteriaType.MERKLE
-        ) {
-            return _validateMerkleProof(
-                accessCriteria.merkleRoot, merkleProof_, user_, roundId_
-            );
-        } else if (accessCriteria.accessCriteriaType == AccessCriteriaType.LIST)
-        {
-            if (!accessCriteria.allowedAddresses[user_]) {
-                revert Module__LM_PC_FundingPot__AccessCriteriaListFailed();
-            }
-
-            return true;
-        }
-
-        // For OPEN access criteria type, no validation needed
-        return true;
     }
 
     /// @notice Retrieves the total contribution for a specific round
@@ -837,66 +927,6 @@ contract LM_PC_FundingPot_v1 is
         return userContributions[roundId_][user_];
     }
 
-    /// @notice Calculates the personal contribution cap for a user in a specific round
-    /// @dev    Determines the maximum amount a user can contribute based on global or round-specific rules
-    /// @param  roundId_ The ID of the current round
-    /// @param  user_ The address of the user
-    /// @return The personal contribution cap for the user
-    function _getUserPersonalCapForRound(
-        uint64 roundId_,
-        uint8 accessCriteriaId__,
-        address user_
-    ) internal view returns (uint) {
-        AccessCriteriaPrivileges storage privileges =
-            accessCriteriaPrivileges[roundId_][accessCriteriaId__];
-
-        uint personalCap = privileges.personalCap;
-
-        Round storage round = rounds[roundId_];
-        if (round.globalAccumulativeCaps) {
-            uint unusedCapacity =
-                _getUserUnusedCapacityFromPreviousRounds(user_, roundId_);
-            return personalCap + unusedCapacity;
-        }
-        return personalCap;
-    }
-
-    /// @notice Calculates unused contribution capacity from previous rounds
-    /// @dev    Aggregates unused contribution caps from previous rounds with global accumulative caps
-    /// @param  user_ The address of the user
-    /// @param  currentRoundId_ The ID of the current round
-    /// @return Total unused contribution capacity from previous rounds
-    function _getUserUnusedCapacityFromPreviousRounds(
-        address user_,
-        uint64 currentRoundId_
-    ) internal view returns (uint) {
-        uint totalUnusedCapacity = 0;
-
-        for (uint64 i = 1; i < currentRoundId_; ++i) {
-            Round storage prevRound = rounds[i];
-            if (!prevRound.globalAccumulativeCaps) continue;
-
-            uint personalCap = 0;
-
-            // Iterate through all possible access criteria IDs (0 to MAX_ACCESS_CRITERIA_ID)
-            for (uint8 j = 0; j <= MAX_ACCESS_CRITERIA_ID; ++j) {
-                AccessCriteriaPrivileges storage privileges =
-                    accessCriteriaPrivileges[i][j];
-
-                // return only the highest personal cap from the selected access criteria
-                if (privileges.personalCap > personalCap) {
-                    personalCap = privileges.personalCap;
-                }
-            }
-
-            uint userContribution = _getUserContributionToRound(i, user_);
-            if (userContribution < personalCap) {
-                totalUnusedCapacity += (personalCap - userContribution);
-            }
-        }
-        return totalUnusedCapacity;
-    }
-
     /// @notice Verifies NFT ownership for access control
     /// @dev    Safely checks the NFT balance of a user using a try-catch block
     /// @param  nftContract_ Address of the NFT contract
@@ -913,11 +943,13 @@ contract LM_PC_FundingPot_v1 is
 
         try IERC721(nftContract_).balanceOf(user_) returns (uint balance) {
             if (balance == 0) {
-                revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
+                return false;
+                // revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
             }
             return true;
         } catch {
-            revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
+            return false;
+            // revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
         }
     }
 
@@ -937,7 +969,8 @@ contract LM_PC_FundingPot_v1 is
         bytes32 leaf = keccak256(abi.encodePacked(user_, roundId_));
 
         if (!MerkleProof.verify(merkleProof_, root_, leaf)) {
-            revert Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();
+            return false;
+            // revert Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();
         }
 
         return true;

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -103,6 +103,9 @@ contract LM_PC_FundingPot_v1 is
     /// @notice Maps round IDs to total contributions
     mapping(uint64 => uint) private roundTotalContributions;
 
+    /// @notice Maps round IDs to closed status
+    mapping(uint64 => bool) private roundClosed;
+
     /// @notice The current round count.
     uint64 private roundCount;
 
@@ -186,14 +189,21 @@ contract LM_PC_FundingPot_v1 is
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[id_];
 
-        bool isOpen =
-            (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN);
-        return (
-            isOpen,
-            accessCriteria.nftContract,
-            accessCriteria.merkleRoot,
-            accessCriteria.allowedAddresses
-        );
+        if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
+            return (
+                true,
+                accessCriteria.nftContract,
+                accessCriteria.merkleRoot,
+                accessCriteria.allowedAddresses
+            );
+        } else {
+            return (
+                false,
+                accessCriteria.nftContract,
+                accessCriteria.merkleRoot,
+                accessCriteria.allowedAddresses
+            );
+        }
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -242,6 +252,11 @@ contract LM_PC_FundingPot_v1 is
         returns (uint8 accessCriteriaCount_)
     {
         return roundIdtoAccessId[roundId_];
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function isRoundClosed(uint64 roundId_) external view returns (bool) {
+        return roundClosed[roundId_];
     }
 
     // -------------------------------------------------------------------------
@@ -463,16 +478,52 @@ contract LM_PC_FundingPot_v1 is
         bytes32[] calldata merkleProof_
     ) external {
         uint adjustedAmount = _validateRoundContribution(
-            roundId_, accessCriteriaId_, merkleProof_, amount_
+            roundId_, accessCriteriaId_, merkleProof_, amount_, msg.sender
         );
 
-        _recordContribution(roundId_, msg.sender, adjustedAmount);
+        Round storage round = rounds[roundId_];
+
+        //Record contribution
+        userContributions[roundId_][msg.sender] += adjustedAmount;
+        roundTotalContributions[roundId_] += adjustedAmount;
 
         IERC20(contributionToken).safeTransferFrom(
             msg.sender, address(this), adjustedAmount
         );
 
         emit ContributionMade(roundId_, msg.sender, adjustedAmount);
+
+        // contribution triggers automatic closure
+        if (!roundClosed[roundId_] && round.autoClosure) {
+            bool readyToClose = _checkRoundClosureConditions(roundId_);
+            if (readyToClose) {
+                _closeRound(roundId_);
+            } else {
+                revert Module__LM_PC_FundingPot__ClosureConditionsNotMet();
+            }
+        }
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function closeRound(uint64 roundId_) external {
+        Round storage round = rounds[roundId_];
+
+        // Validate round exists
+        if (round.roundEnd == 0 && round.roundCap == 0) {
+            revert Module__LM_PC_FundingPot__RoundNotCreated();
+        }
+
+        // Check if round is already closed
+        if (roundClosed[roundId_]) {
+            revert Module__LM_PC_FundingPot__RoundHasEnded();
+        }
+
+        bool readyToClose = _checkRoundClosureConditions(roundId_);
+        if (readyToClose) {
+            _closeRound(roundId_);
+        } else {
+            revert Module__LM_PC_FundingPot__ClosureConditionsNotMet();
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -546,12 +597,14 @@ contract LM_PC_FundingPot_v1 is
     /// @param accessCriteriaId_ ID of the access criteria to check
     /// @param merkleProof_ Merkle proof for validation if needed
     /// @param amount_ The amount sent by the user
+    /// @param user_ The address of the user
     /// @return adjustedAmount The potentially adjusted contribution amount based on personal and round caps
     function _validateRoundContribution(
         uint64 roundId_,
         uint8 accessCriteriaId_,
         bytes32[] calldata merkleProof_,
-        uint amount_
+        uint amount_,
+        address user_
     ) internal view returns (uint adjustedAmount) {
         Round storage round = rounds[roundId_];
         uint currentTime = block.timestamp;
@@ -570,7 +623,9 @@ contract LM_PC_FundingPot_v1 is
             revert Module__LM_PC_FundingPot__RoundHasNotStarted();
         }
 
-        _validateAccessCriteria(roundId_, accessCriteriaId_, merkleProof_);
+        _validateAccessCriteria(
+            roundId_, accessCriteriaId_, merkleProof_, user_
+        );
 
         AccessCriteriaPrivileges storage privileges =
             accessCriteriaPrivileges[roundId_][accessCriteriaId_];
@@ -664,7 +719,8 @@ contract LM_PC_FundingPot_v1 is
     function _validateAccessCriteria(
         uint64 roundId_,
         uint8 accessId_,
-        bytes32[] calldata merkleProof_
+        bytes32[] calldata merkleProof_,
+        address user_
     ) internal view {
         Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria = round.accessCriterias[accessId_];
@@ -676,18 +732,17 @@ contract LM_PC_FundingPot_v1 is
         bool accessGranted = false;
         if (accessCriteria.accessCriteriaType == AccessCriteriaType.NFT) {
             accessGranted =
-                _checkNftOwnership(accessCriteria.nftContract, msg.sender);
+                _checkNftOwnership(accessCriteria.nftContract, user_);
         } else if (
             accessCriteria.accessCriteriaType == AccessCriteriaType.MERKLE
         ) {
             accessGranted = _validateMerkleProof(
-                accessCriteria.merkleRoot, merkleProof_, msg.sender, roundId_
+                accessCriteria.merkleRoot, merkleProof_, user_, roundId_
             );
         } else if (accessCriteria.accessCriteriaType == AccessCriteriaType.LIST)
         {
-            accessGranted = _checkAllowedAddressList(
-                accessCriteria.allowedAddresses, msg.sender
-            );
+            accessGranted =
+                _checkAllowedAddressList(accessCriteria.allowedAddresses, user_);
         }
     }
 
@@ -842,15 +897,42 @@ contract LM_PC_FundingPot_v1 is
         return true;
     }
 
-    /// @notice Records a contribution for a user in a specific round
-    /// @dev    Updates the user's contribution and the total round contribution
-    /// @param  roundId_ The ID of the round
-    /// @param  user_ The address of the user making the contribution
-    /// @param  amount_ The amount of the contribution
-    function _recordContribution(uint64 roundId_, address user_, uint amount_)
+    /// @notice Handles round closure logic
+    /// @dev    Updates round status and executes hook if needed
+    /// @param  roundId_ The ID of the round to close
+    function _closeRound(uint64 roundId_) internal {
+        Round storage round = rounds[roundId_];
+
+        // Mark round as closed
+        roundClosed[roundId_] = true;
+
+        // Execute hook if configured
+        if (round.hookContract != address(0) && round.hookFunction.length > 0) {
+            (bool success,) = round.hookContract.call(round.hookFunction);
+            if (!success) {
+                revert Module__LM_PC_FundingPot__HookExecutionFailed();
+            }
+        }
+
+        // Emit event for round closure
+        emit RoundClosed(
+            roundId_, block.timestamp, roundTotalContributions[roundId_]
+        );
+    }
+
+    /// @notice Checks if a round has reached its cap or time limit
+    /// @param  roundId_ The ID of the round to check
+    /// @return Boolean indicating if the round has reached its cap or time limit
+    function _checkRoundClosureConditions(uint64 roundId_)
         internal
+        view
+        returns (bool)
     {
-        userContributions[roundId_][user_] += amount_;
-        roundTotalContributions[roundId_] += amount_;
+        Round storage round = rounds[roundId_];
+        uint totalContribution = roundTotalContributions[roundId_];
+        bool capReached =
+            round.roundCap > 0 && totalContribution == round.roundCap;
+        bool timeEnded = round.roundEnd > 0 && block.timestamp >= round.roundEnd;
+        return capReached || timeEnded;
     }
 }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -84,9 +84,6 @@ contract LM_PC_FundingPot_v1 is
     /// @notice The payment processor flag for the end timestamp.
     uint8 internal constant FLAG_END = 3;
 
-    /// @notice Maximum amount for the base personal cap
-    uint internal constant BASE_PERSONAL_CAP = 500;
-
     // -------------------------------------------------------------------------
     // State
 
@@ -205,7 +202,7 @@ contract LM_PC_FundingPot_v1 is
         returns (
             bool isRoundOpen_,
             uint personalCap_,
-            bool overrideCap_,
+            bool overrideContributionSpan_,
             uint start_,
             uint cliff_,
             uint end_
@@ -225,7 +222,7 @@ contract LM_PC_FundingPot_v1 is
         return (
             false,
             privs.personalCap,
-            privs.overrideCap,
+            privs.overrideContributionSpan,
             privs.start,
             privs.cliff,
             privs.end
@@ -381,12 +378,17 @@ contract LM_PC_FundingPot_v1 is
         uint64 roundId_,
         uint8 accessId_,
         uint personalCap_,
-        bool overrideCap_,
+        uint capByNFT_,
+        uint capByMerkle_,
+        uint capByList_,
+        bool overrideContributionSpan_,
         uint start_,
         uint cliff_,
         uint end_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
+
+        uint highestCap = 0;
 
         _validateEditRoundParameters(round);
 
@@ -394,9 +396,39 @@ contract LM_PC_FundingPot_v1 is
             round.accessCriterias[accessId_].accessCriteriaId
                 == AccessCriteriaId.OPEN
         ) {
-            revert
-                Module__LM_PC_FundingPot__CannotSetPrivilegesForOpenAccessCriteria();
+            highestCap = personalCap_;
         }
+
+        if (
+            round.accessCriterias[accessId_].accessCriteriaId
+                == AccessCriteriaId.NFT && capByNFT_ > 0
+        ) {
+            uint nftCap = personalCap_ + capByNFT_;
+            if (nftCap > highestCap) {
+                highestCap = nftCap;
+            }
+        }
+
+        if (
+            round.accessCriterias[accessId_].accessCriteriaId
+                == AccessCriteriaId.MERKLE && capByMerkle_ > 0
+        ) {
+            uint merkleCap = personalCap_ + capByMerkle_;
+            if (merkleCap > highestCap) {
+                highestCap = merkleCap;
+            }
+        }
+
+        if (
+            round.accessCriterias[accessId_].accessCriteriaId
+                == AccessCriteriaId.LIST && capByList_ > 0
+        ) {
+            uint listCap = personalCap_ + capByList_;
+            if (listCap > highestCap) {
+                highestCap = listCap;
+            }
+        }
+
         if (!_validTimes(start_, cliff_, end_)) {
             revert Module__LM_PC_FundingPot__InvalidTimes();
         }
@@ -405,7 +437,8 @@ contract LM_PC_FundingPot_v1 is
             accessCriteriaPrivileges[roundId_][accessId_];
 
         accessCriteriaPrivileges.personalCap = personalCap_;
-        accessCriteriaPrivileges.overrideCap = overrideCap_;
+        accessCriteriaPrivileges.overrideContributionSpan =
+            overrideContributionSpan_;
         accessCriteriaPrivileges.start = start_;
         accessCriteriaPrivileges.cliff = cliff_;
         accessCriteriaPrivileges.end = end_;
@@ -414,7 +447,7 @@ contract LM_PC_FundingPot_v1 is
             roundId_,
             accessId_,
             personalCap_,
-            overrideCap_,
+            overrideContributionSpan_,
             start_,
             cliff_,
             end_
@@ -428,19 +461,9 @@ contract LM_PC_FundingPot_v1 is
         uint8 accessCriteriaId_,
         bytes32[] calldata merkleProof_
     ) external {
-        // Validate input amount.
-        if (amount_ == 0) {
-            revert Module__LM_PC_FundingPot__InvalidDepositAmount();
-        }
-
-        // Validate round and access criteria
-        Round storage round = _validateRoundAndAccessCriteria(
-            roundId_, accessCriteriaId_, merkleProof_
+        uint adjustedAmount = _validateRoundContribution(
+            roundId_, accessCriteriaId_, merkleProof_, amount_
         );
-
-        // Check timing and caps based on privileges
-        (uint adjustedAmount, bool canOverrideTimeAndCap) =
-            _validateTimingAndCaps(roundId_, accessCriteriaId_, amount_, round);
 
         _recordContribution(roundId_, msg.sender, adjustedAmount);
 
@@ -519,108 +542,80 @@ contract LM_PC_FundingPot_v1 is
 
     /// @notice Validates the round existence and access criteria
     /// @param roundId_ ID of the round to validate
-    /// @param accessId_ ID of the access criteria to check
+    /// @param accessCriteriaId_ ID of the access criteria to check
     /// @param merkleProof_ Merkle proof for validation if needed
-    /// @return round The round storage object
-    function _validateRoundAndAccessCriteria(
+    /// @param amount_ The amount sent by the user
+    /// @return adjustedAmount The potentially adjusted contribution amount based on personal and round caps
+    function _validateRoundContribution(
         uint64 roundId_,
-        uint8 accessId_,
-        bytes32[] calldata merkleProof_
-    ) internal view returns (Round storage round) {
-        round = rounds[roundId_];
+        uint8 accessCriteriaId_,
+        bytes32[] calldata merkleProof_,
+        uint amount_
+    ) internal view returns (uint adjustedAmount) {
+        Round storage round = rounds[roundId_];
+        uint currentTime = block.timestamp;
+        uint adjustedAmount = amount_;
 
+        if (amount_ == 0) {
+            revert Module__LM_PC_FundingPot__InvalidDepositAmount();
+        }
         // Validate round exists.
         if (round.roundEnd == 0 && round.roundCap == 0) {
             revert Module__LM_PC_FundingPot__RoundNotCreated();
         }
 
-        // Validate access criteria.
-        _validateAccessCriteria(roundId_, accessId_, merkleProof_);
-
-        return round;
-    }
-
-    /// @notice Validates timing and cap constraints, adjusts amount if needed
-    /// @param roundId_ ID of the round
-    /// @param accessId_ ID of the access criteria
-    /// @param amount_ Requested contribution amount
-    /// @param round_ Round storage object
-    /// @return adjustedAmount The potentially adjusted contribution amount
-    /// @return canOverrideTimeAndCap Whether the user can override time and cap constraints
-    function _validateTimingAndCaps(
-        uint64 roundId_,
-        uint8 accessId_,
-        uint amount_,
-        Round storage round_
-    ) internal view returns (uint adjustedAmount, bool canOverrideTimeAndCap) {
-        adjustedAmount = amount_;
-
-        // Get access criteria privileges
-        AccessCriteriaPrivileges storage privileges =
-            accessCriteriaPrivileges[roundId_][accessId_];
-
-        canOverrideTimeAndCap = privileges.overrideCap;
-
-        _validateTiming(round_, privileges, canOverrideTimeAndCap);
-
-        // Handle cap validation and amount adjustment
-        adjustedAmount = _validateAndAdjustCaps(
-            roundId_, amount_, round_, privileges, canOverrideTimeAndCap
-        );
-
-        return (adjustedAmount, canOverrideTimeAndCap);
-    }
-
-    /// @notice Validates timing constraints based on privileges
-    /// @param round_ Round storage object
-    /// @param privileges_ Access criteria privileges
-    /// @param canOverrideTimeAndCap_ Whether the user can override time constraints
-    function _validateTiming(
-        Round storage round_,
-        AccessCriteriaPrivileges storage privileges_,
-        bool canOverrideTimeAndCap_
-    ) internal view {
-        if (canOverrideTimeAndCap_) {
-            return;
-        }
-
-        uint currentTime = block.timestamp;
-
-        // Check custom timing for this access level if defined
-        uint effectiveStart =
-            privileges_.start > 0 ? privileges_.start : round_.roundStart;
-        uint effectiveEnd =
-            privileges_.end > 0 ? privileges_.end : round_.roundEnd;
-
-        if (currentTime < effectiveStart) {
+        // Validate contribution timing
+        if (currentTime < round.roundStart) {
             revert Module__LM_PC_FundingPot__RoundHasNotStarted();
         }
-        if (effectiveEnd > 0 && currentTime > effectiveEnd) {
+
+        _validateAccessCriteria(roundId_, accessCriteriaId_, merkleProof_);
+
+        AccessCriteriaPrivileges storage privileges =
+            accessCriteriaPrivileges[roundId_][accessCriteriaId_];
+
+        bool canOverrideContributionSpan = privileges.overrideContributionSpan;
+
+        // Allow contributions after the round end if the user can override the contribution span
+        if (
+            round.roundEnd > 0 && currentTime > round.roundEnd
+                && !canOverrideContributionSpan
+        ) {
             revert Module__LM_PC_FundingPot__RoundHasEnded();
         }
+
+        adjustedAmount = _validateAndAdjustCaps(
+            roundId_,
+            amount_,
+            round,
+            accessCriteriaId_,
+            canOverrideContributionSpan
+        );
+
+        return adjustedAmount;
     }
 
     /// @notice Validates cap constraints and adjusts amount if needed
     /// @param roundId_ ID of the round
     /// @param amount_ Requested contribution amount
     /// @param round_ Round storage object
-    /// @param privileges_ Access criteria privileges
-    /// @param canOverrideTimeAndCap_ Whether the user can override cap constraints
+    /// @param canOverrideContributionSpan_ Whether the user can override cap constraints
     /// @return adjustedAmount The potentially adjusted contribution amount
     function _validateAndAdjustCaps(
         uint64 roundId_,
         uint amount_,
         Round storage round_,
-        AccessCriteriaPrivileges storage privileges_,
-        bool canOverrideTimeAndCap_
+        uint8 accessId_,
+        bool canOverrideContributionSpan_
     ) internal view returns (uint adjustedAmount) {
         adjustedAmount = amount_;
 
-        if (!canOverrideTimeAndCap_ && round_.roundCap > 0) {
+        if (!canOverrideContributionSpan_ && round_.roundCap > 0) {
             uint totalRoundContribution = _getTotalRoundContribution(roundId_);
             uint effectiveRoundCap = round_.roundCap;
 
-            // If global accumulative caps are enabled, add unused capacity from previous rounds
+            // If global accumulative caps are enabled,
+            // adjust the round cap to acommodate unused capacity from previous rounds
             if (round_.globalAccumulativeCaps) {
                 uint unusedCapacityFromPrevious = 0;
                 for (uint64 i = 1; i < roundId_; ++i) {
@@ -640,7 +635,7 @@ contract LM_PC_FundingPot_v1 is
                 revert Module__LM_PC_FundingPot__RoundCapReached();
             }
 
-            // Adjust for remaining round cap
+            // Allow the user to contribute up to the remaining round cap
             uint remainingRoundCap = effectiveRoundCap - totalRoundContribution;
             if (adjustedAmount > remainingRoundCap) {
                 adjustedAmount = remainingRoundCap;
@@ -649,10 +644,9 @@ contract LM_PC_FundingPot_v1 is
 
         // Check and adjust for personal cap
         uint userPreviousContribution =
-            _getUserContribution(roundId_, msg.sender);
-        uint userPersonalCap = privileges_.personalCap > 0
-            ? privileges_.personalCap
-            : _getUserPersonalCap(roundId_, msg.sender);
+            _getUserContributionToRound(roundId_, msg.sender);
+        uint userPersonalCap =
+            _getUserPersonalCapForRound(roundId_, accessId_, msg.sender);
 
         if (userPreviousContribution + adjustedAmount > userPersonalCap) {
             if (userPreviousContribution < userPersonalCap) {
@@ -663,37 +657,6 @@ contract LM_PC_FundingPot_v1 is
         }
 
         return adjustedAmount;
-    }
-
-    /// @notice Helper function to check if a user meets specific access criteria
-    /// @param accessCriteria_ The access criteria to check against
-    /// @param user_ The user address to validate
-    /// @param merkleProof_ Optional merkle proof for merkle-based validation
-    /// @return (bool, AccessCriteriaId) Returns success and the access criteria type used
-    function _checkAccessCriteriaEligibility(
-        AccessCriteria storage accessCriteria_,
-        address user_,
-        bytes32[] memory merkleProof_
-    ) internal view returns (bool, AccessCriteriaId) {
-        AccessCriteriaId criteriaId = accessCriteria_.accessCriteriaId;
-
-        if (criteriaId == AccessCriteriaId.OPEN) {
-            return (true, criteriaId);
-        }
-        bool isValid;
-        if (criteriaId == AccessCriteriaId.NFT) {
-            isValid = _checkNftOwnership(accessCriteria_.nftContract, user_);
-        } else if (criteriaId == AccessCriteriaId.MERKLE) {
-            isValid = _validateMerkleProof(
-                accessCriteria_.merkleRoot, user_, merkleProof_
-            );
-        } else if (criteriaId == AccessCriteriaId.LIST) {
-            isValid = _checkAllowedAddressList(
-                accessCriteria_.allowedAddresses, user_
-            );
-        }
-
-        return (isValid, criteriaId);
     }
 
     /// @notice Validates access criteria for a specific round and access type
@@ -713,19 +676,18 @@ contract LM_PC_FundingPot_v1 is
             return;
         }
 
-        (bool isValid, AccessCriteriaId criteriaId) =
-        _checkAccessCriteriaEligibility(
-            accessCriteria, msg.sender, merkleProof_
-        );
-
-        if (!isValid) {
-            if (criteriaId == AccessCriteriaId.NFT) {
-                revert Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
-            } else if (criteriaId == AccessCriteriaId.MERKLE) {
-                revert Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();
-            } else if (criteriaId == AccessCriteriaId.LIST) {
-                revert Module__LM_PC_FundingPot__AccessCriteriaListFailed();
-            }
+        bool accessGranted = false;
+        if (accessCriteria.accessCriteriaId == AccessCriteriaId.NFT) {
+            accessGranted =
+                _checkNftOwnership(accessCriteria.nftContract, msg.sender);
+        } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.MERKLE) {
+            accessGranted = _validateMerkleProof(
+                accessCriteria.merkleRoot, merkleProof_, msg.sender, roundId_
+            );
+        } else if (accessCriteria.accessCriteriaId == AccessCriteriaId.LIST) {
+            accessGranted = _checkAllowedAddressList(
+                accessCriteria.allowedAddresses, msg.sender
+            );
         }
     }
 
@@ -746,7 +708,7 @@ contract LM_PC_FundingPot_v1 is
     /// @param  roundId_ The ID of the round to check contributions for
     /// @param  user_ The address of the user
     /// @return The user's contribution amount for the specified round
-    function _getUserContribution(uint64 roundId_, address user_)
+    function _getUserContributionToRound(uint64 roundId_, address user_)
         internal
         view
         returns (uint)
@@ -759,19 +721,23 @@ contract LM_PC_FundingPot_v1 is
     /// @param  roundId_ The ID of the current round
     /// @param  user_ The address of the user
     /// @return The personal contribution cap for the user
-    function _getUserPersonalCap(uint64 roundId_, address user_)
-        internal
-        view
-        returns (uint)
-    {
-        Round storage round = rounds[roundId_];
+    function _getUserPersonalCapForRound(
+        uint64 roundId_,
+        uint8 accessId_,
+        address user_
+    ) internal view returns (uint) {
+        AccessCriteriaPrivileges storage privileges =
+            accessCriteriaPrivileges[roundId_][accessId_];
 
+        uint personalCap = privileges.personalCap;
+
+        Round storage round = rounds[roundId_];
         if (round.globalAccumulativeCaps) {
             uint unusedCapacity =
-                _getUnusedCapacityFromPreviousRounds(user_, roundId_);
-            return BASE_PERSONAL_CAP + unusedCapacity;
+                _getUserUnusedCapacityFromPreviousRounds(user_, roundId_);
+            return personalCap + unusedCapacity;
         }
-        return BASE_PERSONAL_CAP;
+        return personalCap;
     }
 
     /// @notice Calculates unused contribution capacity from previous rounds
@@ -779,37 +745,32 @@ contract LM_PC_FundingPot_v1 is
     /// @param  user_ The address of the user
     /// @param  currentRoundId_ The ID of the current round
     /// @return Total unused contribution capacity from previous rounds
-    function _getUnusedCapacityFromPreviousRounds(
+    function _getUserUnusedCapacityFromPreviousRounds(
         address user_,
         uint64 currentRoundId_
     ) internal view returns (uint) {
         uint totalUnusedCapacity = 0;
-        bytes32[] memory emptyProof = new bytes32[](0);
 
         for (uint64 i = 1; i < currentRoundId_; ++i) {
             Round storage prevRound = rounds[i];
             if (!prevRound.globalAccumulativeCaps) continue;
 
-            uint personalCap = BASE_PERSONAL_CAP;
+            uint personalCap = 0;
 
-            // Check if there were specific privileges for this user in previous rounds
             for (uint8 j = 0; j < 4; ++j) {
                 AccessCriteria storage accessCriteria =
                     prevRound.accessCriterias[j];
-                (bool isValid,) = _checkAccessCriteriaEligibility(
-                    accessCriteria, user_, emptyProof
-                );
 
-                if (isValid) {
-                    AccessCriteriaPrivileges storage privileges =
-                        accessCriteriaPrivileges[i][j];
-                    if (privileges.personalCap > personalCap) {
-                        personalCap = privileges.personalCap;
-                    }
+                AccessCriteriaPrivileges storage privileges =
+                    accessCriteriaPrivileges[i][j];
+
+                // return only the highest personal cap from the selected access criteria
+                if (privileges.personalCap > personalCap) {
+                    personalCap = privileges.personalCap;
                 }
             }
 
-            uint userContribution = _getUserContribution(i, user_);
+            uint userContribution = _getUserContributionToRound(i, user_);
             if (userContribution < personalCap) {
                 totalUnusedCapacity += (personalCap - userContribution);
             }
@@ -863,14 +824,16 @@ contract LM_PC_FundingPot_v1 is
     /// @dev    Validates that the user's address is part of the Merkle tree
     /// @param  root_ The Merkle root to validate against
     /// @param  user_ The address of the user to check
+    /// @param  roundId_ The ID of the round to check
     /// @param  merkleProof_ The Merkle proof to verify
     /// @return Boolean indicating whether the proof is valid
     function _validateMerkleProof(
         bytes32 root_,
+        bytes32[] memory merkleProof_,
         address user_,
-        bytes32[] memory merkleProof_
+        uint64 roundId_
     ) internal pure returns (bool) {
-        bytes32 leaf = keccak256(abi.encodePacked(user_));
+        bytes32 leaf = keccak256(abi.encodePacked(user_, roundId_));
 
         if (!MerkleProof.verify(merkleProof_, root_, leaf)) {
             revert Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -729,8 +729,6 @@ contract LM_PC_FundingPot_v1 is
             bool readyToClose = _checkRoundClosureConditions(roundId_);
             if (readyToClose) {
                 _closeRound(roundId_);
-            } else {
-                revert Module__LM_PC_FundingPot__ClosureConditionsNotMet();
             }
         }
     }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -522,20 +522,20 @@ contract LM_PC_FundingPot_v1 is
         bytes32[] calldata merkleProof_
     ) external {
         uint adjustedAmount = _validateRoundContribution(
-            roundId_, accessCriteriaId_, merkleProof_, amount_, msg.sender
+            roundId_, accessCriteriaId_, merkleProof_, amount_, _msgSender()
         );
 
         Round storage round = rounds[roundId_];
 
         //Record contribution
-        userContributions[roundId_][msg.sender] += adjustedAmount;
+        userContributions[roundId_][_msgSender()] += adjustedAmount;
         roundTotalContributions[roundId_] += adjustedAmount;
 
         IERC20(contributionToken).safeTransferFrom(
-            msg.sender, address(this), adjustedAmount
+            _msgSender(), address(this), adjustedAmount
         );
 
-        emit ContributionMade(roundId_, msg.sender, adjustedAmount);
+        emit ContributionMade(roundId_, _msgSender(), adjustedAmount);
 
         // contribution triggers automatic closure
         if (!roundClosed[roundId_] && round.autoClosure) {
@@ -731,9 +731,9 @@ contract LM_PC_FundingPot_v1 is
 
         // Check and adjust for personal cap
         uint userPreviousContribution =
-            _getUserContributionToRound(roundId_, msg.sender);
+            _getUserContributionToRound(roundId_, _msgSender());
         uint userPersonalCap = _getUserPersonalCapForRound(
-            roundId_, accessCriteriaId__, msg.sender
+            roundId_, accessCriteriaId__, _msgSender()
         );
 
         if (userPreviousContribution + adjustedAmount > userPersonalCap) {
@@ -803,7 +803,6 @@ contract LM_PC_FundingPot_v1 is
         {
             if (!accessCriteria.allowedAddresses[user_]) {
                 revert Module__LM_PC_FundingPot__AccessCriteriaListFailed();
-                return false;
             }
 
             return true;

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -109,42 +109,44 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Emitted when access criteria is set for a round.
     /// @param  roundId_ The unique identifier of the round.
-    /// @param  AccessCriteriaId The identifier of the access criteria.
-    event AccessCriteriaSet(uint64 indexed roundId_, uint8 AccessCriteriaId);
+    /// @param  accessCriteriaId_ The identifier of the access criteria.
+    event AccessCriteriaSet(uint64 indexed roundId_, uint8 accessCriteriaId_);
 
     /// @notice Emitted when access criteria is edited for a round.
     /// @param  roundId_ The unique identifier of the round.
-    /// @param  AccessCriteriaId The identifier of the access criteria.
-    event AccessCriteriaEdited(uint64 indexed roundId_, uint8 AccessCriteriaId);
+    /// @param  accessCriteriaId_ The identifier of the access criteria.
+    event AccessCriteriaEdited(
+        uint64 indexed roundId_, uint8 accessCriteriaId_
+    );
 
-    /// @notice Emitted when access criteria Privileges are set for a round.
+    /// @notice Emitted when access criteria privileges are set for a round.
     /// @param  roundId_ The unique identifier of the round.
-    /// @param  AccessCriteriaId The identifier of the access criteria.
+    /// @param  accessCriteriaId_ The identifier of the access criteria.
     /// @param  personalCap_ The personal cap for the access criteria.
-    /// @param  overrideCap_ Whether to override the global cap.
-    /// @param  start_ The start timestamp for the access criteria.
-    /// @param  cliff_ The cliff timestamp for the access criteria.
-    /// @param  end_ The end timestamp for the access criteria.
+    /// @param  overrideContributionSpan_ Whether to override the round contribution span.
+    /// @param  start_ The start timestamp for for when the linear vesting starts.
+    /// @param  cliff_ The time in seconds from start time at which the unlock starts.
+    /// @param  end_ The end timestamp for when the linear vesting ends.
     event AccessCriteriaPrivilegesSet(
         uint64 indexed roundId_,
-        uint8 AccessCriteriaId,
+        uint8 accessCriteriaId_,
         uint personalCap_,
-        bool overrideCap_,
+        bool overrideContributionSpan_,
         uint start_,
         uint cliff_,
         uint end_
     );
 
-    /// @notice Emitted when a contribution is made to a round
-    /// @param  roundId_ The ID of the round
-    /// @param  contributor_ The address of the contributor
-    /// @param  amount_ The amount contributed
+    /// @notice Emitted when a contribution is made to a round.
+    /// @param  roundId_ The ID of the round.
+    /// @param  contributor_ The address of the contributor.
+    /// @param  amount_ The amount contributed.
     event ContributionMade(uint64 roundId_, address contributor_, uint amount_);
 
-    /// @notice Emitted when a round is closed
-    /// @param  roundId_ The ID of the round
-    /// @param  timestamp_ The timestamp when the round was closed
-    /// @param  totalContributions_ The total contributions collected in the round
+    /// @notice Emitted when a round is closed.
+    /// @param  roundId_ The ID of the round.
+    /// @param  timestamp_ The timestamp when the round was closed.
+    /// @param  totalContributions_ The total contributions collected in the round.
     event RoundClosed(
         uint64 roundId_, uint timestamp_, uint totalContributions_
     );
@@ -184,43 +186,43 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Invalid access criteria ID.
     error Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
-    /// @notice Cannot set Privileges for open access criteria
+    /// @notice Cannot set Privileges for open access criteria.
     error Module__LM_PC_FundingPot__CannotSetPrivilegesForOpenAccessCriteria();
 
-    /// @notice Invalid times
+    /// @notice Invalid times.
     error Module__LM_PC_FundingPot__InvalidTimes();
 
-    /// @notice Round has not started yet
+    /// @notice Round has not started yet.
     error Module__LM_PC_FundingPot__RoundHasNotStarted();
 
-    /// @notice Round has already ended
+    /// @notice Round has already ended.
     error Module__LM_PC_FundingPot__RoundHasEnded();
 
-    /// @notice User does not meet the NFT access criteria
+    /// @notice User does not meet the NFT access criteria.
     error Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
 
-    /// @notice User does not meet the merkle proof access criteria
+    /// @notice User does not meet the merkle proof access criteria.
     error Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();
 
-    /// @notice User is not on the allowlist
+    /// @notice User is not on the allowlist.
     error Module__LM_PC_FundingPot__AccessCriteriaListFailed();
 
-    /// @notice Invalid access criteria type
+    /// @notice Invalid access criteria type.
     error Module__LM_PC_FundingPot__InvalidAccessCriteriaType();
 
-    /// @notice Access not permitted
+    /// @notice Access not permitted.
     error Module__LM_PC_FundingPot__AccessNotPermitted();
 
-    /// @notice User has reached their personal contribution cap
+    /// @notice User has reached their personal contribution cap.
     error Module__LM_PC_FundingPot__PersonalCapReached();
 
-    /// @notice Round contribution cap has been reached
+    /// @notice Round contribution cap has been reached.
     error Module__LM_PC_FundingPot__RoundCapReached();
 
-    /// @notice Round Closure conditions are not met
+    /// @notice Round Closure conditions are not met.
     error Module__LM_PC_FundingPot__ClosureConditionsNotMet();
 
-    /// @notice Hook execution failed
+    /// @notice Hook execution failed.
     error Module__LM_PC_FundingPot__HookExecutionFailed();
 
     // -------------------------------------------------------------------------
@@ -252,7 +254,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundId_ The unique identifier of the round to retrieve.
     /// @param  accessCriteriaId_ The identifier of the access criteria to retrieve.
     /// @param  user_ The address of the user to check access for.
-    /// @return isRoundOpen_ Whether the access criteria is open.
+    /// @return isRoundOpen_ Whether anyone can contribute as part of the access criteria.
     /// @return nftContract_ The address of the NFT contract used for access control.
     /// @return merkleRoot_ The merkle root used for access verification.
     /// @return hasAccess_ The list of explicitly allowed addresses.
@@ -270,18 +272,18 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
             bool hasAccess_
         );
 
-    /// @notice Retrieves the access criteria Privileges for a specific funding round.
+    /// @notice Retrieves the access criteria privileges for a specific funding round.
     /// @param  roundId_ The unique identifier of the round.
-    /// @param  AccessCriteriaId The identifier of the access criteria.
-    /// @return isRoundOpen_ Whether the round is open
-    /// @return personalCap_ The personal cap for the access criteria
-    /// @return overrideContributionSpan_ Whether to override the round contribution span
-    /// @return start_ The start timestamp for the access criteria
-    /// @return cliff_ The cliff timestamp for the access criteria
-    /// @return end_ The end timestamp for the access criteria
+    /// @param  accessCriteriaId_ The identifier of the access criteria.
+    /// @return isRoundOpen_ Whether anyone can contribute as part of the access criteria.
+    /// @return personalCap_ The personal cap for the access criteria.
+    /// @return overrideContributionSpan_ Whether to override the round contribution span.
+    /// @return start_ The start timestamp for the access criteria.
+    /// @return cliff_ The cliff timestamp for the access criteria.
+    /// @return end_ The end timestamp for the access criteria.
     function getRoundAccessCriteriaPrivileges(
         uint64 roundId_,
-        uint8 AccessCriteriaId
+        uint8 accessCriteriaId_
     )
         external
         view
@@ -298,9 +300,9 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @return roundCount_ The total number of funding rounds.
     function getRoundCount() external view returns (uint64 roundCount_);
 
-    /// @notice Retrieves the closed status of a round
-    /// @param  roundId_ The ID of the round
-    /// @return The closed status of the round
+    /// @notice Retrieves the closed status of a round.
+    /// @param  roundId_ The ID of the round.
+    /// @return The closed status of the round.
     function isRoundClosed(uint64 roundId_) external view returns (bool);
 
     // -------------------------------------------------------------------------
@@ -377,21 +379,21 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         address[] memory allowedAddresses_
     ) external;
 
-    /// @notice Set Access Criteria Privileges
-    /// @dev    Only callable by funding pot admin and only before the round has started
-    /// @param  roundId_ ID of the round
-    /// @param  AccessCriteriaId ID of the access criteria
-    /// @param  personalCap_ Personal cap for the access criteria
-    /// @param  capByNFT_ Cap by for the NFT access criteria
-    /// @param  capByMerkle_ Cap for the Merkle root access criteria
-    /// @param  capByList_ Cap by for the List access criteria
-    /// @param  overrideContributionSpan_ Whether to override the round contribution span
-    /// @param  start_ Start timestamp for the access criteria
-    /// @param  cliff_ Cliff timestamp for the access criteria
-    /// @param  end_ End timestamp for the access criteria
+    /// @notice Set access criteria privileges.
+    /// @dev    Only callable by funding pot admin and only before the round has started.
+    /// @param  roundId_ ID of the round.
+    /// @param  accessCriteriaId_ ID of the access criteria.
+    /// @param  personalCap_ Personal cap for the access criteria.
+    /// @param  capByNFT_ Cap by for the NFT access criteria.
+    /// @param  capByMerkle_ Cap for the Merkle root access criteria.
+    /// @param  capByList_ Cap by for the List access criteria.
+    /// @param  overrideContributionSpan_ Whether to override the round contribution span.
+    /// @param  start_ Start timestamp for the access criteria.
+    /// @param  cliff_ Cliff timestamp for the access criteria.
+    /// @param  end_ End timestamp for the access criteria.
     function setAccessCriteriaPrivileges(
         uint64 roundId_,
-        uint8 AccessCriteriaId,
+        uint8 accessCriteriaId_,
         uint personalCap_,
         uint capByNFT_,
         uint capByMerkle_,
@@ -415,7 +417,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bytes32[] calldata merkleProof_
     ) external;
 
-    /// @notice Closes a round
-    /// @param  roundId_ The ID of the round to close
+    /// @notice Closes a round.
+    /// @param  roundId_ The ID of the round to close.
     function closeRound(uint64 roundId_) external;
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -243,7 +243,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Retrieves the access criteria for a specific funding round.
     /// @param  roundId_ The unique identifier of the round to retrieve.
     /// @param  accessCriteriaId_ The identifier of the access criteria to retrieve.
-    /// @return isOpen_ Whether the access criteria is open.
+    /// @return isRoundOpen_ Whether the access criteria is open.
     /// @return nftContract_ The address of the NFT contract used for access control.
     /// @return merkleRoot_ The merkle root used for access verification.
     /// @return allowedAddresses_ The list of explicitly allowed addresses.

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -34,12 +34,11 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  nftContract Address of the NFT contract.
     /// @param  merkleRoot Merkle root for the access criteria.
     /// @param  allowedAddresses Mapping of addresses to their access status.
-    // TODO change array to mapping
     struct AccessCriteria {
         AccessCriteriaType accessCriteriaType;
         address nftContract; // NFT contract address (0x0 if unused)
         bytes32 merkleRoot; // Merkle root (0x0 if unused)
-        address[] allowedAddresses; // Explicit allowlist
+        mapping(address user => bool isAllowed) allowedAddresses; // Mapping of allowed addresses
     }
 
     struct AccessCriteriaPrivileges {
@@ -111,25 +110,12 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Emitted when access criteria is set for a round.
     /// @param  roundId_ The unique identifier of the round.
     /// @param  AccessCriteriaId The identifier of the access criteria.
-    /// @param  accessCriteria_ The access criteria.
-
-    // TODO remove last parameter
-    event AccessCriteriaSet(
-        uint64 indexed roundId_,
-        uint8 AccessCriteriaId,
-        AccessCriteria accessCriteria_
-    );
+    event AccessCriteriaSet(uint64 indexed roundId_, uint8 AccessCriteriaId);
 
     /// @notice Emitted when access criteria is edited for a round.
     /// @param  roundId_ The unique identifier of the round.
     /// @param  AccessCriteriaId The identifier of the access criteria.
-    /// @param  accessCriteria_ The access criteria.
-    // TODO remove last parameter
-    event AccessCriteriaEdited(
-        uint64 indexed roundId_,
-        uint8 AccessCriteriaId,
-        AccessCriteria accessCriteria_
-    );
+    event AccessCriteriaEdited(uint64 indexed roundId_, uint8 AccessCriteriaId);
 
     /// @notice Emitted when access criteria Privileges are set for a round.
     /// @param  roundId_ The unique identifier of the round.
@@ -265,18 +251,23 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Retrieves the access criteria for a specific funding round.
     /// @param  roundId_ The unique identifier of the round to retrieve.
     /// @param  accessCriteriaId_ The identifier of the access criteria to retrieve.
+    /// @param  user_ The address of the user to check access for.
     /// @return isRoundOpen_ Whether the access criteria is open.
     /// @return nftContract_ The address of the NFT contract used for access control.
     /// @return merkleRoot_ The merkle root used for access verification.
-    /// @return allowedAddresses_ The list of explicitly allowed addresses.
-    function getRoundAccessCriteria(uint64 roundId_, uint8 accessCriteriaId_)
+    /// @return hasAccess_ The list of explicitly allowed addresses.
+    function getRoundAccessCriteria(
+        uint64 roundId_,
+        uint8 accessCriteriaId_,
+        address user_
+    )
         external
         view
         returns (
             bool isRoundOpen_,
             address nftContract_,
             bytes32 merkleRoot_,
-            address[] memory allowedAddresses_
+            bool hasAccess_
         );
 
     /// @notice Retrieves the access criteria Privileges for a specific funding round.
@@ -345,7 +336,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  hookFunction_ New encoded function call.
     /// @param  autoClosure_ New closure mechanism setting.
     /// @param  globalAccumulativeCaps_ New global accumulative caps setting.
-    /// TODO allow admin to pass nft merkle root and list of allowed addresses
     function editRound(
         uint64 roundId_,
         uint roundStart_,
@@ -360,22 +350,31 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Set Access Control Check.
     /// @dev    Only callable by funding pot admin and only before the round has started.
     /// @param  roundId_ ID of the round.
-    /// @param  accessCriteria_ Access criteria to set.
-    /// TODO allow admin to pass nft merkle root and list of allowed addresses
+    /// @param  accessCriteriaId_ ID of the access criteria.
+    /// @param  nftContract_ Address of the NFT contract.
+    /// @param  merkleRoot_ Merkle root for the access criteria.
+    /// @param  allowedAddresses_ List of explicitly allowed addresses.
     function setAccessCriteriaForRound(
         uint64 roundId_,
-        AccessCriteria memory accessCriteria_
+        uint8 accessCriteriaId_,
+        address nftContract_,
+        bytes32 merkleRoot_,
+        address[] memory allowedAddresses_
     ) external;
 
     /// @notice Edits an existing access criteria for a round.
     /// @dev    Only callable by funding pot admin and only before the round has started.
     /// @param  roundId_ ID of the round.
     /// @param  accessCriteriaId_ ID of the access criteria.
-    /// @param  accessCriteria_ New access criteria.
+    /// @param  nftContract_ Address of the NFT contract.
+    /// @param  merkleRoot_ Merkle root for the access criteria.
+    /// @param  allowedAddresses_ List of explicitly allowed addresses.
     function editAccessCriteriaForRound(
         uint64 roundId_,
         uint8 accessCriteriaId_,
-        AccessCriteria memory accessCriteria_
+        address nftContract_,
+        bytes32 merkleRoot_,
+        address[] memory allowedAddresses_
     ) external;
 
     /// @notice Set Access Criteria Privileges

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -109,23 +109,27 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Emitted when access criteria is set for a round.
     /// @param  roundId_ The unique identifier of the round.
-    /// @param  accessId_ The identifier of the access criteria.
+    /// @param  AccessCriteriaId The identifier of the access criteria.
     /// @param  accessCriteria_ The access criteria.
     event AccessCriteriaSet(
-        uint64 indexed roundId_, uint8 accessId_, AccessCriteria accessCriteria_
+        uint64 indexed roundId_,
+        uint8 AccessCriteriaId,
+        AccessCriteria accessCriteria_
     );
 
     /// @notice Emitted when access criteria is edited for a round.
     /// @param  roundId_ The unique identifier of the round.
-    /// @param  accessId_ The identifier of the access criteria.
+    /// @param  AccessCriteriaId The identifier of the access criteria.
     /// @param  accessCriteria_ The access criteria.
     event AccessCriteriaEdited(
-        uint64 indexed roundId_, uint8 accessId_, AccessCriteria accessCriteria_
+        uint64 indexed roundId_,
+        uint8 AccessCriteriaId,
+        AccessCriteria accessCriteria_
     );
 
     /// @notice Emitted when access criteria Privileges are set for a round.
     /// @param  roundId_ The unique identifier of the round.
-    /// @param  accessId_ The identifier of the access criteria.
+    /// @param  AccessCriteriaId The identifier of the access criteria.
     /// @param  personalCap_ The personal cap for the access criteria.
     /// @param  overrideCap_ Whether to override the global cap.
     /// @param  start_ The start timestamp for the access criteria.
@@ -133,7 +137,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  end_ The end timestamp for the access criteria.
     event AccessCriteriaPrivilegesSet(
         uint64 indexed roundId_,
-        uint8 accessId_,
+        uint8 AccessCriteriaId,
         uint personalCap_,
         bool overrideCap_,
         uint start_,
@@ -273,14 +277,17 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Retrieves the access criteria Privileges for a specific funding round.
     /// @param  roundId_ The unique identifier of the round.
-    /// @param  accessId_ The identifier of the access criteria.
+    /// @param  AccessCriteriaId The identifier of the access criteria.
     /// @return isRoundOpen_ Whether the round is open
     /// @return personalCap_ The personal cap for the access criteria
     /// @return overrideContributionSpan_ Whether to override the round contribution span
     /// @return start_ The start timestamp for the access criteria
     /// @return cliff_ The cliff timestamp for the access criteria
     /// @return end_ The end timestamp for the access criteria
-    function getRoundAccessCriteriaPrivileges(uint64 roundId_, uint8 accessId_)
+    function getRoundAccessCriteriaPrivileges(
+        uint64 roundId_,
+        uint8 AccessCriteriaId
+    )
         external
         view
         returns (
@@ -368,7 +375,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Set Access Criteria Privileges
     /// @dev    Only callable by funding pot admin and only before the round has started
     /// @param  roundId_ ID of the round
-    /// @param  accessId_ ID of the access criteria
+    /// @param  AccessCriteriaId ID of the access criteria
     /// @param  personalCap_ Personal cap for the access criteria
     /// @param  capByNFT_ Cap by for the NFT access criteria
     /// @param  capByMerkle_ Cap for the Merkle root access criteria
@@ -379,7 +386,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  end_ End timestamp for the access criteria
     function setAccessCriteriaPrivileges(
         uint64 roundId_,
-        uint8 accessId_,
+        uint8 AccessCriteriaId,
         uint personalCap_,
         uint capByNFT_,
         uint capByMerkle_,

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -34,6 +34,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  nftContract Address of the NFT contract.
     /// @param  merkleRoot Merkle root for the access criteria.
     /// @param  allowedAddresses Mapping of addresses to their access status.
+    // TODO change array to mapping
     struct AccessCriteria {
         AccessCriteriaType accessCriteriaType;
         address nftContract; // NFT contract address (0x0 if unused)
@@ -111,6 +112,8 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundId_ The unique identifier of the round.
     /// @param  AccessCriteriaId The identifier of the access criteria.
     /// @param  accessCriteria_ The access criteria.
+
+    // TODO remove last parameter
     event AccessCriteriaSet(
         uint64 indexed roundId_,
         uint8 AccessCriteriaId,
@@ -121,6 +124,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundId_ The unique identifier of the round.
     /// @param  AccessCriteriaId The identifier of the access criteria.
     /// @param  accessCriteria_ The access criteria.
+    // TODO remove last parameter
     event AccessCriteriaEdited(
         uint64 indexed roundId_,
         uint8 AccessCriteriaId,
@@ -341,6 +345,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  hookFunction_ New encoded function call.
     /// @param  autoClosure_ New closure mechanism setting.
     /// @param  globalAccumulativeCaps_ New global accumulative caps setting.
+    /// TODO allow admin to pass nft merkle root and list of allowed addresses
     function editRound(
         uint64 roundId_,
         uint roundStart_,
@@ -356,6 +361,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @dev    Only callable by funding pot admin and only before the round has started.
     /// @param  roundId_ ID of the round.
     /// @param  accessCriteria_ Access criteria to set.
+    /// TODO allow admin to pass nft merkle root and list of allowed addresses
     function setAccessCriteriaForRound(
         uint64 roundId_,
         AccessCriteria memory accessCriteria_

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -41,6 +41,12 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         mapping(address user => bool isAllowed) allowedAddresses; // Mapping of allowed addresses
     }
 
+    /// @notice Struct used to store information about a funding round's access criteria privileges.
+    /// @param  personalCap Personal cap for the access criteria.
+    /// @param  overrideContributionSpan Whether to override the round contribution span.
+    /// @param  start The start timestamp for for when the linear vesting starts.
+    /// @param  cliff The time in seconds from start time at which the unlock starts.
+    /// @param  end The end timestamp for when the linear vesting ends.
     struct AccessCriteriaPrivileges {
         uint personalCap;
         bool overrideContributionSpan;

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -296,14 +296,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @return roundCount_ The total number of funding rounds.
     function getRoundCount() external view returns (uint64 roundCount_);
 
-    /// @notice Retrieves the total number of access criteria for a specific round.
-    /// @param  roundId_ The unique identifier of the round.
-    /// @return accessCriteriaCount_ The total number of access criteria for the round.
-    function getRoundAccessCriteriaCount(uint64 roundId_)
-        external
-        view
-        returns (uint8 accessCriteriaCount_);
-
     /// @notice Retrieves the closed status of a round
     /// @param  roundId_ The ID of the round
     /// @return The closed status of the round

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -340,14 +340,20 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Gets eligibility information for a user in a specific round
     /// @param  roundId_ The ID of the round to check eligibility for
+    /// @param  accessCriteriaId_ The ID of the access criteria to check eligibility for
     /// @param  merkleProof_ The Merkle proof for validation if needed
     /// @param  user_ The address of the user to check
-    /// @return eligibility Complete eligibility information for the user
+    /// @return isEligible Whether the user is eligible for the round through any criteria
+    /// @return remainingAmountAllowedToContribute The remaining contribution the user can make
     function getUserEligibility(
         uint64 roundId_,
+        uint8 accessCriteriaId_,
         bytes32[] memory merkleProof_,
         address user_
-    ) external view returns (RoundUserEligibility memory eligibility);
+    )
+        external
+        view
+        returns (bool isEligible, uint remainingAmountAllowedToContribute);
 
     // -------------------------------------------------------------------------
     // Public - Mutating

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -123,6 +123,12 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint64 indexed roundId_, uint8 accessId_, AccessCriteria accessCriteria_
     );
 
+    /// @notice Emitted when a contribution is made to a round
+    /// @param  roundId_ The ID of the round
+    /// @param  contributor_ The address of the contributor
+    /// @param  amount_ The amount contributed
+    event ContributionMade(uint64 roundId_, address contributor_, uint amount_);
+
     // -------------------------------------------------------------------------
     // Errors
 
@@ -158,6 +164,33 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Invalid access criteria ID.
     error Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
+
+    /// @notice Round has not started yet
+    error Module__LM_PC_FundingPot__RoundHasNotStarted();
+
+    /// @notice Round has already ended
+    error Module__LM_PC_FundingPot__RoundHasEnded();
+
+    /// @notice User does not meet the NFT access criteria
+    error Module__LM_PC_FundingPot__AccessCriteriaNftFailed();
+
+    /// @notice User does not meet the merkle proof access criteria
+    error Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed();
+
+    /// @notice User is not on the allowlist
+    error Module__LM_PC_FundingPot__AccessCriteriaListFailed();
+
+    /// @notice Invalid access criteria type
+    error Module__LM_PC_FundingPot__InvalidAccessCriteriaType();
+
+    /// @notice Access not permitted
+    error Module__LM_PC_FundingPot__AccessNotPermitted();
+
+    /// @notice User has reached their personal contribution cap
+    error Module__LM_PC_FundingPot__PersonalCapReached();
+
+    /// @notice Round contribution cap has been reached
+    error Module__LM_PC_FundingPot__RoundCapReached();
 
     // -------------------------------------------------------------------------
     // Public - Getters
@@ -315,5 +348,21 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint _start,
         uint _cliff,
         uint _end
+    ) external;
+
+    /// @notice Allows a user to contribute to a specific funding round.
+    /// @dev    Verifies the contribution eligibility based on the provided Merkle proof.
+    /// @param  roundId_ The unique identifier of the funding round.
+    /// @param  amount_ The amount of tokens being contributed.
+    /// @param  accessCriteriaId_ The identifier for the access criteria to validate eligibility.
+    /// @param  contributionToken_ The address of the token used for contribution.
+    /// @param  merkleProof_ The Merkle proof used to verify the contributor's eligibility.
+
+    function contribute(
+        uint64 roundId_,
+        uint amount_,
+        uint8 accessCriteriaId_,
+        address contributionToken_,
+        bytes32[] calldata merkleProof_
     ) external;
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -65,6 +65,22 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         bytes32[] merkleProof;
     }
 
+    /// @notice Struct to represent a user's complete eligibility information for a round
+    /// @param  isEligible Whether the user is eligible for the round through any criteria
+    /// @param  isNftHolder Whether the user is eligible through NFT holding
+    /// @param  isInMerkleTree Whether the user is eligible through Merkle proof
+    /// @param  isInAllowlist Whether the user is eligible through allowlist
+    /// @param  highestPersonalCap The highest personal cap the user can access
+    /// @param  canOverrideContributionSpan Whether the user has any criteria that can override contribution span
+    struct RoundUserEligibility {
+        bool isEligible;
+        bool isNftHolder;
+        bool isInMerkleTree;
+        bool isInAllowlist;
+        uint highestPersonalCap;
+        bool canOverrideContributionSpan;
+    }
+
     // -------------------------------------------------------------------------
     // Enums
 
@@ -171,7 +187,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundId_ The ID of the round.
     /// @param  accessCriteriaId_ The ID of the access criteria.
     /// @param  addressesRemoved_ The addresses that were removed from the allowlist.
-    event AccessCriteriaAddressesRemoved(
+    event AllowlistedAddressesRemoved(
         uint64 roundId_, uint8 accessCriteriaId_, address[] addressesRemoved_
     );
 
@@ -277,23 +293,18 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Retrieves the access criteria for a specific funding round.
     /// @param  roundId_ The unique identifier of the round to retrieve.
     /// @param  accessCriteriaId_ The identifier of the access criteria to retrieve.
-    /// @param  user_ The address of the user to check access for.
     /// @return isRoundOpen_ Whether anyone can contribute as part of the access criteria.
     /// @return nftContract_ The address of the NFT contract used for access control.
     /// @return merkleRoot_ The merkle root used for access verification.
-    /// @return hasAccess_ The list of explicitly allowed addresses.
-    function getRoundAccessCriteria(
-        uint64 roundId_,
-        uint8 accessCriteriaId_,
-        address user_
-    )
+    /// @return isList_ If the access criteria is a list, this will be true.
+    function getRoundAccessCriteria(uint64 roundId_, uint8 accessCriteriaId_)
         external
         view
         returns (
             bool isRoundOpen_,
             address nftContract_,
             bytes32 merkleRoot_,
-            bool hasAccess_
+            bool isList_
         );
 
     /// @notice Retrieves the access criteria privileges for a specific funding round.
@@ -326,6 +337,17 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundId_ The ID of the round.
     /// @return The closed status of the round.
     function isRoundClosed(uint64 roundId_) external view returns (bool);
+
+    /// @notice Gets eligibility information for a user in a specific round
+    /// @param  roundId_ The ID of the round to check eligibility for
+    /// @param  merkleProof_ The Merkle proof for validation if needed
+    /// @param  user_ The address of the user to check
+    /// @return eligibility Complete eligibility information for the user
+    function getUserEligibility(
+        uint64 roundId_,
+        bytes32[] memory merkleProof_,
+        address user_
+    ) external view returns (RoundUserEligibility memory eligibility);
 
     // -------------------------------------------------------------------------
     // Public - Mutating
@@ -406,7 +428,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundId_ ID of the round.
     /// @param  accessCriteriaId_ ID of the access criteria.
     /// @param  addressesToRemove_ List of addresses to remove from the allowed list.
-    function removeAccessCriteriaAddressesForRound(
+    function removeAllowlistedAddresses(
         uint64 roundId_,
         uint8 accessCriteriaId_,
         address[] calldata addressesToRemove_

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -43,7 +43,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     struct AccessCriteriaPrivileges {
         uint personalCap;
-        bool overrideCap;
+        bool overrideContributionSpan;
         uint start;
         uint cliff;
         uint end;
@@ -262,7 +262,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  accessId_ The identifier of the access criteria.
     /// @return isRoundOpen_ Whether the round is open
     /// @return personalCap_ The personal cap for the access criteria
-    /// @return overrideCap_ Whether to override the global cap
+    /// @return overrideContributionSpan_ Whether to override the round contribution span
     /// @return start_ The start timestamp for the access criteria
     /// @return cliff_ The cliff timestamp for the access criteria
     /// @return end_ The end timestamp for the access criteria
@@ -272,7 +272,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         returns (
             bool isRoundOpen_,
             uint personalCap_,
-            bool overrideCap_,
+            bool overrideContributionSpan_,
             uint start_,
             uint cliff_,
             uint end_
@@ -359,7 +359,10 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundId_ ID of the round
     /// @param  accessId_ ID of the access criteria
     /// @param  personalCap_ Personal cap for the access criteria
-    /// @param  overrideCap_ Whether to override the global cap
+    /// @param  capByNFT_ Cap by for the NFT access criteria
+    /// @param  capByMerkle_ Cap for the Merkle root access criteria
+    /// @param  capByList_ Cap by for the List access criteria
+    /// @param  overrideContributionSpan_ Whether to override the round contribution span
     /// @param  start_ Start timestamp for the access criteria
     /// @param  cliff_ Cliff timestamp for the access criteria
     /// @param  end_ End timestamp for the access criteria
@@ -367,7 +370,10 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint64 roundId_,
         uint8 accessId_,
         uint personalCap_,
-        bool overrideCap_,
+        uint capByNFT_,
+        uint capByMerkle_,
+        uint capByList_,
+        bool overrideContributionSpan_,
         uint start_,
         uint cliff_,
         uint end_

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -55,6 +55,16 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint end;
     }
 
+    /// @notice Struct used to specify previous round's access criteria for carry-over capacity
+    /// @param roundId The ID of the previous round
+    /// @param accessCriteriaId The ID of the access criteria in that round
+    /// @param merkleProof The Merkle proof needed to validate eligibility (if needed)
+    struct UnspentPersonalRoundCap {
+        uint64 roundId;
+        uint8 accessCriteriaId;
+        bytes32[] merkleProof;
+    }
+
     // -------------------------------------------------------------------------
     // Enums
 
@@ -421,6 +431,20 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint amount_,
         uint8 accessCriteriaId_,
         bytes32[] calldata merkleProof_
+    ) external;
+
+    /// @notice Allows a user to contribute to a round with unused capacity from previous rounds
+    /// @param roundId_ The ID of the round to contribute to
+    /// @param amount_ The amount to contribute
+    /// @param accessCriteriaId_ The ID of the access criteria to use for this contribution
+    /// @param merkleProof_ The Merkle proof for validation if needed
+    /// @param unspentPersonalRoundCaps_ Array of previous rounds and access criteria to calculate unused capacity from
+    function contributeToRound(
+        uint64 roundId_,
+        uint amount_,
+        uint8 accessCriteriaId_,
+        bytes32[] calldata merkleProof_,
+        UnspentPersonalRoundCap[] calldata unspentPersonalRoundCaps_
     ) external;
 
     /// @notice Closes a round.

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -357,8 +357,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  accessCriteriaId_ The identifier for the access criteria to validate eligibility.
     /// @param  contributionToken_ The address of the token used for contribution.
     /// @param  merkleProof_ The Merkle proof used to verify the contributor's eligibility.
-
-    function contribute(
+    function contributeToRound(
         uint64 roundId_,
         uint amount_,
         uint8 accessCriteriaId_,

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -147,6 +147,14 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  amount_ The amount contributed
     event ContributionMade(uint64 roundId_, address contributor_, uint amount_);
 
+    /// @notice Emitted when a round is closed
+    /// @param  roundId_ The ID of the round
+    /// @param  timestamp_ The timestamp when the round was closed
+    /// @param  totalContributions_ The total contributions collected in the round
+    event RoundClosed(
+        uint64 roundId_, uint timestamp_, uint totalContributions_
+    );
+
     // -------------------------------------------------------------------------
     // Errors
 
@@ -214,6 +222,12 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Round contribution cap has been reached
     error Module__LM_PC_FundingPot__RoundCapReached();
+
+    /// @notice Round Closure conditions are not met
+    error Module__LM_PC_FundingPot__ClosureConditionsNotMet();
+
+    /// @notice Hook execution failed
+    error Module__LM_PC_FundingPot__HookExecutionFailed();
 
     // -------------------------------------------------------------------------
     // Public - Getters
@@ -289,6 +303,11 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         external
         view
         returns (uint8 accessCriteriaCount_);
+
+    /// @notice Retrieves the closed status of a round
+    /// @param  roundId_ The ID of the round
+    /// @return The closed status of the round
+    function isRoundClosed(uint64 roundId_) external view returns (bool);
 
     // -------------------------------------------------------------------------
     // Public - Mutating
@@ -391,4 +410,8 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint8 accessCriteriaId_,
         bytes32[] calldata merkleProof_
     ) external;
+
+    /// @notice Closes a round
+    /// @param  roundId_ The ID of the round to close
+    function closeRound(uint64 roundId_) external;
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -41,7 +41,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         address[] allowedAddresses; // Explicit allowlist
     }
 
-    struct AccessCriteriaPrivilages {
+    struct AccessCriteriaPrivileges {
         uint personalCap;
         bool overrideCap;
         uint start;
@@ -123,6 +123,24 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint64 indexed roundId_, uint8 accessId_, AccessCriteria accessCriteria_
     );
 
+    /// @notice Emitted when access criteria Privileges are set for a round.
+    /// @param  roundId_ The unique identifier of the round.
+    /// @param  accessId_ The identifier of the access criteria.
+    /// @param  personalCap_ The personal cap for the access criteria.
+    /// @param  overrideCap_ Whether to override the global cap.
+    /// @param  start_ The start timestamp for the access criteria.
+    /// @param  cliff_ The cliff timestamp for the access criteria.
+    /// @param  end_ The end timestamp for the access criteria.
+    event AccessCriteriaPrivilegesSet(
+        uint64 indexed roundId_,
+        uint8 accessId_,
+        uint personalCap_,
+        bool overrideCap_,
+        uint start_,
+        uint cliff_,
+        uint end_
+    );
+
     /// @notice Emitted when a contribution is made to a round
     /// @param  roundId_ The ID of the round
     /// @param  contributor_ The address of the contributor
@@ -164,6 +182,11 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Invalid access criteria ID.
     error Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
+    /// @notice Cannot set Privileges for open access criteria
+    error Module__LM_PC_FundingPot__CannotSetPrivilegesForOpenAccessCriteria();
+
+    /// @notice Invalid times
+    error Module__LM_PC_FundingPot__InvalidTimes();
 
     /// @notice Round has not started yet
     error Module__LM_PC_FundingPot__RoundHasNotStarted();
@@ -234,7 +257,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
             address[] memory allowedAddresses_
         );
 
-    /// @notice Retrieves the access criteria privilages for a specific funding round.
+    /// @notice Retrieves the access criteria Privileges for a specific funding round.
     /// @param  roundId_ The unique identifier of the round.
     /// @param  accessId_ The identifier of the access criteria.
     /// @return isRoundOpen_ Whether the round is open
@@ -243,7 +266,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @return start_ The start timestamp for the access criteria
     /// @return cliff_ The cliff timestamp for the access criteria
     /// @return end_ The end timestamp for the access criteria
-    function getRoundAccessCriteriaPrivilages(uint64 roundId_, uint8 accessId_)
+    function getRoundAccessCriteriaPrivileges(uint64 roundId_, uint8 accessId_)
         external
         view
         returns (
@@ -331,23 +354,23 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         AccessCriteria memory accessCriteria_
     ) external;
 
-    /// @notice Set Access Criteria Privilages
+    /// @notice Set Access Criteria Privileges
     /// @dev    Only callable by funding pot admin and only before the round has started
     /// @param  roundId_ ID of the round
     /// @param  accessId_ ID of the access criteria
     /// @param  personalCap_ Personal cap for the access criteria
     /// @param  overrideCap_ Whether to override the global cap
-    /// @param  _start Start timestamp for the access criteria
-    /// @param  _cliff Cliff timestamp for the access criteria
-    /// @param  _end End timestamp for the access criteria
-    function setAccessCriteriaPrivilages(
+    /// @param  start_ Start timestamp for the access criteria
+    /// @param  cliff_ Cliff timestamp for the access criteria
+    /// @param  end_ End timestamp for the access criteria
+    function setAccessCriteriaPrivileges(
         uint64 roundId_,
         uint8 accessId_,
         uint personalCap_,
         bool overrideCap_,
-        uint _start,
-        uint _cliff,
-        uint _end
+        uint start_,
+        uint cliff_,
+        uint end_
     ) external;
 
     /// @notice Allows a user to contribute to a specific funding round.
@@ -355,13 +378,11 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  roundId_ The unique identifier of the funding round.
     /// @param  amount_ The amount of tokens being contributed.
     /// @param  accessCriteriaId_ The identifier for the access criteria to validate eligibility.
-    /// @param  contributionToken_ The address of the token used for contribution.
     /// @param  merkleProof_ The Merkle proof used to verify the contributor's eligibility.
     function contributeToRound(
         uint64 roundId_,
         uint amount_,
         uint8 accessCriteriaId_,
-        address contributionToken_,
         bytes32[] calldata merkleProof_
     ) external;
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -167,6 +167,14 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint64 roundId_, uint timestamp_, uint totalContributions_
     );
 
+    /// @notice Emitted when addresses are removed from an access criteria's allowed list.
+    /// @param  roundId_ The ID of the round.
+    /// @param  accessCriteriaId_ The ID of the access criteria.
+    /// @param  addressesRemoved_ The addresses that were removed from the allowlist.
+    event AccessCriteriaAddressesRemoved(
+        uint64 roundId_, uint8 accessCriteriaId_, address[] addressesRemoved_
+    );
+
     // -------------------------------------------------------------------------
     // Errors
 
@@ -291,7 +299,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Retrieves the access criteria privileges for a specific funding round.
     /// @param  roundId_ The unique identifier of the round.
     /// @param  accessCriteriaId_ The identifier of the access criteria.
-    /// @return isRoundOpen_ Whether anyone can contribute as part of the access criteria.
     /// @return personalCap_ The personal cap for the access criteria.
     /// @return overrideContributionSpan_ Whether to override the round contribution span.
     /// @return start_ The start timestamp for the access criteria.
@@ -304,7 +311,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         external
         view
         returns (
-            bool isRoundOpen_,
             uint personalCap_,
             bool overrideContributionSpan_,
             uint start_,
@@ -395,14 +401,22 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         address[] memory allowedAddresses_
     ) external;
 
+    /// @notice Removes addresses from the allowed list for a specific access criteria.
+    /// @dev    Only callable by funding pot admin and only before the round has started.
+    /// @param  roundId_ ID of the round.
+    /// @param  accessCriteriaId_ ID of the access criteria.
+    /// @param  addressesToRemove_ List of addresses to remove from the allowed list.
+    function removeAccessCriteriaAddressesForRound(
+        uint64 roundId_,
+        uint8 accessCriteriaId_,
+        address[] calldata addressesToRemove_
+    ) external;
+
     /// @notice Set access criteria privileges.
     /// @dev    Only callable by funding pot admin and only before the round has started.
     /// @param  roundId_ ID of the round.
     /// @param  accessCriteriaId_ ID of the access criteria.
     /// @param  personalCap_ Personal cap for the access criteria.
-    /// @param  capByNFT_ Cap by for the NFT access criteria.
-    /// @param  capByMerkle_ Cap for the Merkle root access criteria.
-    /// @param  capByList_ Cap by for the List access criteria.
     /// @param  overrideContributionSpan_ Whether to override the round contribution span.
     /// @param  start_ Start timestamp for the access criteria.
     /// @param  cliff_ Cliff timestamp for the access criteria.
@@ -411,9 +425,6 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint64 roundId_,
         uint8 accessCriteriaId_,
         uint personalCap_,
-        uint capByNFT_,
-        uint capByMerkle_,
-        uint capByList_,
         bool overrideContributionSpan_,
         uint start_,
         uint cliff_,

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -41,6 +41,14 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         address[] allowedAddresses; // Explicit allowlist
     }
 
+    struct AccessCriteriaPrivilages {
+        uint personalCap;
+        bool overrideCap;
+        uint start;
+        uint cliff;
+        uint end;
+    }
+
     // -------------------------------------------------------------------------
     // Enums
 
@@ -187,10 +195,31 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         external
         view
         returns (
-            bool isOpen_,
+            bool isRoundOpen_,
             address nftContract_,
             bytes32 merkleRoot_,
             address[] memory allowedAddresses_
+        );
+
+    /// @notice Retrieves the access criteria privilages for a specific funding round.
+    /// @param  roundId_ The unique identifier of the round.
+    /// @param  accessId_ The identifier of the access criteria.
+    /// @return isRoundOpen_ Whether the round is open
+    /// @return personalCap_ The personal cap for the access criteria
+    /// @return overrideCap_ Whether to override the global cap
+    /// @return start_ The start timestamp for the access criteria
+    /// @return cliff_ The cliff timestamp for the access criteria
+    /// @return end_ The end timestamp for the access criteria
+    function getRoundAccessCriteriaPrivilages(uint64 roundId_, uint8 accessId_)
+        external
+        view
+        returns (
+            bool isRoundOpen_,
+            uint personalCap_,
+            bool overrideCap_,
+            uint start_,
+            uint cliff_,
+            uint end_
         );
 
     /// @notice Retrieves the total number of funding rounds.
@@ -267,5 +296,24 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint64 roundId_,
         uint8 accessCriteriaId_,
         AccessCriteria memory accessCriteria_
+    ) external;
+
+    /// @notice Set Access Criteria Privilages
+    /// @dev    Only callable by funding pot admin and only before the round has started
+    /// @param  roundId_ ID of the round
+    /// @param  accessId_ ID of the access criteria
+    /// @param  personalCap_ Personal cap for the access criteria
+    /// @param  overrideCap_ Whether to override the global cap
+    /// @param  _start Start timestamp for the access criteria
+    /// @param  _cliff Cliff timestamp for the access criteria
+    /// @param  _end End timestamp for the access criteria
+    function setAccessCriteriaPrivilages(
+        uint64 roundId_,
+        uint8 accessId_,
+        uint personalCap_,
+        bool overrideCap_,
+        uint _start,
+        uint _cliff,
+        uint _end
     ) external;
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1024,16 +1024,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         (
             bool isOpen,
-            address retreivedNftContract,
-            bytes32 retreivedMerkleRoot,
+            address retrievedNftContract,
+            bytes32 retrievedMerkleRoot,
             bool hasAccess
-        ) = fundingPot.getRoundAccessCriteria(
-            roundId, accessCriteriaEnum, address(0x2)
-        );
+        ) = fundingPot.getRoundAccessCriteria(roundId, accessCriteriaEnum);
 
         assertEq(isOpen, accessCriteriaEnum == 1);
-        assertEq(retreivedNftContract, nftContract);
-        assertEq(retreivedMerkleRoot, merkleRoot);
+        assertEq(retrievedNftContract, nftContract);
+        assertEq(retrievedMerkleRoot, merkleRoot);
         if (accessCriteriaEnum == 1 || accessCriteriaEnum == 4) {
             assertTrue(hasAccess);
         } else {

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1094,9 +1094,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPotToken.approve(address(fundingPot), 110);
 
         vm.prank(contributor1_);
-        fundingPot.contributeToRound(
-            roundId, 10, accessId, address(fundingPotToken), new bytes32[](0)
-        );
+        fundingPot.contributeToRound(roundId, 10, accessId, new bytes32[](0));
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1108,11 +1106,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            amount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, amount, accessId, new bytes32[](0)
         );
     }
 
@@ -1145,11 +1139,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            amount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, amount, accessId, new bytes32[](0)
         );
     }
 
@@ -1184,11 +1174,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            amount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, amount, accessId, new bytes32[](0)
         );
     }
 
@@ -1223,11 +1209,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            amount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, amount, accessId, new bytes32[](0)
         );
     }
 
@@ -1260,9 +1242,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
 
         vm.prank(contributor1_);
-        fundingPot.contributeToRound(
-            roundId, amount, accessId, address(fundingPotToken), PROOF
-        );
+        fundingPot.contributeToRound(roundId, amount, accessId, PROOF);
     }
 
     function testFuzzContributeToRound_revertsGivenAllowedListAccessCriteriaIsNotMet(
@@ -1295,11 +1275,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            amount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, amount, accessId, new bytes32[](0)
         );
     }
 
@@ -1327,11 +1303,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            amount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, amount, accessId, new bytes32[](0)
         );
 
         // Get the base personal cap from the contract
@@ -1349,9 +1321,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.prank(contributor1_);
 
         uint remainingCap = personalCap - amount;
-        fundingPot.contributeToRound(
-            roundId, 251, accessId, address(fundingPotToken), new bytes32[](0)
-        );
+        fundingPot.contributeToRound(roundId, 251, accessId, new bytes32[](0));
     }
 
     /*
@@ -1420,11 +1390,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            amount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, amount, accessId, new bytes32[](0)
         );
 
         uint totalContributions =
@@ -1466,11 +1432,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            amount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, amount, accessId, new bytes32[](0)
         );
 
         // only the amount that does not exceed the roundcap is contributed
@@ -1505,11 +1467,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // First contribution
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            firstAmount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, firstAmount, accessId, new bytes32[](0)
         );
 
         // Get the personal cap
@@ -1520,11 +1478,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            secondAmount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, secondAmount, accessId, new bytes32[](0)
         );
 
         uint totalContribution =
@@ -1546,7 +1500,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
 
         // Set privileges with override capability
-        fundingPot.setAccessCriteriaPrivilages(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId,
             accessId,
             500, // personalCap
@@ -1569,11 +1523,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // This should succeed despite being after round end, due to override privilege
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId,
-            amount,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            roundId, amount, accessId, new bytes32[](0)
         );
 
         // Verify the contribution was recorded
@@ -1632,11 +1582,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.warp(roundStart + 1);
         uint round1Contribution = 200;
         fundingPot.contributeToRound(
-            round1Id,
-            round1Contribution,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            round1Id, round1Contribution, accessId, new bytes32[](0)
         );
 
         // Move to Round 2
@@ -1649,11 +1595,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint round2MaxContribution = basePersonalCap + unusedCapacityFromRound1;
         fundingPot.contributeToRound(
-            round2Id,
-            round2MaxContribution,
-            accessId,
-            address(fundingPotToken),
-            new bytes32[](0)
+            round2Id, round2MaxContribution, accessId, new bytes32[](0)
         );
         vm.stopPrank();
 
@@ -1716,16 +1658,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.startPrank(contributor1_);
         fundingPotToken.approve(address(fundingPot), 300);
-        fundingPot.contributeToRound(
-            round1Id, 300, accessId, address(fundingPotToken), new bytes32[](0)
-        );
+        fundingPot.contributeToRound(round1Id, 300, accessId, new bytes32[](0));
         vm.stopPrank();
 
         vm.startPrank(contributor2_);
         fundingPotToken.approve(address(fundingPot), 200);
-        fundingPot.contributeToRound(
-            round1Id, 200, accessId, address(fundingPotToken), new bytes32[](0)
-        );
+        fundingPot.contributeToRound(round1Id, 200, accessId, new bytes32[](0));
         vm.stopPrank();
 
         // Move to Round 2
@@ -1739,16 +1677,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.startPrank(contributor2_);
         fundingPotToken.approve(address(fundingPot), 400);
-        fundingPot.contributeToRound(
-            round2Id, 400, accessId, address(fundingPotToken), new bytes32[](0)
-        );
+        fundingPot.contributeToRound(round2Id, 400, accessId, new bytes32[](0));
         vm.stopPrank();
 
         vm.startPrank(contributor3_);
         fundingPotToken.approve(address(fundingPot), 600);
-        fundingPot.contributeToRound(
-            round2Id, 600, accessId, address(fundingPotToken), new bytes32[](0)
-        );
+        fundingPot.contributeToRound(round2Id, 600, accessId, new bytes32[](0));
         vm.stopPrank();
 
         // Verify Round 1 contributions

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1095,6 +1095,40 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.editAccessCriteriaForRound(roundId, 0, newAccessCriteria);
     }
 
+    /* Test: contributeToRound() unhappy paths
+    ├── Given the round has not started yet
+    │   └── When the user contributes to the round
+    │       └── Then the transaction should revert
+    │
+    ├── Given the round has ended
+    │   └── When the user contributes to the round
+    │       └── Then the transaction should revert
+    │
+    ├── Given a round has been configured with generic round configuration and access criteria
+    │   And the round has started
+    │   And the round has not ended
+    │   And the user has approved their contribution
+    │   And the total contribution cap is not yet reached
+    │   ├── Given the access criteria is an NFT
+    │   │   └── And the user does not fulfill the access criteria
+    │   │       └── When the user contributes to the round
+    │   │           └── Then the transaction should revert
+    │   │
+    │   ├── Given the access criteria is a Merkle Root
+    │   │   └── And the user does not fulfill the access criteria
+    │   │       └── When the user contributes to the round
+    │   │           └── Then the transaction should revert
+    │   │
+    │   ├── Given the access criteria is a List
+    │   │   └── And the user does not fulfill the access criteria
+    │   │       └── When the user contributes to the round
+    │   │           └── Then the transaction should revert
+    │   │
+    │   └── Given a user has already contributed up to their personal cap
+    │       └── When the user attempts to contribute again
+    │           └── Then the transaction should revert
+    */
+
     function testContributeToRound_revertsGivenContributionIsBeforeRoundStart()
         public
     {
@@ -1316,7 +1350,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.contributeToRound(roundId, 251, accessId, new bytes32[](0));
     }
 
-    /*
+    /* Test: contributeToRound() happy paths
     ├── Given a round has been configured with generic round configuration and access criteria
     │   And the round has started
     │   And the user fulfills the access criteria

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -175,12 +175,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │   └── When user attempts to create a round
     │       └── Then it should revert
     │
-    ├── And round end time == 0
+    ├── And round end time == 0 
     ├── And round cap == 0
     │   └── When user attempts to create a round
     │       └── Then it should revert
     │
-    ├── And round end time is set
+    ├── And round end time is set 
     ├── And round end != 0
     ├── And round end < round start
     │   └── When user attempts to create a round
@@ -352,7 +352,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ├── Given all the valid parameters are provided
         │   └── When user attempts to create a round
         │       └── Then it should not be active and should return the round id
-    */
+        */
 
     function testCreateRound() public {
         RoundParams memory params = _defaultRoundParams;
@@ -396,29 +396,29 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │       └── Then it should revert
     │
     └── Given user has FUNDING_POT_ADMIN_ROLE
-        ├── Given round does not exist
-        │   └── When user attempts to edit the round
-        │       └── Then it should revert
+    ├── Given round does not exist
+    │   └── When user attempts to edit the round
+    │       └── Then it should revert
         │
-        ├── Given round is active
-        │   └── When user attempts to edit the round
-        │       └── Then it should revert
+    ├── Given round is active
+    │   └── When user attempts to edit the round
+    │       └── Then it should revert
         │
-        ├── Given round start time is in the past
+    ├── Given round start time is in the past
         │   └── When user attempts to edit a round with this parameter
-        │       └── Then it should revert
+    │       └── Then it should revert
         │
         ├── Given round end time == 0 and round cap == 0
         │   └── When user attempts to edit a round with these parameters
-        │       └── Then it should revert
+    │       └── Then it should revert
         │
         ├── Given round end time is set and round end < round start
-        │   └── When user attempts to edit the round
-        │       └── Then it should revert
+    │   └── When user attempts to edit the round
+    │       └── Then it should revert
         │
         ├── Given hook contract is set but hook function is empty
-        │   └── When user attempts to edit the round
-        │       └── Then it should revert
+    │   └── When user attempts to edit the round
+    │       └── Then it should revert
         │
         ├── Given hook function is set but hook contract is empty
         │   └── When user attempts to edit the round
@@ -786,29 +786,29 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │       └── Then it should revert
     │
     └── Given user has FUNDING_POT_ADMIN_ROLE
-        ├── Given round does not exist
-        │   └── When user attempts to set access criteria
-        │       └── Then it should revert
+    ├── Given round does not exist
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
         │
-        ├── Given round is active
-        │   └── When user attempts to set access criteria
-        │       └── Then it should revert
+    ├── Given round is active
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
         │
-        ├── Given AccessCriteriaId is NFT and nftContract is 0x0
-        │   └── When user attempts to set access criteria
-        │       └── Then it should revert
+    ├── Given AccessCriteriaId is NFT and nftContract is 0x0
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
         │
-        ├── Given AccessCriteriaId is MERKLE and merkleRoot is 0x0
-        │   └── When user attempts to set access criteria
-        │       └── Then it should revert
+    ├── Given AccessCriteriaId is MERKLE and merkleRoot is 0x0
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
         │
-        ├── Given AccessCriteriaId is LIST and allowedAddresses is empty
-        │   └── When user attempts to set access criteria
-        │       └── Then it should revert
+    ├── Given AccessCriteriaId is LIST and allowedAddresses is empty
+    │   └── When user attempts to set access criteria
+    │       └── Then it should revert
         │
-        └── Given all the valid parameters are provided
-            └── When user attempts to set access criteria
-                └── Then it should not revert
+    └── Given all the valid parameters are provided
+        └── When user attempts to set access criteria
+            └── Then it should not revert
     */
 
     function testFuzzSetAccessCriteria_revertsGivenUserDoesNotHaveFundingPotAdminRole(
@@ -1072,7 +1072,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 0;
         uint amount = 250;
 
         // Warp to make the round active
@@ -1085,7 +1084,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId, 10, accessCriteriaId, new bytes32[](0)
+            roundId, 10, accessCriteriaEnum, new bytes32[](0)
         );
 
         vm.expectRevert(
@@ -1098,7 +1097,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId, amount, accessCriteriaId, new bytes32[](0)
+            roundId, amount, accessCriteriaEnum, new bytes32[](0)
         );
     }
 
@@ -1180,19 +1179,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testContributeToRound_revertsGivenNFTAccessCriteriaIsNotMet()
         public
     {
-        testCreateRound();
+        uint8 accessId = 2;
+        _helper_setupRoundWithAccessCriteria(accessId);
 
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+
         uint amount = 250;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
-
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
-            roundId, accessId, 500, 10, 0, 0, false, 0, 0, 0
-        );
+        // _helper_callSetAccessCriteriaPrivileges(
+        //     roundId, accessId, 500, 10, 0, 0, false, 0, 0, 0
+        // );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
@@ -1200,6 +1196,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Approve
         vm.prank(contributor1_);
         _token.approve(address(fundingPot), amount);
+
+        mockNFTContract.balanceOf(contributor1_);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1220,7 +1218,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 2;
+        uint8 accessId = 3;
         uint amount = 250;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
@@ -1255,7 +1253,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 3;
+        uint8 accessId = 4;
         uint amount = 250;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
@@ -1747,13 +1745,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzz_validateAccessCriteria(
         uint64 roundId_,
         uint8 accessId_,
-        bytes32[] calldata merkleProof_
+        bytes32[] calldata merkleProof_,
+        address user_
     ) external {
         vm.assume(roundId_ <= fundingPot.getRoundCount() + 1);
         vm.assume(accessId_ <= 4);
 
         try fundingPot.exposed_validateAccessCriteria(
-            roundId_, accessId_, merkleProof_
+            roundId_, accessId_, merkleProof_, msg.sender
         ) {
             assert(true);
         } catch (bytes memory) {

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -394,7 +394,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     {
         vm.assume(user_ != address(0) && user_ != address(this));
         testCreateRound();
-
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = RoundParams({

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1240,6 +1240,52 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
+    function testFuzzContributeToRound_revertsWhenContributionExceedsPersonalCap(
+    ) public {
+        testCreateRound(1000);
+
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+        uint amount = 250;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(1);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        mockNFTContract.mint(contributor_);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+
+        // Approve
+        vm.prank(contributor_);
+        fundingPotToken.approve(address(fundingPot), 500);
+
+        vm.prank(contributor_);
+        fundingPot.contributeToRound(
+            roundId,
+            amount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+
+        // Attempt to contribute beyond personal cap
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__PersonalCapReached
+                    .selector
+            )
+        );
+        vm.prank(contributor_);
+
+        fundingPot.contributeToRound(
+            roundId, 251, 0, address(fundingPotToken), new bytes32[](0)
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Test: Internal Functions
 

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -114,7 +114,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _setUpOrchestrator(fundingPot);
 
         // Initiate the Logic Module with the metadata and config data
-        fundingPot.init(_orchestrator, _METADATA, abi.encode(address(_token)));
+        fundingPot.init(_orchestrator, _METADATA, abi.encode(""));
 
         _authorizer.setIsAuthorized(address(this), true);
 
@@ -1604,6 +1604,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessId = 1;
 
         uint firstAmount = 400;
+        uint personalCap = 500;
 
         (
             address nftContract,
@@ -1615,7 +1616,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            roundId, accessId, personalCap, 0, 0, 0, false, 0, 0, 0
         );
 
         mockNFTContract.mint(contributor1_);
@@ -1633,11 +1634,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, firstAmount, accessId, new bytes32[](0)
         );
 
-        // Get the personal cap
-        uint personalCap = fundingPot.exposed_getUserPersonalCapForRound(
-            roundId, accessId, contributor1_
-        );
-
         uint secondAmount = 200;
 
         vm.prank(contributor1_);
@@ -1648,6 +1644,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint totalContribution = fundingPot.exposed_getUserContributionToRound(
             roundId, contributor1_
         );
+
         assertEq(totalContribution, personalCap);
     }
 
@@ -1698,9 +1695,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testContributeToRound_worksGivenPersonalCapAccumulation() public {
-        _defaultRoundParams.globalAccumulativeCaps = true; // global accumulative caps enabled
-
-        // Create Round 1
+        _defaultRoundParams.globalAccumulativeCaps = true;
         fundingPot.createRound(
             _defaultRoundParams.roundStart,
             _defaultRoundParams.roundEnd,
@@ -1713,22 +1708,26 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint64 round1Id = fundingPot.getRoundCount();
 
-        uint8 accessId = 1;
+        uint8 accessCriteriaId = 1;
         (
             address nftContract,
             bytes32 merkleRoot,
             address[] memory allowedAddresses
-        ) = _helper_createAccessCriteria(accessId);
-
+        ) = _helper_createAccessCriteria(accessCriteriaId);
         fundingPot.setAccessCriteriaForRound(
-            round1Id, accessId, nftContract, merkleRoot, allowedAddresses
+            round1Id,
+            accessCriteriaId,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
         );
+
         fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            round1Id, accessCriteriaId, 500, 0, 0, 0, false, 0, 0, 0
         );
+
         mockNFTContract.mint(contributor1_);
 
-        // Create Round 2
         fundingPot.createRound(
             _defaultRoundParams.roundStart + 3 days,
             _defaultRoundParams.roundEnd + 3 days,
@@ -1739,47 +1738,54 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.globalAccumulativeCaps
         );
         uint64 round2Id = fundingPot.getRoundCount();
+
         fundingPot.setAccessCriteriaForRound(
-            round2Id, accessId, nftContract, merkleRoot, allowedAddresses
+            round2Id, accessCriteriaId, address(0), bytes32(0), allowedAddresses
         );
+
+        // Set personal cap of 400 for round 2
         fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            round2Id, accessCriteriaId, 400, 0, 0, 0, false, 0, 0, 0
         );
 
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 1500);
-
-        // Contribute to Round 1
         vm.warp(_defaultRoundParams.roundStart + 1);
-        uint round1Contribution = 200;
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 1000);
         fundingPot.contributeToRound(
-            round1Id, round1Contribution, accessId, new bytes32[](0)
+            round1Id, 200, accessCriteriaId, new bytes32[](0)
         );
 
-        // Move to Round 2
+        // Warp to round 2
         vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
 
-        // Calculate unused capacity from Round 1
-        uint personalCap = fundingPot.exposed_getUserPersonalCapForRound(
-            round1Id, accessId, contributor1_
-        );
+        // Create unspent capacity structure
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap({
+            roundId: round1Id,
+            accessCriteriaId: accessCriteriaId,
+            merkleProof: new bytes32[](0)
+        });
 
+        // Contribute to round 2 with unspent capacity from round 1
         fundingPot.contributeToRound(
-            round2Id, personalCap, accessId, new bytes32[](0)
+            round2Id, 700, accessCriteriaId, new bytes32[](0), unspentCaps
         );
         vm.stopPrank();
 
+        // Verify contributions are recorded correctly
         assertEq(
             fundingPot.exposed_getUserContributionToRound(
                 round1Id, contributor1_
             ),
-            round1Contribution
+            200
         );
+
         assertEq(
             fundingPot.exposed_getUserContributionToRound(
                 round2Id, contributor1_
             ),
-            personalCap
+            700
         );
     }
 
@@ -1912,25 +1918,30 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         }
     }
 
-    function testFuzz_validateAndAdjustCaps(
+    function testFuzz_validateAndAdjustCapsWithUnspentCap(
         uint64 roundId_,
         uint amount_,
         uint8 accessId_,
-        bool canOverrideContributionSpan_
+        bool canOverrideContributionSpan_,
+        uint unspentPersonalCap_
     ) external {
         vm.assume(roundId_ > 0 && roundId_ >= fundingPot.getRoundCount());
         vm.assume(amount_ <= 1000);
         vm.assume(accessId_ <= 4);
+        vm.assume(unspentPersonalCap_ >= 0);
 
-        try fundingPot.exposed_validateAndAdjustCaps(
-            roundId_, amount_, accessId_, canOverrideContributionSpan_
+        try fundingPot.exposed_validateAndAdjustCapsWithUnspentCap(
+            roundId_,
+            amount_,
+            accessId_,
+            canOverrideContributionSpan_,
+            unspentPersonalCap_
         ) returns (uint adjustedAmount) {
             assertLe(
                 adjustedAmount, amount_, "Adjusted amount should be <= amount_"
             );
             assertGe(adjustedAmount, 0, "Adjusted amount should be >= 0");
         } catch (bytes memory reason) {
-            // Compare using keccak256 hash rather than direct string comparison
             bytes32 roundCapReachedSelector = keccak256(
                 abi.encodeWithSignature(
                     "Module__LM_PC_FundingPot__RoundCapReached()"
@@ -1948,230 +1959,11 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     "Should not revert RoundCapReached when canOverrideContributionSpan is true"
                 );
             } else if (keccak256(reason) == personalCapReachedSelector) {
-                // We expect this sometimes
                 assertTrue(true, "Personal cap reached as expected");
             } else {
                 assertTrue(false, "Unexpected revert reason");
             }
         }
-    }
-
-    // -------------------------------------------------------------------------
-    // Test: _calculateUnusedCapacityFromPreviousRounds
-
-    function test_calculateUnusedCapacityFromPreviousRounds_returnsZeroForFirstRound(
-    ) public {
-        // First round should have no unused capacity from previous rounds
-        uint64 roundId = 1;
-        uint unusedCapacity = fundingPot
-            .exposed_calculateUnusedCapacityFromPreviousRounds(roundId);
-        assertEq(unusedCapacity, 0);
-    }
-
-    function test_calculateUnusedCapacityFromPreviousRounds_withPartiallyUsedCap(
-    ) public {
-        // Create first round with cap 1000 but only use 600
-        RoundParams memory params = _defaultRoundParams;
-        params.roundStart = block.timestamp + 1 days;
-        params.roundEnd = block.timestamp + 2 days;
-        params.roundCap = 1000;
-        params.globalAccumulativeCaps = true;
-
-        uint64 roundId1 = fundingPot.createRound(
-            params.roundStart,
-            params.roundEnd,
-            params.roundCap,
-            params.hookContract,
-            params.hookFunction,
-            params.autoClosure,
-            params.globalAccumulativeCaps
-        );
-
-        // Set access criteria and privileges
-        uint8 accessId = 0;
-        (
-            address nftContract,
-            bytes32 merkleRoot,
-            address[] memory allowedAddresses
-        ) = _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(
-            roundId1, accessId, nftContract, merkleRoot, allowedAddresses
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            roundId1,
-            accessId,
-            1000, // personal cap high enough for test
-            0, // no NFT cap
-            0, // no merkle cap
-            0, // no list cap
-            false,
-            0, // no start
-            0, // no cliff
-            0 // no end
-        );
-
-        // Contribute 600 to first round
-        vm.warp(params.roundStart + 1);
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 600);
-        fundingPot.contributeToRound(roundId1, 600, accessId, new bytes32[](0));
-        vm.stopPrank();
-
-        // Check unused capacity for next round (should be 400)
-        uint64 roundId2 = 2;
-        uint unusedCapacity = fundingPot
-            .exposed_calculateUnusedCapacityFromPreviousRounds(roundId2);
-        assertEq(unusedCapacity, 400);
-    }
-
-    function test_calculateUnusedCapacityFromPreviousRounds_withMultipleRounds()
-        public
-    {
-        // Create first round with cap 1000, use 600
-        RoundParams memory params = _defaultRoundParams;
-        params.roundStart = block.timestamp + 1 days;
-        params.roundEnd = block.timestamp + 2 days;
-        params.roundCap = 1000;
-        params.globalAccumulativeCaps = true;
-
-        uint64 roundId1 = fundingPot.createRound(
-            params.roundStart,
-            params.roundEnd,
-            params.roundCap,
-            params.hookContract,
-            params.hookFunction,
-            params.autoClosure,
-            params.globalAccumulativeCaps
-        );
-
-        // Set access criteria for round 1
-        uint8 accessId = 0;
-        (
-            address nftContract,
-            bytes32 merkleRoot,
-            address[] memory allowedAddresses
-        ) = _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(
-            roundId1, accessId, nftContract, merkleRoot, allowedAddresses
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            roundId1,
-            accessId,
-            1000, // personal cap high enough for the test
-            0, // no NFT cap
-            0, // no merkle cap
-            0, // no list cap
-            false,
-            0, // no start
-            0, // no cliff
-            0 // no end
-        );
-
-        // Warp to round 1 start time and contribute
-        vm.warp(params.roundStart + 1);
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 600);
-        fundingPot.contributeToRound(roundId1, 600, accessId, new bytes32[](0));
-        vm.stopPrank();
-
-        // Create second round with cap 2000
-        uint64 roundId2 = fundingPot.createRound(
-            params.roundStart + 2 days, // Start when first round ends
-            params.roundStart + 4 days, // End 2 days after start
-            2000, // Cap of 2000
-            params.hookContract,
-            params.hookFunction,
-            params.autoClosure,
-            params.globalAccumulativeCaps
-        );
-
-        // Set access criteria for round 2
-        fundingPot.setAccessCriteriaForRound(
-            roundId2, accessId, nftContract, merkleRoot, allowedAddresses
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            roundId2,
-            accessId,
-            2000, // personal cap high enough for the test
-            0, // no NFT cap
-            0, // no merkle cap
-            0, // no list cap
-            false,
-            0, // no start
-            0, // no cliff
-            0 // no end
-        );
-
-        // Warp to round 2 start time and contribute
-        vm.warp(params.roundStart + 2 days + 1);
-        vm.startPrank(contributor2_);
-        _token.approve(address(fundingPot), 1500);
-        fundingPot.contributeToRound(roundId2, 1500, accessId, new bytes32[](0));
-        vm.stopPrank();
-
-        // Check unused capacity for third round
-        // Round 1: 400 unused (1000-600)
-        // Round 2: 500 unused (2000-1500)
-        // Total: 900 unused
-        uint64 roundId3 = 3;
-        uint unusedCapacity = fundingPot
-            .exposed_calculateUnusedCapacityFromPreviousRounds(roundId3);
-        assertEq(unusedCapacity, 900);
-    }
-
-    function test_calculateUnusedCapacityFromPreviousRounds_withoutGlobalAccumulativeCaps(
-    ) public {
-        // Create first round with cap 1000, use 600, but no global accumulative caps
-        RoundParams memory params = _defaultRoundParams;
-        params.roundStart = block.timestamp + 1 days;
-        params.roundEnd = block.timestamp + 2 days;
-        params.roundCap = 1000;
-        params.globalAccumulativeCaps = false;
-
-        uint64 roundId1 = fundingPot.createRound(
-            params.roundStart,
-            params.roundEnd,
-            params.roundCap,
-            params.hookContract,
-            params.hookFunction,
-            params.autoClosure,
-            params.globalAccumulativeCaps
-        );
-
-        // Set access criteria and privileges
-        uint8 accessId = 0;
-        (
-            address nftContract,
-            bytes32 merkleRoot,
-            address[] memory allowedAddresses
-        ) = _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(
-            roundId1, accessId, nftContract, merkleRoot, allowedAddresses
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            roundId1,
-            accessId,
-            1000, // personal cap high enough for test
-            0, // no NFT cap
-            0, // no merkle cap
-            0, // no list cap
-            false,
-            0, // no start
-            0, // no cliff
-            0 // no end
-        );
-
-        vm.warp(params.roundStart + 1);
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 600);
-        fundingPot.contributeToRound(roundId1, 600, accessId, new bytes32[](0));
-        vm.stopPrank();
-
-        // Should return 0 since global accumulative caps is disabled
-        uint64 roundId2 = 2;
-        uint unusedCapacity = fundingPot
-            .exposed_calculateUnusedCapacityFromPreviousRounds(roundId2);
-        assertEq(unusedCapacity, 0);
     }
 
     // -------------------------------------------------------------------------

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1234,7 +1234,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            roundId, accessId, 500, false, 0, 0, 0
         );
 
         // Approve
@@ -1274,7 +1274,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            roundId, accessId, 500, false, 0, 0, 0
         );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
@@ -1349,7 +1349,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            roundId, accessId, 500, false, 0, 0, 0
         );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
@@ -1389,7 +1389,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            roundId, accessId, 500, false, 0, 0, 0
         );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
@@ -1431,7 +1431,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            roundId, accessId, 500, false, 0, 0, 0
         );
 
         mockNFTContract.mint(contributor1_);
@@ -1521,7 +1521,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, 500, 100, 0, 0, false, 0, 0, 0
+            roundId, accessId, 500, false, 0, 0, 0
         );
         mockNFTContract.mint(contributor1_);
 
@@ -1572,7 +1572,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, 200, 0, 0, 0, false, 0, 0, 0
+            roundId, accessId, 200, false, 0, 0, 0
         );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
@@ -1616,7 +1616,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, personalCap, 0, 0, 0, false, 0, 0, 0
+            roundId, accessId, personalCap, false, 0, 0, 0
         );
 
         mockNFTContract.mint(contributor1_);
@@ -1669,7 +1669,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Set privileges with override capability
         fundingPot.setAccessCriteriaPrivileges(
-            roundId, accessId, 500, 200, 0, 0, true, 0, 0, 0
+            roundId, accessId, 500, true, 0, 0, 0
         );
 
         mockNFTContract.mint(contributor1_);
@@ -1723,7 +1723,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
 
         fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessCriteriaId, 500, 0, 0, 0, false, 0, 0, 0
+            round1Id, accessCriteriaId, 500, false, 0, 0, 0
         );
 
         mockNFTContract.mint(contributor1_);
@@ -1745,7 +1745,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Set personal cap of 400 for round 2
         fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessCriteriaId, 400, 0, 0, 0, false, 0, 0, 0
+            round2Id, accessCriteriaId, 400, false, 0, 0, 0
         );
 
         vm.warp(_defaultRoundParams.roundStart + 1);
@@ -1816,7 +1816,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             round1Id, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            round1Id, accessId, 500, false, 0, 0, 0
         );
 
         // Round 2 with a different cap
@@ -1835,7 +1835,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             round2Id, accessId, nftContract, merkleRoot, allowedAddresses
         );
         fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            round2Id, accessId, 500, false, 0, 0, 0
         );
 
         // Round 1: Multiple users contribute, but don't reach the cap
@@ -1999,9 +1999,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId,
             accessId,
             1000, // personal cap equal to round cap
-            0, // no NFT cap
-            0, // no merkle cap
-            0, // no list cap
             false,
             0, // no start
             0, // no cliff
@@ -2093,9 +2090,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId,
             accessId,
             1000, // personal cap equal to round cap
-            0, // no NFT cap
-            0, // no merkle cap
-            0, // no list cap
             false,
             0, // no start
             0, // no cliff

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1112,8 +1112,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
-        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
-
         // Approve
         vm.prank(contributor1_);
         _token.approve(address(fundingPot), 500);
@@ -1309,11 +1307,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, amount, accessId, new bytes32[](0)
         );
 
-        // Get the base personal cap from the contract
-        uint personalCap = fundingPot.exposed_getUserPersonalCapForRound(
-            roundId, accessId, contributor1_
-        );
-
         // Attempt to contribute beyond personal cap
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1324,7 +1317,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
         vm.prank(contributor1_);
 
-        uint remainingCap = personalCap - amount;
         fundingPot.contributeToRound(roundId, 251, accessId, new bytes32[](0));
     }
 
@@ -1410,7 +1402,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testContributeToRound_worksGivenUserCurrentContributionExceedsTheRoundCap(
-        uint roundCap_,
         uint8 accessCriteriaEnumOld,
         uint8 accessCriteriaEnumNew
     ) public {
@@ -1433,8 +1424,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, accessId, 200, 0, 0, 0, false, 0, 0, 0
         );
 
-        (uint roundStart,, uint roundCap,,,,) =
-            fundingPot.getRoundGenericParameters(roundId);
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
 
         // Approve
@@ -1732,9 +1722,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testFuzz_validateAccessCriteria(
         uint64 roundId_,
         uint8 accessId_,
-        bytes32[] calldata merkleProof_,
-        address user_
-    ) external {
+        bytes32[] calldata merkleProof_
+    ) external view {
         vm.assume(roundId_ <= fundingPot.getRoundCount() + 1);
         vm.assume(accessId_ <= 4);
 
@@ -1756,11 +1745,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.assume(roundId_ > 0 && roundId_ >= fundingPot.getRoundCount());
         vm.assume(amount_ <= 1000);
         vm.assume(accessId_ <= 4);
-
-        uint initialTotalContribution =
-            fundingPot.exposed_getTotalRoundContributions(roundId_);
-        uint initialUserContribution =
-            fundingPot.exposed_getUserContributionToRound(roundId_, msg.sender);
 
         try fundingPot.exposed_validateAndAdjustCaps(
             roundId_, amount_, accessId_, canOverrideContributionSpan_
@@ -1787,12 +1771,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     !canOverrideContributionSpan_,
                     "Should not revert RoundCapReached when canOverrideContributionSpan is true"
                 );
-                // Additional assertions commented out for now
-                // assert(roundCap > 0, "Round cap should be > 0");
-                // assert(
-                //     initialTotalContribution >= effectiveRoundCap,
-                //     "Total contribution should be >= effectiveRoundCap"
-                // );
             } else if (keccak256(reason) == personalCapReachedSelector) {
                 // We expect this sometimes
                 assertTrue(true, "Personal cap reached as expected");
@@ -1805,14 +1783,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // -------------------------------------------------------------------------
     // Helper Functions
 
-    // @notice Creates a default funding round
-    function _helper_createDefaultFundingRound(uint roundCap_)
-        internal
-        returns (RoundParams memory)
-    {
-        return _defaultRoundParams;
-    }
-
     // @notice Creates edit round parameters with customizable values
     function _helper_createEditRoundParams(
         uint roundStart_,
@@ -1822,7 +1792,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         bytes memory hookFunction_,
         bool autoClosure_,
         bool globalAccumulativeCaps_
-    ) internal returns (RoundParams memory) {
+    ) internal pure returns (RoundParams memory) {
         return RoundParams({
             roundStart: roundStart_,
             roundEnd: roundEnd_,
@@ -1836,14 +1806,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function _helper_createAccessCriteria(uint8 accessCriteriaEnum)
         internal
-        returns (ILM_PC_FundingPot_v1.AccessCriteria memory)
+        view
+        returns (ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria)
     {
         {
             if (
                 accessCriteriaEnum
                     == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN)
             ) {
-                return ILM_PC_FundingPot_v1.AccessCriteria(
+                accessCriteria = ILM_PC_FundingPot_v1.AccessCriteria(
                     ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN,
                     address(0x0),
                     bytes32(uint(0x0)),
@@ -1855,7 +1826,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             ) {
                 address nftContract = address(mockNFTContract);
 
-                return ILM_PC_FundingPot_v1.AccessCriteria(
+                accessCriteria = ILM_PC_FundingPot_v1.AccessCriteria(
                     ILM_PC_FundingPot_v1.AccessCriteriaType.NFT,
                     nftContract,
                     bytes32(uint(0x0)),
@@ -1867,7 +1838,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             ) {
                 bytes32 merkleRoot = ROOT;
 
-                return ILM_PC_FundingPot_v1.AccessCriteria(
+                accessCriteria = ILM_PC_FundingPot_v1.AccessCriteria(
                     ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE,
                     address(0x0),
                     merkleRoot,
@@ -1882,7 +1853,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 allowedAddresses[1] = address(0x2);
                 allowedAddresses[2] = address(0x3);
 
-                return ILM_PC_FundingPot_v1.AccessCriteria(
+                accessCriteria = ILM_PC_FundingPot_v1.AccessCriteria(
                     ILM_PC_FundingPot_v1.AccessCriteriaType.LIST,
                     address(0x0),
                     bytes32(uint(0x0)),

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -142,8 +142,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             true,
             true
         );
-
-        ///TODO : add array here for allowed addresses
     }
 
     // -------------------------------------------------------------------------
@@ -177,12 +175,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │   └── When user attempts to create a round
     │       └── Then it should revert
     │
-    ├── And round end time == 0 
+    ├── And round end time == 0
     ├── And round cap == 0
     │   └── When user attempts to create a round
     │       └── Then it should revert
     │
-    ├── And round end time is set 
+    ├── And round end time is set
     ├── And round end != 0
     ├── And round end < round start
     │   └── When user attempts to create a round
@@ -824,8 +822,11 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum_);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum_);
 
         vm.startPrank(user_);
         bytes32 roleId = _authorizer.generateRoleId(
@@ -836,7 +837,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId,
+            accessCriteriaEnum_,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
         vm.stopPrank();
     }
 
@@ -847,8 +854,11 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -857,7 +867,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId,
+            accessCriteriaEnum,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
     }
 
     function testFuzzSetAccessCriteria_revertsGivenRoundIsActive(
@@ -868,8 +884,11 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
@@ -881,7 +900,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId,
+            accessCriteriaEnum,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
     }
 
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsNFTAndNftContractIsZero(
@@ -892,9 +917,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
-        accessCriteria.nftContract = address(0);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
+        nftContract = address(0);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -903,7 +931,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId,
+            accessCriteriaEnum,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
     }
 
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsMerkleAndMerkleRootIsZero(
@@ -914,9 +948,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
-        accessCriteria.merkleRoot = bytes32(uint(0x0));
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
+        merkleRoot = bytes32(uint(0x0));
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -925,7 +962,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId,
+            accessCriteriaEnum,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
     }
 
     function testSetAccessCriteria_revertsGivenAccessCriteriaIdIsListAndAllowedAddressesIsEmpty(
@@ -936,9 +979,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
-        accessCriteria.allowedAddresses = new address[](0);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
+        allowedAddresses = new address[](0);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -947,7 +993,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId,
+            accessCriteriaEnum,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
     }
 
     function testFuzzSetAccessCriteria(uint8 accessCriteriaEnum) public {
@@ -956,22 +1008,37 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
-
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-
         (
-            bool isOpen,
             address nftContract,
             bytes32 merkleRoot,
             address[] memory allowedAddresses
-        ) = fundingPot.getRoundAccessCriteria(roundId, accessCriteriaEnum);
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
+
+        fundingPot.setAccessCriteriaForRound(
+            roundId,
+            accessCriteriaEnum,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
+
+        (
+            bool isOpen,
+            address retreivedNftContract,
+            bytes32 retreivedMerkleRoot,
+            bool hasAccess
+        ) = fundingPot.getRoundAccessCriteria(
+            roundId, accessCriteriaEnum, address(0x2)
+        );
 
         assertEq(isOpen, accessCriteriaEnum == 1);
-        assertEq(nftContract, accessCriteria.nftContract);
-        assertEq(merkleRoot, accessCriteria.merkleRoot);
-        assertEq(allowedAddresses, accessCriteria.allowedAddresses);
+        assertEq(retreivedNftContract, nftContract);
+        assertEq(retreivedMerkleRoot, merkleRoot);
+        if (accessCriteriaEnum == 1 || accessCriteriaEnum == 4) {
+            assertTrue(hasAccess);
+        } else {
+            assertFalse(hasAccess);
+        }
     }
 
     /* Test editAccessCriteriaForRound()
@@ -1007,10 +1074,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 0;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
 
         vm.startPrank(user_);
         bytes32 roleId = _authorizer.generateRoleId(
@@ -1022,7 +1091,11 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
         fundingPot.editAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
+            roundId,
+            accessCriteriaEnum,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
         );
         vm.stopPrank();
     }
@@ -1036,8 +1109,11 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessCriteriaId = 10; // Invalid ID
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1047,7 +1123,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
         fundingPot.editAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
+            roundId, accessCriteriaId, nftContract, merkleRoot, allowedAddresses
         );
     }
 
@@ -1058,12 +1134,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessCriteriaId = 0;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
 
         vm.expectRevert();
         fundingPot.editAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
+            roundId, accessCriteriaId, nftContract, merkleRoot, allowedAddresses
         );
     }
 
@@ -1081,8 +1160,11 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.warp(roundStart + 1);
 
         // Create a new access criteria to try to edit with
-        ILM_PC_FundingPot_v1.AccessCriteria memory newAccessCriteria =
-            _helper_createAccessCriteria((accessCriteriaEnum + 1) % 5); // Use a different access criteria type
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria((accessCriteriaEnum + 1) % 5); // Use a different access criteria type
 
         // Expect revert when trying to edit access criteria for an active round
         vm.expectRevert(
@@ -1094,7 +1176,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
 
         // Attempt to edit the access criteria for the active round
-        fundingPot.editAccessCriteriaForRound(roundId, 0, newAccessCriteria);
+        fundingPot.editAccessCriteriaForRound(
+            roundId, 0, nftContract, merkleRoot, allowedAddresses
+        );
     }
 
     /* Test: contributeToRound() unhappy paths
@@ -1140,10 +1224,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessId = 1;
         uint amount = 250;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1175,10 +1264,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessId = 0;
         uint amount = 250;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1245,10 +1339,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessId = 3;
         uint amount = 250;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1280,10 +1379,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessId = 4;
         uint amount = 250;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1317,10 +1421,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessId = 1;
         uint amount = 500;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1385,7 +1494,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │   And the user has not fully utilized their personal contribution potential in previous rounds
     │   └── When the user wants to contribute to the current round
     │       └── Then they can contribute up to their personal limit of the current round plus unfilled potential from previous rounds
-    │   
+    │
     ├── Given the round has been configured with global accumulative caps
     │   And in the previous round the round contribution cap was X
     │   And in total Y had been contributed in the previous round
@@ -1402,10 +1511,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessId = 1;
         uint amount = 250;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 100, 0, 0, false, 0, 0, 0
         );
@@ -1448,10 +1562,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessId = 0;
         uint amount = 201;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 200, 0, 0, 0, false, 0, 0, 0
         );
@@ -1486,10 +1605,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint firstAmount = 400;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1536,10 +1660,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint8 accessId = 1;
         uint amount = 250;
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
 
         // Set privileges with override capability
         fundingPot.setAccessCriteriaPrivileges(
@@ -1585,9 +1714,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 round1Id = fundingPot.getRoundCount();
 
         uint8 accessId = 1;
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(1);
-        fundingPot.setAccessCriteriaForRound(round1Id, accessCriteria);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
+
+        fundingPot.setAccessCriteriaForRound(
+            round1Id, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1604,7 +1739,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.globalAccumulativeCaps
         );
         uint64 round2Id = fundingPot.getRoundCount();
-        fundingPot.setAccessCriteriaForRound(round2Id, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            round2Id, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1664,9 +1801,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 round1Id = fundingPot.getRoundCount();
 
         uint8 accessId = 0;
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(round1Id, accessCriteria);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(
+            round1Id, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1683,7 +1825,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.globalAccumulativeCaps
         );
         uint64 round2Id = fundingPot.getRoundCount();
-        fundingPot.setAccessCriteriaForRound(round2Id, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            round2Id, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1845,9 +1989,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Set access criteria and privileges
         uint8 accessId = 0;
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(roundId1, accessCriteria);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(
+            roundId1, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId1,
             accessId,
@@ -1897,9 +2046,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Set access criteria for round 1
         uint8 accessId = 0;
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(roundId1, accessCriteria);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(
+            roundId1, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId1,
             accessId,
@@ -1932,7 +2086,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
 
         // Set access criteria for round 2
-        fundingPot.setAccessCriteriaForRound(roundId2, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId2, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId2,
             accessId,
@@ -1984,9 +2140,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Set access criteria and privileges
         uint8 accessId = 0;
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(roundId1, accessCriteria);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(
+            roundId1, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId1,
             accessId,
@@ -2034,9 +2195,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Set access criteria and privileges
         uint8 accessId = 0;
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId,
             accessId,
@@ -2123,9 +2289,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Set access criteria and privileges
         uint8 accessId = 0;
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(
+            roundId, accessId, nftContract, merkleRoot, allowedAddresses
+        );
         fundingPot.setAccessCriteriaPrivileges(
             roundId,
             accessId,
@@ -2205,58 +2376,50 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function _helper_createAccessCriteria(uint8 accessCriteriaEnum)
         internal
         view
-        returns (ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria)
+        returns (
+            address nftContract_,
+            bytes32 merkleRoot_,
+            address[] memory allowedAddresses_
+        )
     {
         {
             if (
                 accessCriteriaEnum
                     == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN)
             ) {
-                accessCriteria = ILM_PC_FundingPot_v1.AccessCriteria(
-                    ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN,
-                    address(0x0),
-                    bytes32(uint(0x0)),
-                    new address[](0)
-                );
+                nftContract_ = address(0x0);
+                merkleRoot_ = bytes32(uint(0x0));
+                allowedAddresses_ = new address[](0);
             } else if (
                 accessCriteriaEnum
                     == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.NFT)
             ) {
                 address nftContract = address(mockNFTContract);
 
-                accessCriteria = ILM_PC_FundingPot_v1.AccessCriteria(
-                    ILM_PC_FundingPot_v1.AccessCriteriaType.NFT,
-                    nftContract,
-                    bytes32(uint(0x0)),
-                    new address[](0)
-                );
+                nftContract_ = nftContract;
+                merkleRoot_ = bytes32(uint(0x0));
+                allowedAddresses_ = new address[](0);
             } else if (
                 accessCriteriaEnum
                     == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE)
             ) {
                 bytes32 merkleRoot = ROOT;
 
-                accessCriteria = ILM_PC_FundingPot_v1.AccessCriteria(
-                    ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE,
-                    address(0x0),
-                    merkleRoot,
-                    new address[](0)
-                );
+                nftContract_ = address(0x0);
+                merkleRoot_ = merkleRoot;
+                allowedAddresses_ = new address[](0);
             } else if (
                 accessCriteriaEnum
                     == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.LIST)
             ) {
                 address[] memory allowedAddresses = new address[](3);
-                allowedAddresses[0] = address(0x1);
+                allowedAddresses[0] = address(this);
                 allowedAddresses[1] = address(0x2);
                 allowedAddresses[2] = address(0x3);
 
-                accessCriteria = ILM_PC_FundingPot_v1.AccessCriteria(
-                    ILM_PC_FundingPot_v1.AccessCriteriaType.LIST,
-                    address(0x0),
-                    bytes32(uint(0x0)),
-                    allowedAddresses
-                );
+                nftContract_ = address(0x0);
+                merkleRoot_ = bytes32(uint(0x0));
+                allowedAddresses_ = allowedAddresses;
             }
         }
     }
@@ -2275,9 +2438,18 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.globalAccumulativeCaps
         );
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(accessCriteriaEnum);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(
+            roundId,
+            accessCriteriaEnum,
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -18,6 +18,8 @@ import {
     ERC20PaymentClientBaseV2Mock,
     ERC20Mock
 } from "test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV2Mock.sol";
+import {ERC721Mock} from
+    "test/utils/mocks/modules/logicModules/LM_PC_FundingPot_v2NFTMock.sol";
 
 // System under Test (SuT)
 import {LM_PC_FundingPot_v1_Exposed} from
@@ -46,6 +48,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     bytes32 internal constant FUNDING_POT_ADMIN_ROLE = "FUNDING_POT_ADMIN";
     address contributor_;
+
+    bytes32 PROOF_ONE =
+        0x0fd7c981d39bece61f7499702bf59b3114a90e66b51ba2c53abdf7b62986c00a;
+    bytes32 PROOF_TWO =
+        0xe5ebd1e1b5a5478a944ecab36a9a954ac3b6b8216875f6524caa7a1d87096576;
+    bytes32[] PROOF = [PROOF_ONE, PROOF_TWO];
+    bytes32 ROOT =
+        0xaa5d581231e596618465a56aa0f5870ba6e20785fe436d5bfb82b08662ccc7c4;
 
     // -------------------------------------------------------------------------
     // State
@@ -80,6 +90,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         bool globalAccumulativeCaps;
     }
 
+    ERC721Mock mockNFTContract = new ERC721Mock("NFT Mock", "NFT");
+
     // -------------------------------------------------------------------------
     // Setup
     function setUp() public {
@@ -87,8 +99,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         address impl = address(new LM_PC_FundingPot_v1_Exposed());
         fundingPot = LM_PC_FundingPot_v1_Exposed(Clones.clone(impl));
 
+        // Mint tokens to the contributor
         contributor_ = address(0xBeef);
-
         fundingPotToken.mint(contributor_, 10_000);
 
         // Setup the module to test
@@ -1117,6 +1129,117 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(allowedAddresses, newAccessCriteria.allowedAddresses);
     }
 
+    function testFuzzContributeToRound_revertsWhenNFTAccessCriteriaIsNotMet()
+        public
+    {
+        testCreateRound(1000);
+
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+        uint amount = 250;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(1);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+
+        // Approve
+        vm.prank(contributor_);
+        fundingPotToken.approve(address(fundingPot), amount);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__AccessCriteriaNftFailed
+                    .selector
+            )
+        );
+
+        vm.prank(contributor_);
+        fundingPot.contributeToRound(
+            roundId,
+            amount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+    }
+
+    function testFuzzContributeToRound_revertsWhenMerkleRootAccessCriteriaIsNotMet(
+    ) public {
+        testCreateRound(1000);
+
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+        uint amount = 250;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(2);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+
+        // Approve
+        vm.prank(contributor_);
+        fundingPotToken.approve(address(fundingPot), amount);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__AccessCriteriaMerkleFailed
+                    .selector
+            )
+        );
+
+        vm.prank(contributor_);
+        fundingPot.contributeToRound(
+            roundId, amount, accessId, address(fundingPotToken), PROOF
+        );
+    }
+
+    function testFuzzContributeToRound_revertsWhenAllowedListAccessCriteriaIsNotMet(
+    ) public {
+        testCreateRound(1000);
+
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+        uint amount = 250;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(3);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+
+        // Approve
+        vm.prank(contributor_);
+        fundingPotToken.approve(address(fundingPot), amount);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__AccessCriteriaListFailed
+                    .selector
+            )
+        );
+
+        vm.prank(contributor_);
+        fundingPot.contributeToRound(
+            roundId,
+            amount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Test: Internal Functions
 
@@ -1171,7 +1294,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 accessCriteriaEnum
                     == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.NFT)
             ) {
-                address nftContract = address(0x1);
+                address nftContract = address(mockNFTContract);
 
                 return ILM_PC_FundingPot_v1.AccessCriteria(
                     ILM_PC_FundingPot_v1.AccessCriteriaType.NFT,
@@ -1183,7 +1306,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 accessCriteriaEnum
                     == uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE)
             ) {
-                bytes32 merkleRoot = bytes32(uint(0x1));
+                bytes32 merkleRoot = ROOT;
 
                 return ILM_PC_FundingPot_v1.AccessCriteria(
                     ILM_PC_FundingPot_v1.AccessCriteriaType.MERKLE,

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1108,7 +1108,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1143,7 +1143,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1177,10 +1177,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint64 roundId = fundingPot.getRoundCount();
 
         uint amount = 250;
-
-        // _helper_callSetAccessCriteriaPrivileges(
-        //     roundId, accessId, 500, 10, 0, 0, false, 0, 0, 0
-        // );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
@@ -1217,7 +1213,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1252,7 +1248,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1289,7 +1285,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1374,7 +1370,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 100, 0, 0, false, 0, 0, 0
         );
         mockNFTContract.mint(contributor1_);
@@ -1420,7 +1416,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 200, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1458,7 +1454,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1510,7 +1506,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
 
         // Set privileges with override capability
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             roundId, accessId, 500, 200, 0, 0, true, 0, 0, 0
         );
 
@@ -1556,7 +1552,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(1);
         fundingPot.setAccessCriteriaForRound(round1Id, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
         mockNFTContract.mint(contributor1_);
@@ -1573,7 +1569,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
         uint64 round2Id = fundingPot.getRoundCount();
         fundingPot.setAccessCriteriaForRound(round2Id, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1635,7 +1631,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
         fundingPot.setAccessCriteriaForRound(round1Id, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1652,7 +1648,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
         uint64 round2Id = fundingPot.getRoundCount();
         fundingPot.setAccessCriteriaForRound(round2Id, accessCriteria);
-        _helper_callSetAccessCriteriaPrivileges(
+        fundingPot.setAccessCriteriaPrivileges(
             round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
@@ -1874,31 +1870,5 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessCriteriaEnum);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
-    }
-
-    function _helper_callSetAccessCriteriaPrivileges(
-        uint64 roundId,
-        uint8 accessId,
-        uint personalCap,
-        uint capByNFT,
-        uint capByMerkle,
-        uint capByList,
-        bool canOverrideTimeConstraints,
-        uint start,
-        uint cliff,
-        uint end
-    ) internal {
-        fundingPot.setAccessCriteriaPrivileges(
-            roundId,
-            accessId,
-            personalCap,
-            capByNFT,
-            capByMerkle,
-            capByList,
-            canOverrideTimeConstraints,
-            start,
-            cliff,
-            end
-        );
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -67,7 +67,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint roundCap;
         address hookContract;
         bytes hookFunction;
-        bool closureMechanism;
+        bool autoClosure;
         bool globalAccumulativeCaps;
     }
     // SuT
@@ -106,17 +106,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         contributor2_ = address(0xDEAD);
         contributor3_ = address(0xCAFE);
 
-        fundingPotToken.mint(contributor1_, 10_000);
-        fundingPotToken.mint(contributor2_, 10_000);
-        fundingPotToken.mint(contributor3_, 10_000);
+        _token.mint(contributor1_, 10_000);
+        _token.mint(contributor2_, 10_000);
+        _token.mint(contributor3_, 10_000);
 
         // Setup the module to test
         _setUpOrchestrator(fundingPot);
 
         // Initiate the Logic Module with the metadata and config data
-        fundingPot.init(
-            _orchestrator, _METADATA, abi.encode(address(fundingPotToken))
-        );
+        fundingPot.init(_orchestrator, _METADATA, abi.encode(address(_token)));
 
         _authorizer.setIsAuthorized(address(this), true);
 
@@ -214,7 +212,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 IModule_v1.Module__CallerNotAuthorized.selector, roleId, user_
             )
         );
-        RoundParams memory params = _helper_createDefaultFundingRound();
+        RoundParams memory params = _defaultRoundParams;
+
         fundingPot.createRound(
             params.roundStart,
             params.roundEnd,
@@ -231,7 +230,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         public
     {
         vm.assume(roundStart_ < block.timestamp);
-        RoundParams memory params = _helper_createDefaultFundingRound();
+        RoundParams memory params = _defaultRoundParams;
+
         params.roundStart = roundStart_;
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -254,7 +254,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testCreateRound_revertsGivenRoundEndTimeAndCapAreBothZero()
         public
     {
-        RoundParams memory params = _helper_createDefaultFundingRound();
+        RoundParams memory params = _defaultRoundParams;
+
         params.roundEnd = 0;
         params.roundCap = 0;
         vm.expectRevert(
@@ -278,7 +279,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testCreateRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
         uint roundEnd_
     ) public {
-        RoundParams memory params = _helper_createDefaultFundingRound();
+        RoundParams memory params = _defaultRoundParams;
+
         vm.assume(roundEnd_ != 0 && roundEnd_ < params.roundStart);
         params.roundEnd = roundEnd_;
         vm.expectRevert(
@@ -301,7 +303,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testCreateRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty(
     ) public {
-        RoundParams memory params = _helper_createDefaultFundingRound();
+        RoundParams memory params = _defaultRoundParams;
         params.hookContract = address(1);
         params.hookFunction = bytes("");
         vm.expectRevert(
@@ -324,7 +326,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testCreateRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty(
     ) public {
-        RoundParams memory params = _helper_createDefaultFundingRound();
+        RoundParams memory params = _defaultRoundParams;
+
         params.hookContract = address(0);
         params.hookFunction = bytes("test");
         vm.expectRevert(
@@ -429,7 +432,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testEditRound_revertsGivenUserIsNotFundingPotAdmin(address user_)
         public
     {
-        testCreateRound(1000);
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = RoundParams({
@@ -465,9 +468,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testEditRound_revertsGivenRoundIsNotCreated() public {
-        testCreateRound(1000);
-        uint64 roundId = fundingPot.getRoundCount() + 1;
-
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = RoundParams({
@@ -500,7 +501,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testEditRound_revertsGivenRoundIsActive() public {
-        testCreateRound(1000);
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params;
@@ -547,20 +548,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testEditRound_revertsGivenRoundStartIsInThePast(uint roundStartP_)
         public
     {
-        testCreateRound(1000);
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-
-        RoundParameters memory editedParams = _helper_createEditedRoundParams();
+        _editedRoundParams;
         vm.assume(roundStartP_ < block.timestamp);
-        RoundParams memory params = RoundParams({
-            roundStart: roundStartP_,
-            roundEnd: block.timestamp + 4 days,
-            roundCap: 2000,
-            hookContract: address(0x1),
-            hookFunction: bytes("test"),
-            autoClosure: true,
-            globalAccumulativeCaps: true
-        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -572,18 +563,18 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         fundingPot.editRound(
             roundId,
-            params.roundStart,
-            params.roundEnd,
-            params.roundCap,
-            params.hookContract,
-            params.hookFunction,
-            params.autoClosure,
-            params.globalAccumulativeCaps
+            _editedRoundParams.roundStart,
+            _editedRoundParams.roundEnd,
+            _editedRoundParams.roundCap,
+            _editedRoundParams.hookContract,
+            _editedRoundParams.hookFunction,
+            _editedRoundParams.autoClosure,
+            _editedRoundParams.globalAccumulativeCaps
         );
     }
 
     function testEditRound_revertsGivenRoundEndTimeAndCapAreBothZero() public {
-        testCreateRound(1000);
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = RoundParams({
@@ -624,7 +615,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundEnd_ != 0 && roundStart_ > block.timestamp
                 && roundEnd_ < roundStart_
         );
-        testCreateRound(1000);
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         // Get the current round start time
@@ -668,7 +659,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty()
         public
     {
-        testCreateRound(1000);
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = _helper_createEditRoundParams(
@@ -704,7 +695,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty()
         public
     {
-        testCreateRound(1000);
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = _helper_createEditRoundParams(
@@ -752,7 +743,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     */
 
     function testEditRound() public {
-        testCreateRound(1000);
+        testCreateRound();
         uint64 lastRoundId = fundingPot.getRoundCount();
 
         RoundParams memory params = _editedRoundParams;
@@ -827,7 +818,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.assume(accessCriteriaEnum_ >= 0 && accessCriteriaEnum_ <= 4);
         vm.assume(user_ != address(0) && user_ != address(this));
 
-        testCreateRound(1000);
+        testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
@@ -1004,10 +995,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 ├── Then it should not revert
                 └── Then the access criteria should be updated
     */
-    function testContributeToRound_revertsGivenRoundContributionCapReached(
-        uint roundCap_
-    ) public {
-        testCreateRound(10);
 
     function testFuzzEditAccessCriteriaForRound_revertsGivenUserDoesNotHaveFundingPotAdminRole(
         uint8 accessCriteriaEnum,
@@ -1086,6 +1073,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessCriteriaId = 0;
+        uint amount = 250;
 
         // Warp to make the round active
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
@@ -1093,10 +1081,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), 110);
+        _token.approve(address(fundingPot), 110);
 
         vm.prank(contributor1_);
-        fundingPot.contributeToRound(roundId, 10, accessId, new bytes32[](0));
+        fundingPot.contributeToRound(
+            roundId, 10, accessCriteriaId, new bytes32[](0)
+        );
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1108,14 +1098,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
-            roundId, amount, accessId, new bytes32[](0)
+            roundId, amount, accessCriteriaId, new bytes32[](0)
         );
     }
 
     function testContributeToRound_revertsGivenContributionIsBeforeRoundStart()
         public
     {
-        testCreateRound(1000);
+        testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 1;
@@ -1124,7 +1114,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1133,7 +1123,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), 500);
+        _token.approve(address(fundingPot), 500);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1152,7 +1142,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testContributeToRound_revertsGivenContributionIsAfterRoundEnd()
         public
     {
-        testCreateRound(1000);
+        testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 0;
@@ -1161,7 +1151,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1171,7 +1161,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), 500);
+        _token.approve(address(fundingPot), 500);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1190,7 +1180,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testContributeToRound_revertsGivenNFTAccessCriteriaIsNotMet()
         public
     {
-        testCreateRound(1000);
+        testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 1;
@@ -1199,7 +1189,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             roundId, accessId, 500, 10, 0, 0, false, 0, 0, 0
         );
@@ -1209,7 +1199,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), amount);
+        _token.approve(address(fundingPot), amount);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1227,7 +1217,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testContributeToRound_revertsGivenMerkleRootAccessCriteriaIsNotMet(
     ) public {
-        testCreateRound(1000);
+        testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 2;
@@ -1236,7 +1226,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1246,7 +1236,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), amount);
+        _token.approve(address(fundingPot), amount);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1262,7 +1252,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testontributeToRound_revertsGivenAllowedListAccessCriteriaIsNotMet(
     ) public {
-        testCreateRound(1000);
+        testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 3;
@@ -1271,7 +1261,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1281,7 +1271,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), amount);
+        _token.approve(address(fundingPot), amount);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1299,7 +1289,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testContributeToRound_revertsGivenPreviousContributionExceedsPersonalCap(
     ) public {
-        testCreateRound(1000);
+        testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 1;
@@ -1308,7 +1298,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1320,7 +1310,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), 1000);
+        _token.approve(address(fundingPot), 1000);
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
@@ -1390,7 +1380,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │
     */
     function testContributeToRound_worksGivenAllConditionsMet() public {
-        testCreateRound(1000);
+        testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 1;
@@ -1399,7 +1389,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             roundId, accessId, 500, 100, 0, 0, false, 0, 0, 0
         );
@@ -1410,7 +1400,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), 500);
+        _token.approve(address(fundingPot), 500);
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
@@ -1428,7 +1418,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testContributeToRound_worksGivenUserCurrentContributionExceedsTheRoundCap(
-        uint roundCap_
+        uint roundCap_,
+        uint8 accessCriteriaEnumOld,
+        uint8 accessCriteriaEnumNew
     ) public {
         vm.assume(accessCriteriaEnumOld >= 0 && accessCriteriaEnumOld <= 4);
         vm.assume(
@@ -1444,7 +1436,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1455,7 +1447,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), amount);
+        _token.approve(address(fundingPot), amount);
 
         vm.prank(contributor1_);
         fundingPot.contributeToRound(
@@ -1473,7 +1465,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testContributeToRound_worksGivenContributionPartiallyExceedingPersonalCap(
     ) public {
-        testCreateRound(1000);
+        testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 1;
@@ -1483,7 +1475,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1495,7 +1487,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), 1000 ether);
+        _token.approve(address(fundingPot), 1000 ether);
 
         // First contribution
         vm.prank(contributor1_);
@@ -1524,7 +1516,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testContributeToRound_worksGivenUserCanOverrideTimeConstraints()
         public
     {
-        testCreateRound(1000);
+        testCreateRound();
 
         uint64 roundId = fundingPot.getRoundCount();
         uint8 accessId = 1;
@@ -1533,7 +1525,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
 
-        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
 
         // Set privileges with override capability
         _helper_callSetAccessCriteriaPrivileges(
@@ -1548,7 +1540,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Approve
         vm.prank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), amount);
+        _token.approve(address(fundingPot), amount);
 
         // This should succeed despite being after round end, due to override privilege
         vm.prank(contributor1_);
@@ -1563,33 +1555,25 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testContributeToRound_worksGivenPersonalCapAccumulation() public {
-        (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool closureMechanism,
-            bool globalAccumulativeCaps
-        ) = _helper_createDefaultFundingRound(1000);
-        globalAccumulativeCaps = true; // global accumulative caps enabled
+        _defaultRoundParams.globalAccumulativeCaps = true; // global accumulative caps enabled
 
-        // Round 1
+        // Create Round 1
         fundingPot.createRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
+            _defaultRoundParams.roundStart,
+            _defaultRoundParams.roundEnd,
+            _defaultRoundParams.roundCap,
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            _defaultRoundParams.globalAccumulativeCaps
         );
+
         uint64 round1Id = fundingPot.getRoundCount();
 
         uint8 accessId = 1;
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(1);
-        fundingPot.setAccessCriteriaForRound(round1Id, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(round1Id, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1597,32 +1581,32 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Create Round 2
         fundingPot.createRound(
-            roundStart + 3 days,
-            roundEnd + 3 days,
-            roundCap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
+            _defaultRoundParams.roundStart + 3 days,
+            _defaultRoundParams.roundEnd + 3 days,
+            _defaultRoundParams.roundCap,
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            _defaultRoundParams.globalAccumulativeCaps
         );
         uint64 round2Id = fundingPot.getRoundCount();
-        fundingPot.setAccessCriteriaForRound(round2Id, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(round2Id, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
         vm.startPrank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), 1500);
+        _token.approve(address(fundingPot), 1500);
 
         // Contribute to Round 1
-        vm.warp(roundStart + 1);
+        vm.warp(_defaultRoundParams.roundStart + 1);
         uint round1Contribution = 200;
         fundingPot.contributeToRound(
             round1Id, round1Contribution, accessId, new bytes32[](0)
         );
 
         // Move to Round 2
-        vm.warp(roundStart + 3 days + 1);
+        vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
 
         // Calculate unused capacity from Round 1
         uint personalCap = fundingPot.exposed_getUserPersonalCapForRound(
@@ -1651,33 +1635,24 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testContributeToRound_worksGivenTotalRoundCapAccumulation()
         public
     {
-        (
-            uint roundStart,
-            uint roundEnd,
-            uint roundCap,
-            address hookContract,
-            bytes memory hookFunction,
-            bool closureMechanism,
-            bool globalAccumulativeCaps
-        ) = _helper_createDefaultFundingRound(1000);
-        globalAccumulativeCaps = true;
+        _defaultRoundParams.globalAccumulativeCaps = true; // global accumulative caps enabled
 
         // Create Round 1
         fundingPot.createRound(
-            roundStart,
-            roundEnd,
-            roundCap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
+            _defaultRoundParams.roundStart,
+            _defaultRoundParams.roundEnd,
+            _defaultRoundParams.roundCap,
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            _defaultRoundParams.globalAccumulativeCaps
         );
         uint64 round1Id = fundingPot.getRoundCount();
 
         uint8 accessId = 0;
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessId);
-        fundingPot.setAccessCriteriaForRound(round1Id, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(round1Id, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
@@ -1685,49 +1660,49 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Round 2 with a different cap
         uint round2Cap = 500;
         fundingPot.createRound(
-            roundStart + 3 days,
-            roundEnd + 3 days,
+            _defaultRoundParams.roundStart,
+            _defaultRoundParams.roundEnd,
             round2Cap,
-            hookContract,
-            hookFunction,
-            closureMechanism,
-            globalAccumulativeCaps
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            _defaultRoundParams.globalAccumulativeCaps
         );
         uint64 round2Id = fundingPot.getRoundCount();
-        fundingPot.setAccessCriteriaForRound(round2Id, accessId, accessCriteria);
+        fundingPot.setAccessCriteriaForRound(round2Id, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
             round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
         );
 
         // Round 1: Multiple users contribute, but don't reach the cap
-        vm.warp(roundStart + 1);
+        vm.warp(_defaultRoundParams.roundStart + 1);
 
         vm.startPrank(contributor1_);
-        fundingPotToken.approve(address(fundingPot), 300);
+        _token.approve(address(fundingPot), 300);
         fundingPot.contributeToRound(round1Id, 300, accessId, new bytes32[](0));
         vm.stopPrank();
 
         vm.startPrank(contributor2_);
-        fundingPotToken.approve(address(fundingPot), 200);
+        _token.approve(address(fundingPot), 200);
         fundingPot.contributeToRound(round1Id, 200, accessId, new bytes32[](0));
         vm.stopPrank();
 
         // Move to Round 2
-        vm.warp(roundStart + 3 days + 1);
+        vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
 
-        uint unusedCapacityFromRound1 =
-            roundCap - fundingPot.exposed_getTotalRoundContributions(round1Id);
+        uint unusedCapacityFromRound1 = _defaultRoundParams.roundCap
+            - fundingPot.exposed_getTotalRoundContributions(round1Id);
         uint totalAvailableCapacityRound2 = round2Cap + unusedCapacityFromRound1;
 
         // Round 2: Contributors try to use the accumulated capacity
 
         vm.startPrank(contributor2_);
-        fundingPotToken.approve(address(fundingPot), 400);
+        _token.approve(address(fundingPot), 400);
         fundingPot.contributeToRound(round2Id, 400, accessId, new bytes32[](0));
         vm.stopPrank();
 
         vm.startPrank(contributor3_);
-        fundingPotToken.approve(address(fundingPot), 600);
+        _token.approve(address(fundingPot), 600);
         fundingPot.contributeToRound(round2Id, 600, accessId, new bytes32[](0));
         vm.stopPrank();
 
@@ -1942,5 +1917,31 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _helper_createAccessCriteria(accessCriteriaEnum);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+    }
+
+    function _helper_callSetAccessCriteriaPrivileges(
+        uint64 roundId,
+        uint8 accessId,
+        uint personalCap,
+        uint capByNFT,
+        uint capByMerkle,
+        uint capByList,
+        bool canOverrideTimeConstraints,
+        uint start,
+        uint cliff,
+        uint end
+    ) internal {
+        fundingPot.setAccessCriteriaPrivileges(
+            roundId,
+            accessId,
+            personalCap,
+            capByNFT,
+            capByMerkle,
+            capByList,
+            canOverrideTimeConstraints,
+            start,
+            cliff,
+            end
+        );
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -953,7 +953,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 0;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);
@@ -965,7 +964,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address nftContract,
             bytes32 merkleRoot,
             address[] memory allowedAddresses
-        ) = fundingPot.getRoundAccessCriteria(roundId, accessCriteriaId);
+        ) = fundingPot.getRoundAccessCriteria(roundId, accessCriteriaEnum);
 
         assertEq(isOpen, accessCriteriaEnum == 1);
         assertEq(nftContract, accessCriteria.nftContract);
@@ -1071,35 +1070,29 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     ) public {
         vm.assume(accessCriteriaEnum >= 0 && accessCriteriaEnum <= 4);
 
+        // Set up a round with access criteria
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnum);
         uint64 roundId = fundingPot.getRoundCount();
-        uint amount = 250;
 
         // Warp to make the round active
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
 
-        // Approve
-        vm.prank(contributor1_);
-        _token.approve(address(fundingPot), 110);
+        // Create a new access criteria to try to edit with
+        ILM_PC_FundingPot_v1.AccessCriteria memory newAccessCriteria =
+            _helper_createAccessCriteria((accessCriteriaEnum + 1) % 5); // Use a different access criteria type
 
-        vm.prank(contributor1_);
-        fundingPot.contributeToRound(
-            roundId, 10, accessCriteriaEnum, new bytes32[](0)
-        );
-
+        // Expect revert when trying to edit access criteria for an active round
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__PersonalCapReached
+                    .Module__LM_PC_FundingPot__RoundAlreadyStarted
                     .selector
             )
         );
 
-        vm.prank(contributor1_);
-        fundingPot.contributeToRound(
-            roundId, amount, accessCriteriaEnum, new bytes32[](0)
-        );
+        // Attempt to edit the access criteria for the active round
+        fundingPot.editAccessCriteriaForRound(roundId, 0, newAccessCriteria);
     }
 
     function testContributeToRound_revertsGivenContributionIsBeforeRoundStart()

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -142,6 +142,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             true,
             true
         );
+
+        ///TODO : add array here for allowed addresses
     }
 
     // -------------------------------------------------------------------------

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1004,7 +1004,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 ├── Then it should not revert
                 └── Then the access criteria should be updated
     */
-    function testFuzzContributeToRound_revertsGivenRoundContributionCapReached(
+    function testContributeToRound_revertsGivenRoundContributionCapReached(
         uint roundCap_
     ) public {
         testCreateRound(10);
@@ -1112,8 +1112,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzContributeToRound_revertsGivenContributionIsBeforeRoundStart(
-    ) public {
+    function testContributeToRound_revertsGivenContributionIsBeforeRoundStart()
+        public
+    {
         testCreateRound(1000);
 
         uint64 roundId = fundingPot.getRoundCount();
@@ -1121,9 +1122,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint amount = 250;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(0);
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
 
@@ -1145,19 +1149,22 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzContributeToRound_revertsGivenContributionIsAfterRoundEnd()
+    function testContributeToRound_revertsGivenContributionIsAfterRoundEnd()
         public
     {
         testCreateRound(1000);
 
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessId = 0;
         uint amount = 250;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(0);
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 10 days);
@@ -1180,7 +1187,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzContributeToRound_revertsGivenNFTAccessCriteriaIsNotMet()
+    function testContributeToRound_revertsGivenNFTAccessCriteriaIsNotMet()
         public
     {
         testCreateRound(1000);
@@ -1190,9 +1197,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint amount = 250;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(1);
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 10, 0, 0, false, 0, 0, 0
+        );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
@@ -1215,18 +1225,21 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzContributeToRound_revertsGivenMerkleRootAccessCriteriaIsNotMet(
+    function testContributeToRound_revertsGivenMerkleRootAccessCriteriaIsNotMet(
     ) public {
         testCreateRound(1000);
 
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessId = 2;
         uint amount = 250;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(2);
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
@@ -1247,18 +1260,21 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.contributeToRound(roundId, amount, accessId, PROOF);
     }
 
-    function testFuzzContributeToRound_revertsGivenAllowedListAccessCriteriaIsNotMet(
+    function testontributeToRound_revertsGivenAllowedListAccessCriteriaIsNotMet(
     ) public {
         testCreateRound(1000);
 
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessId = 1;
+        uint8 accessId = 3;
         uint amount = 250;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(3);
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
@@ -1281,7 +1297,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzContributeToRound_revertsGivenPreviousContributionExceedsPersonalCap(
+    function testContributeToRound_revertsGivenPreviousContributionExceedsPersonalCap(
     ) public {
         testCreateRound(1000);
 
@@ -1290,9 +1306,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint amount = 500;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(1);
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
 
         mockNFTContract.mint(contributor1_);
 
@@ -1309,8 +1328,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
 
         // Get the base personal cap from the contract
-        uint personalCap =
-            fundingPot.exposed_getUserPersonalCap(roundId, contributor1_);
+        uint personalCap = fundingPot.exposed_getUserPersonalCapForRound(
+            roundId, accessId, contributor1_
+        );
 
         // Attempt to contribute beyond personal cap
         vm.expectRevert(
@@ -1369,7 +1389,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │           And the funds are transferred into the funding pot
     │
     */
-    function testFuzzContributeToRound_worksGivenAllConditionsMet() public {
+    function testContributeToRound_worksGivenAllConditionsMet() public {
         testCreateRound(1000);
 
         uint64 roundId = fundingPot.getRoundCount();
@@ -1377,10 +1397,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint amount = 250;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(1);
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
-
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 100, 0, 0, false, 0, 0, 0
+        );
         mockNFTContract.mint(contributor1_);
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
@@ -1400,12 +1422,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         assertEq(totalContributions, amount);
 
-        uint personalContributions =
-            fundingPot.exposed_getUserContribution(roundId, contributor1_);
+        uint personalContributions = fundingPot
+            .exposed_getUserContributionToRound(roundId, contributor1_);
         assertEq(personalContributions, amount);
     }
 
-    function testFuzzContributeToRound_worksGivenUserCurrentContributionExceedsTheRoundCap(
+    function testContributeToRound_worksGivenUserCurrentContributionExceedsTheRoundCap(
         uint roundCap_
     ) public {
         vm.assume(accessCriteriaEnumOld >= 0 && accessCriteriaEnumOld <= 4);
@@ -1416,13 +1438,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         _helper_setupRoundWithAccessCriteria(accessCriteriaEnumOld);
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 0;
+        uint8 accessId = 0;
+        uint amount = 201;
 
-        // Create and apply new access criteria
-        ILM_PC_FundingPot_v1.AccessCriteria memory newAccessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnumNew);
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
 
         (uint roundStart,, uint roundCap,,,,) =
             fundingPot.getRoundGenericParameters(roundId);
@@ -1439,11 +1464,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // only the amount that does not exceed the roundcap is contributed
         assertEq(
-            fundingPot.exposed_getUserContribution(roundId, contributor1_), 200
+            fundingPot.exposed_getUserContributionToRound(
+                roundId, contributor1_
+            ),
+            200
         );
     }
 
-    function testFuzzContributeToRound_worksGivenContributionPartiallyExceedingPersonalCap(
+    function testContributeToRound_worksGivenContributionPartiallyExceedingPersonalCap(
     ) public {
         testCreateRound(1000);
 
@@ -1453,9 +1481,12 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint firstAmount = 400;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(1);
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
 
         mockNFTContract.mint(contributor1_);
 
@@ -1473,8 +1504,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
 
         // Get the personal cap
-        uint personalCap =
-            fundingPot.exposed_getUserPersonalCap(roundId, contributor1_);
+        uint personalCap = fundingPot.exposed_getUserPersonalCapForRound(
+            roundId, accessId, contributor1_
+        );
 
         uint secondAmount = 200;
 
@@ -1483,13 +1515,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             roundId, secondAmount, accessId, new bytes32[](0)
         );
 
-        uint totalContribution =
-            fundingPot.exposed_getUserContribution(roundId, contributor1_);
+        uint totalContribution = fundingPot.exposed_getUserContributionToRound(
+            roundId, contributor1_
+        );
         assertEq(totalContribution, personalCap);
     }
 
-    function testFuzzContributeToRound_worksGivenUserCanOverrideTimeConstraints(
-    ) public {
+    function testContributeToRound_worksGivenUserCanOverrideTimeConstraints()
+        public
+    {
         testCreateRound(1000);
 
         uint64 roundId = fundingPot.getRoundCount();
@@ -1497,19 +1531,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint amount = 250;
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(1);
+            _helper_createAccessCriteria(accessId);
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
 
         // Set privileges with override capability
-        fundingPot.setAccessCriteriaPrivileges(
-            roundId,
-            accessId,
-            500, // personalCap
-            true, // overrideCap (can override time constraints)
-            0, // start
-            0, // cliff
-            0 // end
+        _helper_callSetAccessCriteriaPrivileges(
+            roundId, accessId, 500, 200, 0, 0, true, 0, 0, 0
         );
 
         mockNFTContract.mint(contributor1_);
@@ -1562,6 +1590,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(1);
         fundingPot.setAccessCriteriaForRound(round1Id, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
         mockNFTContract.mint(contributor1_);
 
         // Create Round 2
@@ -1576,6 +1607,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
         uint64 round2Id = fundingPot.getRoundCount();
         fundingPot.setAccessCriteriaForRound(round2Id, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
 
         vm.startPrank(contributor1_);
         fundingPotToken.approve(address(fundingPot), 1500);
@@ -1591,23 +1625,26 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.warp(roundStart + 3 days + 1);
 
         // Calculate unused capacity from Round 1
-        uint basePersonalCap =
-            fundingPot.exposed_getUserPersonalCap(round1Id, contributor1_);
-        uint unusedCapacityFromRound1 = basePersonalCap - round1Contribution;
+        uint personalCap = fundingPot.exposed_getUserPersonalCapForRound(
+            round1Id, accessId, contributor1_
+        );
 
-        uint round2MaxContribution = basePersonalCap + unusedCapacityFromRound1;
         fundingPot.contributeToRound(
-            round2Id, round2MaxContribution, accessId, new bytes32[](0)
+            round2Id, personalCap, accessId, new bytes32[](0)
         );
         vm.stopPrank();
 
         assertEq(
-            fundingPot.exposed_getUserContribution(round1Id, contributor1_),
+            fundingPot.exposed_getUserContributionToRound(
+                round1Id, contributor1_
+            ),
             round1Contribution
         );
         assertEq(
-            fundingPot.exposed_getUserContribution(round2Id, contributor1_),
-            round2MaxContribution
+            fundingPot.exposed_getUserContributionToRound(
+                round2Id, contributor1_
+            ),
+            personalCap
         );
     }
 
@@ -1639,8 +1676,11 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint8 accessId = 0;
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(0);
+            _helper_createAccessCriteria(accessId);
         fundingPot.setAccessCriteriaForRound(round1Id, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            round1Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
 
         // Round 2 with a different cap
         uint round2Cap = 500;
@@ -1655,6 +1695,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
         uint64 round2Id = fundingPot.getRoundCount();
         fundingPot.setAccessCriteriaForRound(round2Id, accessId, accessCriteria);
+        _helper_callSetAccessCriteriaPrivileges(
+            round2Id, accessId, 500, 0, 0, 0, false, 0, 0, 0
+        );
+
         // Round 1: Multiple users contribute, but don't reach the cap
         vm.warp(roundStart + 1);
 
@@ -1690,19 +1734,31 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Verify Round 1 contributions
         assertEq(fundingPot.exposed_getTotalRoundContributions(round1Id), 500);
         assertEq(
-            fundingPot.exposed_getUserContribution(round1Id, contributor1_), 300
+            fundingPot.exposed_getUserContributionToRound(
+                round1Id, contributor1_
+            ),
+            300
         );
         assertEq(
-            fundingPot.exposed_getUserContribution(round1Id, contributor2_), 200
+            fundingPot.exposed_getUserContributionToRound(
+                round1Id, contributor2_
+            ),
+            200
         );
 
         // Verify Round 2 contributions
         assertEq(fundingPot.exposed_getTotalRoundContributions(round2Id), 1000);
         assertEq(
-            fundingPot.exposed_getUserContribution(round2Id, contributor2_), 400
+            fundingPot.exposed_getUserContributionToRound(
+                round2Id, contributor2_
+            ),
+            400
         );
         assertEq(
-            fundingPot.exposed_getUserContribution(round2Id, contributor3_), 600
+            fundingPot.exposed_getUserContributionToRound(
+                round2Id, contributor3_
+            ),
+            600
         );
 
         assertEq(

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -44,10 +44,22 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // -------------------------------------------------------------------------
     // Constants
 
+    bytes32 internal constant FUNDING_POT_ADMIN_ROLE = "FUNDING_POT_ADMIN";
+    address contributor_;
+
     // -------------------------------------------------------------------------
     // State
-
+    struct RoundParameters {
+        uint roundStart;
+        uint roundEnd;
+        uint roundCap;
+        address hookContract;
+        bytes hookFunction;
+        bool closureMechanism;
+        bool globalAccumulativeCaps;
+    }
     // SuT
+
     LM_PC_FundingPot_v1_Exposed fundingPot;
 
     // Storage variables to avoid stack too deep
@@ -74,6 +86,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Deploy the SuT
         address impl = address(new LM_PC_FundingPot_v1_Exposed());
         fundingPot = LM_PC_FundingPot_v1_Exposed(Clones.clone(impl));
+
+        contributor_ = address(0xBeef);
+
+        fundingPotToken.mint(contributor_, 10_000);
 
         // Setup the module to test
         _setUpOrchestrator(fundingPot);
@@ -308,7 +324,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    /* Test createRound()
+    /* Test Fuzz createRound()
         ├── Given all the valid parameters are provided
         │   └── When user attempts to create a round
         │       └── Then it should not be active and should return the round id
@@ -392,8 +408,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testEditRound_revertsGivenUserIsNotFundingPotAdmin(address user_)
         public
     {
-        vm.assume(user_ != address(0) && user_ != address(this));
-        testCreateRound();
+        testCreateRound(1000);
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = RoundParams({
@@ -429,7 +444,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testEditRound_revertsGivenRoundIsNotCreated() public {
-        testCreateRound();
+        testCreateRound(1000);
+        uint64 roundId = fundingPot.getRoundCount() + 1;
 
         uint64 roundId = fundingPot.getRoundCount();
 
@@ -462,8 +478,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testEditRound_revertsGivenRoundIsActive(uint roundStart_) public {
-        testCreateRound();
+    function testEditRound_revertsGivenRoundIsActive() public {
+        testCreateRound(1000);
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params;
@@ -510,9 +526,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testEditRound_revertsGivenRoundStartIsInThePast(uint roundStartP_)
         public
     {
-        testCreateRound();
+        testCreateRound(1000);
         uint64 roundId = fundingPot.getRoundCount();
 
+        RoundParameters memory editedParams = _helper_createEditedRoundParams();
         vm.assume(roundStartP_ < block.timestamp);
         RoundParams memory params = RoundParams({
             roundStart: roundStartP_,
@@ -545,7 +562,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testEditRound_revertsGivenRoundEndTimeAndCapAreBothZero() public {
-        testCreateRound();
+        testCreateRound(1000);
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = RoundParams({
@@ -579,9 +596,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     function testEditRound_revertsGivenRoundEndTimeIsBeforeRoundStart(
-        uint roundEnd_
+        uint roundEnd_,
+        uint roundStart_
     ) public {
-        testCreateRound();
+        vm.assume(
+            roundEnd_ != 0 && roundStart_ > block.timestamp
+                && roundEnd_ < roundStart_
+        );
+        testCreateRound(1000);
         uint64 roundId = fundingPot.getRoundCount();
 
         // Get the current round start time
@@ -625,7 +647,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testEditRound_revertsGivenHookContractIsSetButHookFunctionIsEmpty()
         public
     {
-        testCreateRound();
+        testCreateRound(1000);
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = _helper_createEditRoundParams(
@@ -661,7 +683,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testEditRound_revertsGivenHookFunctionIsSetButHookContractIsEmpty()
         public
     {
-        testCreateRound();
+        testCreateRound(1000);
         uint64 roundId = fundingPot.getRoundCount();
 
         RoundParams memory params = _helper_createEditRoundParams(
@@ -709,7 +731,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     */
 
     function testEditRound() public {
-        testCreateRound();
+        testCreateRound(1000);
         uint64 lastRoundId = fundingPot.getRoundCount();
 
         RoundParams memory params = _editedRoundParams;
@@ -784,7 +806,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.assume(accessCriteriaEnum_ >= 0 && accessCriteriaEnum_ <= 4);
         vm.assume(user_ != address(0) && user_ != address(this));
 
-        testCreateRound();
+        testCreateRound(1000);
         uint64 roundId = fundingPot.getRoundCount();
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
@@ -1050,7 +1072,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.expectRevert(
             abi.encodeWithSelector(
                 ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__RoundAlreadyStarted
+                    .Module__LM_PC_FundingPot__PersonalCapReached
                     .selector
             )
         );
@@ -1102,7 +1124,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // Helper Functions
 
     // @notice Creates a default funding round
-    function _helper_createDefaultFundingRound()
+    function _helper_createDefaultFundingRound(uint roundCap_)
         internal
         returns (RoundParams memory)
     {

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -114,7 +114,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         _setUpOrchestrator(fundingPot);
 
         // Initiate the Logic Module with the metadata and config data
-        fundingPot.init(_orchestrator, _METADATA, abi.encode(""));
+        fundingPot.init(
+            _orchestrator, _METADATA, abi.encode(address(fundingPotToken))
+        );
 
         _authorizer.setIsAuthorized(address(this), true);
 

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1236,7 +1236,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.contributeToRound(roundId, amount, accessId, PROOF);
     }
 
-    function testontributeToRound_revertsGivenAllowedListAccessCriteriaIsNotMet(
+    function testContributeToRound_revertsGivenAllowedListAccessCriteriaIsNotMet(
     ) public {
         testCreateRound();
 
@@ -1777,6 +1777,372 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     // -------------------------------------------------------------------------
+    // Test: _calculateUnusedCapacityFromPreviousRounds
+
+    function test_calculateUnusedCapacityFromPreviousRounds_returnsZeroForFirstRound(
+    ) public {
+        // First round should have no unused capacity from previous rounds
+        uint64 roundId = 1;
+        uint unusedCapacity = fundingPot
+            .exposed_calculateUnusedCapacityFromPreviousRounds(roundId);
+        assertEq(unusedCapacity, 0);
+    }
+
+    function test_calculateUnusedCapacityFromPreviousRounds_withPartiallyUsedCap(
+    ) public {
+        // Create first round with cap 1000 but only use 600
+        RoundParams memory params = _defaultRoundParams;
+        params.roundStart = block.timestamp + 1 days;
+        params.roundEnd = block.timestamp + 2 days;
+        params.roundCap = 1000;
+        params.globalAccumulativeCaps = true;
+
+        uint64 roundId1 = fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
+        );
+
+        // Set access criteria and privileges
+        uint8 accessId = 0;
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(roundId1, accessCriteria);
+        fundingPot.setAccessCriteriaPrivileges(
+            roundId1,
+            accessId,
+            1000, // personal cap high enough for test
+            0, // no NFT cap
+            0, // no merkle cap
+            0, // no list cap
+            false,
+            0, // no start
+            0, // no cliff
+            0 // no end
+        );
+
+        // Contribute 600 to first round
+        vm.warp(params.roundStart + 1);
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 600);
+        fundingPot.contributeToRound(roundId1, 600, accessId, new bytes32[](0));
+        vm.stopPrank();
+
+        // Check unused capacity for next round (should be 400)
+        uint64 roundId2 = 2;
+        uint unusedCapacity = fundingPot
+            .exposed_calculateUnusedCapacityFromPreviousRounds(roundId2);
+        assertEq(unusedCapacity, 400);
+    }
+
+    function test_calculateUnusedCapacityFromPreviousRounds_withMultipleRounds()
+        public
+    {
+        // Create first round with cap 1000, use 600
+        RoundParams memory params = _defaultRoundParams;
+        params.roundStart = block.timestamp + 1 days;
+        params.roundEnd = block.timestamp + 2 days;
+        params.roundCap = 1000;
+        params.globalAccumulativeCaps = true;
+
+        uint64 roundId1 = fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
+        );
+
+        // Set access criteria for round 1
+        uint8 accessId = 0;
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(roundId1, accessCriteria);
+        fundingPot.setAccessCriteriaPrivileges(
+            roundId1,
+            accessId,
+            1000, // personal cap high enough for the test
+            0, // no NFT cap
+            0, // no merkle cap
+            0, // no list cap
+            false,
+            0, // no start
+            0, // no cliff
+            0 // no end
+        );
+
+        // Warp to round 1 start time and contribute
+        vm.warp(params.roundStart + 1);
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 600);
+        fundingPot.contributeToRound(roundId1, 600, accessId, new bytes32[](0));
+        vm.stopPrank();
+
+        // Create second round with cap 2000
+        uint64 roundId2 = fundingPot.createRound(
+            params.roundStart + 2 days, // Start when first round ends
+            params.roundStart + 4 days, // End 2 days after start
+            2000, // Cap of 2000
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
+        );
+
+        // Set access criteria for round 2
+        fundingPot.setAccessCriteriaForRound(roundId2, accessCriteria);
+        fundingPot.setAccessCriteriaPrivileges(
+            roundId2,
+            accessId,
+            2000, // personal cap high enough for the test
+            0, // no NFT cap
+            0, // no merkle cap
+            0, // no list cap
+            false,
+            0, // no start
+            0, // no cliff
+            0 // no end
+        );
+
+        // Warp to round 2 start time and contribute
+        vm.warp(params.roundStart + 2 days + 1);
+        vm.startPrank(contributor2_);
+        _token.approve(address(fundingPot), 1500);
+        fundingPot.contributeToRound(roundId2, 1500, accessId, new bytes32[](0));
+        vm.stopPrank();
+
+        // Check unused capacity for third round
+        // Round 1: 400 unused (1000-600)
+        // Round 2: 500 unused (2000-1500)
+        // Total: 900 unused
+        uint64 roundId3 = 3;
+        uint unusedCapacity = fundingPot
+            .exposed_calculateUnusedCapacityFromPreviousRounds(roundId3);
+        assertEq(unusedCapacity, 900);
+    }
+
+    function test_calculateUnusedCapacityFromPreviousRounds_withoutGlobalAccumulativeCaps(
+    ) public {
+        // Create first round with cap 1000, use 600, but no global accumulative caps
+        RoundParams memory params = _defaultRoundParams;
+        params.roundStart = block.timestamp + 1 days;
+        params.roundEnd = block.timestamp + 2 days;
+        params.roundCap = 1000;
+        params.globalAccumulativeCaps = false;
+
+        uint64 roundId1 = fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
+        );
+
+        // Set access criteria and privileges
+        uint8 accessId = 0;
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(roundId1, accessCriteria);
+        fundingPot.setAccessCriteriaPrivileges(
+            roundId1,
+            accessId,
+            1000, // personal cap high enough for test
+            0, // no NFT cap
+            0, // no merkle cap
+            0, // no list cap
+            false,
+            0, // no start
+            0, // no cliff
+            0 // no end
+        );
+
+        vm.warp(params.roundStart + 1);
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 600);
+        fundingPot.contributeToRound(roundId1, 600, accessId, new bytes32[](0));
+        vm.stopPrank();
+
+        // Should return 0 since global accumulative caps is disabled
+        uint64 roundId2 = 2;
+        uint unusedCapacity = fundingPot
+            .exposed_calculateUnusedCapacityFromPreviousRounds(roundId2);
+        assertEq(unusedCapacity, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Test: _checkRoundClosureConditions
+
+    function test_checkRoundClosureConditions_whenCapReached() public {
+        RoundParams memory params = _defaultRoundParams;
+        params.roundStart = block.timestamp + 1 days;
+        params.roundEnd = block.timestamp + 2 days;
+        params.roundCap = 1000;
+
+        uint64 roundId = fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
+        );
+
+        // Set access criteria and privileges
+        uint8 accessId = 0;
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaPrivileges(
+            roundId,
+            accessId,
+            1000, // personal cap equal to round cap
+            0, // no NFT cap
+            0, // no merkle cap
+            0, // no list cap
+            false,
+            0, // no start
+            0, // no cliff
+            0 // no end
+        );
+
+        // Contribute up to the cap
+        vm.warp(params.roundStart + 1);
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), params.roundCap);
+        fundingPot.contributeToRound(
+            roundId, params.roundCap, accessId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        assertTrue(fundingPot.exposed_checkRoundClosureConditions(roundId));
+    }
+
+    function test_checkRoundClosureConditions_whenEndTimeReached() public {
+        RoundParams memory params = _defaultRoundParams;
+        params.roundStart = block.timestamp + 1 days;
+        params.roundEnd = block.timestamp + 2 days;
+        params.roundCap = 1000;
+
+        uint64 roundId = fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
+        );
+
+        // Move time past end time
+        vm.warp(params.roundEnd + 1);
+        assertTrue(fundingPot.exposed_checkRoundClosureConditions(roundId));
+    }
+
+    function test_checkRoundClosureConditions_whenNeitherConditionMet()
+        public
+    {
+        RoundParams memory params = _defaultRoundParams;
+        params.roundStart = block.timestamp + 1 days;
+        params.roundEnd = block.timestamp + 2 days;
+        params.roundCap = 1000;
+
+        uint64 roundId = fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
+        );
+
+        // Time is before end and no contributions
+        assertFalse(fundingPot.exposed_checkRoundClosureConditions(roundId));
+    }
+
+    function test_checkRoundClosureConditions_withNoEndTime() public {
+        RoundParams memory params = _defaultRoundParams;
+        params.roundStart = block.timestamp + 1 days;
+        params.roundEnd = 0; // No end time
+        params.roundCap = 1000;
+
+        uint64 roundId = fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
+        );
+
+        // Set access criteria and privileges
+        uint8 accessId = 0;
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(accessId);
+        fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
+        fundingPot.setAccessCriteriaPrivileges(
+            roundId,
+            accessId,
+            1000, // personal cap equal to round cap
+            0, // no NFT cap
+            0, // no merkle cap
+            0, // no list cap
+            false,
+            0, // no start
+            0, // no cliff
+            0 // no end
+        );
+
+        // Should be false initially
+        assertFalse(fundingPot.exposed_checkRoundClosureConditions(roundId));
+
+        // Should be true when cap is reached
+        vm.warp(params.roundStart + 1);
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), params.roundCap);
+        fundingPot.contributeToRound(
+            roundId, params.roundCap, accessId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        assertTrue(fundingPot.exposed_checkRoundClosureConditions(roundId));
+    }
+
+    function test_checkRoundClosureConditions_withNoCap() public {
+        RoundParams memory params = _defaultRoundParams;
+        params.roundStart = block.timestamp + 1 days;
+        params.roundEnd = block.timestamp + 2 days;
+        params.roundCap = 0; // No cap
+
+        uint64 roundId = fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.globalAccumulativeCaps
+        );
+
+        // Should be false before end time
+        assertFalse(fundingPot.exposed_checkRoundClosureConditions(roundId));
+
+        // Should be true after end time
+        vm.warp(params.roundEnd + 1);
+        assertTrue(fundingPot.exposed_checkRoundClosureConditions(roundId));
+    }
+
+    // -------------------------------------------------------------------------
     // Helper Functions
 
     // @notice Creates edit round parameters with customizable values
@@ -1863,8 +2229,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function _helper_setupRoundWithAccessCriteria(uint8 accessCriteriaEnum)
         internal
     {
-        testCreateRound();
-        uint64 roundId = fundingPot.getRoundCount();
+        uint64 roundId = fundingPot.createRound(
+            _defaultRoundParams.roundStart,
+            _defaultRoundParams.roundEnd,
+            _defaultRoundParams.roundCap,
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            _defaultRoundParams.globalAccumulativeCaps
+        );
 
         ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
             _helper_createAccessCriteria(accessCriteriaEnum);

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -47,7 +47,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     // Constants
 
     bytes32 internal constant FUNDING_POT_ADMIN_ROLE = "FUNDING_POT_ADMIN";
-    address contributor_;
+    address contributor1_;
+    address contributor2_;
+    address contributor3_;
 
     bytes32 PROOF_ONE =
         0x0fd7c981d39bece61f7499702bf59b3114a90e66b51ba2c53abdf7b62986c00a;
@@ -99,9 +101,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         address impl = address(new LM_PC_FundingPot_v1_Exposed());
         fundingPot = LM_PC_FundingPot_v1_Exposed(Clones.clone(impl));
 
-        // Mint tokens to the contributor
-        contributor_ = address(0xBeef);
-        fundingPotToken.mint(contributor_, 10_000);
+        // Mint tokens to the contributors
+        contributor1_ = address(0xBeef);
+        contributor2_ = address(0xDEAD);
+        contributor3_ = address(0xCAFE);
+
+        fundingPotToken.mint(contributor1_, 10_000);
+        fundingPotToken.mint(contributor2_, 10_000);
+        fundingPotToken.mint(contributor3_, 10_000);
 
         // Setup the module to test
         _setUpOrchestrator(fundingPot);
@@ -995,6 +1002,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 ├── Then it should not revert
                 └── Then the access criteria should be updated
     */
+    function testFuzzContributeToRound_revertsGivenRoundContributionCapReached(
+        uint roundCap_
+    ) public {
+        testCreateRound(10);
 
     function testFuzzEditAccessCriteriaForRound_revertsGivenUserDoesNotHaveFundingPotAdminRole(
         uint8 accessCriteriaEnum,
@@ -1078,8 +1089,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(roundStart + 1);
 
-        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnum);
+        // Approve
+        vm.prank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), 110);
+
+        vm.prank(contributor1_);
+        fundingPot.contributeToRound(
+            roundId, 10, accessId, address(fundingPotToken), new bytes32[](0)
+        );
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1088,48 +1105,94 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     .selector
             )
         );
-        fundingPot.editAccessCriteriaForRound(
-            roundId, accessCriteriaId, accessCriteria
+
+        vm.prank(contributor1_);
+        fundingPot.contributeToRound(
+            roundId,
+            amount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
         );
     }
 
-    function testFuzzEditAccessCriteriaForRound(
-        uint8 accessCriteriaEnumOld,
-        uint8 accessCriteriaEnumNew
+    function testFuzzContributeToRound_revertsGivenContributionIsBeforeRoundStart(
     ) public {
-        vm.assume(accessCriteriaEnumOld >= 0 && accessCriteriaEnumOld <= 4);
-        vm.assume(
-            accessCriteriaEnumNew != accessCriteriaEnumOld
-                && accessCriteriaEnumNew >= 0 && accessCriteriaEnumNew <= 4
-        );
+        testCreateRound(1000);
 
-        _helper_setupRoundWithAccessCriteria(accessCriteriaEnumOld);
         uint64 roundId = fundingPot.getRoundCount();
-        uint8 accessCriteriaId = 0;
+        uint8 accessId = 1;
+        uint amount = 250;
 
-        // Create and apply new access criteria
-        ILM_PC_FundingPot_v1.AccessCriteria memory newAccessCriteria =
-            _helper_createAccessCriteria(accessCriteriaEnumNew);
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(0);
 
-        fundingPot.editAccessCriteriaForRound(
-            roundId, accessCriteriaId, newAccessCriteria
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+
+        // Approve
+        vm.prank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), 500);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundHasNotStarted
+                    .selector
+            )
         );
 
-        // Verify the access criteria was updated
-        (
-            bool isOpen,
-            address nftContract,
-            bytes32 merkleRoot,
-            address[] memory allowedAddresses
-        ) = fundingPot.getRoundAccessCriteria(roundId, accessCriteriaId);
-
-        assertEq(isOpen, accessCriteriaEnumNew == 1);
-        assertEq(nftContract, newAccessCriteria.nftContract);
-        assertEq(merkleRoot, newAccessCriteria.merkleRoot);
-        assertEq(allowedAddresses, newAccessCriteria.allowedAddresses);
+        vm.prank(contributor1_);
+        fundingPot.contributeToRound(
+            roundId,
+            amount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
     }
 
-    function testFuzzContributeToRound_revertsWhenNFTAccessCriteriaIsNotMet()
+    function testFuzzContributeToRound_revertsGivenContributionIsAfterRoundEnd()
+        public
+    {
+        testCreateRound(1000);
+
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+        uint amount = 250;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(0);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 10 days);
+
+        // Approve
+        vm.prank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), 500);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundHasEnded
+                    .selector
+            )
+        );
+
+        vm.prank(contributor1_);
+        fundingPot.contributeToRound(
+            roundId,
+            amount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+    }
+
+    function testFuzzContributeToRound_revertsGivenNFTAccessCriteriaIsNotMet()
         public
     {
         testCreateRound(1000);
@@ -1147,7 +1210,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.warp(roundStart + 1);
 
         // Approve
-        vm.prank(contributor_);
+        vm.prank(contributor1_);
         fundingPotToken.approve(address(fundingPot), amount);
 
         vm.expectRevert(
@@ -1158,7 +1221,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        vm.prank(contributor_);
+        vm.prank(contributor1_);
         fundingPot.contributeToRound(
             roundId,
             amount,
@@ -1168,7 +1231,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzContributeToRound_revertsWhenMerkleRootAccessCriteriaIsNotMet(
+    function testFuzzContributeToRound_revertsGivenMerkleRootAccessCriteriaIsNotMet(
     ) public {
         testCreateRound(1000);
 
@@ -1185,7 +1248,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.warp(roundStart + 1);
 
         // Approve
-        vm.prank(contributor_);
+        vm.prank(contributor1_);
         fundingPotToken.approve(address(fundingPot), amount);
 
         vm.expectRevert(
@@ -1196,13 +1259,13 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        vm.prank(contributor_);
+        vm.prank(contributor1_);
         fundingPot.contributeToRound(
             roundId, amount, accessId, address(fundingPotToken), PROOF
         );
     }
 
-    function testFuzzContributeToRound_revertsWhenAllowedListAccessCriteriaIsNotMet(
+    function testFuzzContributeToRound_revertsGivenAllowedListAccessCriteriaIsNotMet(
     ) public {
         testCreateRound(1000);
 
@@ -1219,7 +1282,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.warp(roundStart + 1);
 
         // Approve
-        vm.prank(contributor_);
+        vm.prank(contributor1_);
         fundingPotToken.approve(address(fundingPot), amount);
 
         vm.expectRevert(
@@ -1230,7 +1293,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             )
         );
 
-        vm.prank(contributor_);
+        vm.prank(contributor1_);
         fundingPot.contributeToRound(
             roundId,
             amount,
@@ -1240,7 +1303,236 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testFuzzContributeToRound_revertsWhenContributionExceedsPersonalCap(
+    function testFuzzContributeToRound_revertsGivenPreviousContributionExceedsPersonalCap(
+    ) public {
+        testCreateRound(1000);
+
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+        uint amount = 500;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(1);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        mockNFTContract.mint(contributor1_);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+
+        // Approve
+        vm.prank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), 1000);
+
+        vm.prank(contributor1_);
+        fundingPot.contributeToRound(
+            roundId,
+            amount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+
+        // Get the base personal cap from the contract
+        uint personalCap =
+            fundingPot.exposed_getUserPersonalCap(roundId, contributor1_);
+
+        // Attempt to contribute beyond personal cap
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__PersonalCapReached
+                    .selector
+            )
+        );
+        vm.prank(contributor1_);
+
+        uint remainingCap = personalCap - amount;
+        fundingPot.contributeToRound(
+            roundId, 251, accessId, address(fundingPotToken), new bytes32[](0)
+        );
+    }
+
+    /*
+    ├── Given a round has been configured with generic round configuration and access criteria
+    │   And the round has started
+    │   And the user fulfills the access criteria
+    │   And the user doesn't violate any privileges
+    │   And the user doesn't violate generic round parameters
+    │   And the user has approved the collateral token
+    │   └── When the user contributes to the round
+    │       └── Then the funds are transferred to the funding pot
+    │           And the contribution is recorded
+    ├── Given the round contribution cap is not reached
+    │   └── When the user contributes to the round so that it exceeds the round contribution cap
+    │       └── Then only the valid contribution amount is transferred to the funding pot
+    │           And the contribution is recorded
+    │           And round closure is initiated
+    │
+    ├── Given the user fulfills the access criteria
+    │   └── And the user has already contributed their personal cap partially
+    │       └── When the user attempts to contribute more than their personal cap
+    │           └── Then only the amount up to the cap is accepted as contribution
+    │               And the contribution is recorded
+    │
+    ├── Given the user fulfills the access criteria
+    │   └── And their access criteria has the privilege to override the contribution span
+    │       └── When <reason for end of contribution span>
+    │           └── And the user attempts to contribute
+    │               └── Then the contribution is still recorded
+    │
+    ├── Given the user fulfills the access criteria
+    │   And the round is set to have global accumulative caps
+    │   And the user has not fully utilized their personal contribution potential in previous rounds
+    │   └── When the user wants to contribute to the current round
+    │       └── Then they can contribute up to their personal limit of the current round plus unfilled potential from previous rounds
+    │   
+    ├── Given the round has been configured with global accumulative caps
+    │   And in the previous round the round contribution cap was X
+    │   And in total Y had been contributed in the previous round
+    │   And the round contribution cap for the current round is Z
+    │   └── When users attempt to contribute
+    │       └── Then they can in total contribute Z + X - Y
+    │           And the funds are transferred into the funding pot
+    │
+    */
+    function testFuzzContributeToRound_worksGivenAllConditionsMet() public {
+        testCreateRound(1000);
+
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+        uint amount = 250;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(1);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        mockNFTContract.mint(contributor1_);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+
+        // Approve
+        vm.prank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), 500);
+
+        vm.prank(contributor1_);
+        fundingPot.contributeToRound(
+            roundId,
+            amount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+
+        uint totalContributions =
+            fundingPot.exposed_getTotalRoundContributions(roundId);
+
+        assertEq(totalContributions, amount);
+
+        uint personalContributions =
+            fundingPot.exposed_getUserContribution(roundId, contributor1_);
+        assertEq(personalContributions, amount);
+    }
+
+    function testFuzzContributeToRound_worksGivenUserCurrentContributionExceedsTheRoundCap(
+        uint roundCap_
+    ) public {
+        vm.assume(accessCriteriaEnumOld >= 0 && accessCriteriaEnumOld <= 4);
+        vm.assume(
+            accessCriteriaEnumNew != accessCriteriaEnumOld
+                && accessCriteriaEnumNew >= 0 && accessCriteriaEnumNew <= 4
+        );
+
+        _helper_setupRoundWithAccessCriteria(accessCriteriaEnumOld);
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessCriteriaId = 0;
+
+        // Create and apply new access criteria
+        ILM_PC_FundingPot_v1.AccessCriteria memory newAccessCriteria =
+            _helper_createAccessCriteria(accessCriteriaEnumNew);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        (uint roundStart,, uint roundCap,,,,) =
+            fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+
+        // Approve
+        vm.prank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), amount);
+
+        vm.prank(contributor1_);
+        fundingPot.contributeToRound(
+            roundId,
+            amount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+
+        // only the amount that does not exceed the roundcap is contributed
+        assertEq(
+            fundingPot.exposed_getUserContribution(roundId, contributor1_), 200
+        );
+    }
+
+    function testFuzzContributeToRound_worksGivenContributionPartiallyExceedingPersonalCap(
+    ) public {
+        testCreateRound(1000);
+
+        uint64 roundId = fundingPot.getRoundCount();
+        uint8 accessId = 1;
+
+        uint firstAmount = 400;
+
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(1);
+
+        fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
+
+        mockNFTContract.mint(contributor1_);
+
+        (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
+        vm.warp(roundStart + 1);
+
+        // Approve
+        vm.prank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), 1000 ether);
+
+        // First contribution
+        vm.prank(contributor1_);
+        fundingPot.contributeToRound(
+            roundId,
+            firstAmount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+
+        // Get the personal cap
+        uint personalCap =
+            fundingPot.exposed_getUserPersonalCap(roundId, contributor1_);
+
+        uint secondAmount = 200;
+
+        vm.prank(contributor1_);
+        fundingPot.contributeToRound(
+            roundId,
+            secondAmount,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+
+        uint totalContribution =
+            fundingPot.exposed_getUserContribution(roundId, contributor1_);
+        assertEq(totalContribution, personalCap);
+    }
+
+    function testFuzzContributeToRound_worksGivenUserCanOverrideTimeConstraints(
     ) public {
         testCreateRound(1000);
 
@@ -1253,16 +1545,29 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         fundingPot.setAccessCriteriaForRound(roundId, accessId, accessCriteria);
 
-        mockNFTContract.mint(contributor_);
+        // Set privileges with override capability
+        fundingPot.setAccessCriteriaPrivilages(
+            roundId,
+            accessId,
+            500, // personalCap
+            true, // overrideCap (can override time constraints)
+            0, // start
+            0, // cliff
+            0 // end
+        );
+
+        mockNFTContract.mint(contributor1_);
 
         (uint roundStart,,,,,,) = fundingPot.getRoundGenericParameters(roundId);
-        vm.warp(roundStart + 1);
+
+        vm.warp(roundStart + 10 days);
 
         // Approve
-        vm.prank(contributor_);
-        fundingPotToken.approve(address(fundingPot), 500);
+        vm.prank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), amount);
 
-        vm.prank(contributor_);
+        // This should succeed despite being after round end, due to override privilege
+        vm.prank(contributor1_);
         fundingPot.contributeToRound(
             roundId,
             amount,
@@ -1271,23 +1576,204 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             new bytes32[](0)
         );
 
-        // Attempt to contribute beyond personal cap
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__PersonalCapReached
-                    .selector
-            )
-        );
-        vm.prank(contributor_);
+        // Verify the contribution was recorded
+        uint totalContribution =
+            fundingPot.exposed_getTotalRoundContributions(roundId);
+        assertEq(totalContribution, amount);
+    }
 
+    function testContributeToRound_worksGivenPersonalCapAccumulation() public {
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = _helper_createDefaultFundingRound(1000);
+        globalAccumulativeCaps = true; // global accumulative caps enabled
+
+        // Round 1
+        fundingPot.createRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+        uint64 round1Id = fundingPot.getRoundCount();
+
+        uint8 accessId = 1;
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(1);
+        fundingPot.setAccessCriteriaForRound(round1Id, accessId, accessCriteria);
+        mockNFTContract.mint(contributor1_);
+
+        // Create Round 2
+        fundingPot.createRound(
+            roundStart + 3 days,
+            roundEnd + 3 days,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+        uint64 round2Id = fundingPot.getRoundCount();
+        fundingPot.setAccessCriteriaForRound(round2Id, accessId, accessCriteria);
+
+        vm.startPrank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), 1500);
+
+        // Contribute to Round 1
+        vm.warp(roundStart + 1);
+        uint round1Contribution = 200;
         fundingPot.contributeToRound(
-            roundId, 251, 0, address(fundingPotToken), new bytes32[](0)
+            round1Id,
+            round1Contribution,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+
+        // Move to Round 2
+        vm.warp(roundStart + 3 days + 1);
+
+        // Calculate unused capacity from Round 1
+        uint basePersonalCap =
+            fundingPot.exposed_getUserPersonalCap(round1Id, contributor1_);
+        uint unusedCapacityFromRound1 = basePersonalCap - round1Contribution;
+
+        uint round2MaxContribution = basePersonalCap + unusedCapacityFromRound1;
+        fundingPot.contributeToRound(
+            round2Id,
+            round2MaxContribution,
+            accessId,
+            address(fundingPotToken),
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        assertEq(
+            fundingPot.exposed_getUserContribution(round1Id, contributor1_),
+            round1Contribution
+        );
+        assertEq(
+            fundingPot.exposed_getUserContribution(round2Id, contributor1_),
+            round2MaxContribution
         );
     }
 
-    // -------------------------------------------------------------------------
-    // Test: Internal Functions
+    function testContributeToRound_worksGivenTotalRoundCapAccumulation()
+        public
+    {
+        (
+            uint roundStart,
+            uint roundEnd,
+            uint roundCap,
+            address hookContract,
+            bytes memory hookFunction,
+            bool closureMechanism,
+            bool globalAccumulativeCaps
+        ) = _helper_createDefaultFundingRound(1000);
+        globalAccumulativeCaps = true;
+
+        // Create Round 1
+        fundingPot.createRound(
+            roundStart,
+            roundEnd,
+            roundCap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+        uint64 round1Id = fundingPot.getRoundCount();
+
+        uint8 accessId = 0;
+        ILM_PC_FundingPot_v1.AccessCriteria memory accessCriteria =
+            _helper_createAccessCriteria(0);
+        fundingPot.setAccessCriteriaForRound(round1Id, accessId, accessCriteria);
+
+        // Round 2 with a different cap
+        uint round2Cap = 500;
+        fundingPot.createRound(
+            roundStart + 3 days,
+            roundEnd + 3 days,
+            round2Cap,
+            hookContract,
+            hookFunction,
+            closureMechanism,
+            globalAccumulativeCaps
+        );
+        uint64 round2Id = fundingPot.getRoundCount();
+        fundingPot.setAccessCriteriaForRound(round2Id, accessId, accessCriteria);
+        // Round 1: Multiple users contribute, but don't reach the cap
+        vm.warp(roundStart + 1);
+
+        vm.startPrank(contributor1_);
+        fundingPotToken.approve(address(fundingPot), 300);
+        fundingPot.contributeToRound(
+            round1Id, 300, accessId, address(fundingPotToken), new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        vm.startPrank(contributor2_);
+        fundingPotToken.approve(address(fundingPot), 200);
+        fundingPot.contributeToRound(
+            round1Id, 200, accessId, address(fundingPotToken), new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // Move to Round 2
+        vm.warp(roundStart + 3 days + 1);
+
+        uint unusedCapacityFromRound1 =
+            roundCap - fundingPot.exposed_getTotalRoundContributions(round1Id);
+        uint totalAvailableCapacityRound2 = round2Cap + unusedCapacityFromRound1;
+
+        // Round 2: Contributors try to use the accumulated capacity
+
+        vm.startPrank(contributor2_);
+        fundingPotToken.approve(address(fundingPot), 400);
+        fundingPot.contributeToRound(
+            round2Id, 400, accessId, address(fundingPotToken), new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        vm.startPrank(contributor3_);
+        fundingPotToken.approve(address(fundingPot), 600);
+        fundingPot.contributeToRound(
+            round2Id, 600, accessId, address(fundingPotToken), new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // Verify Round 1 contributions
+        assertEq(fundingPot.exposed_getTotalRoundContributions(round1Id), 500);
+        assertEq(
+            fundingPot.exposed_getUserContribution(round1Id, contributor1_), 300
+        );
+        assertEq(
+            fundingPot.exposed_getUserContribution(round1Id, contributor2_), 200
+        );
+
+        // Verify Round 2 contributions
+        assertEq(fundingPot.exposed_getTotalRoundContributions(round2Id), 1000);
+        assertEq(
+            fundingPot.exposed_getUserContribution(round2Id, contributor2_), 400
+        );
+        assertEq(
+            fundingPot.exposed_getUserContribution(round2Id, contributor3_), 600
+        );
+
+        assertEq(
+            fundingPot.exposed_getTotalRoundContributions(round2Id),
+            totalAvailableCapacityRound2
+        );
+    }
 
     // -------------------------------------------------------------------------
     // Helper Functions

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -545,13 +545,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-    function testEditRound_revertsGivenRoundStartIsInThePast(uint roundStartP_)
+    function testEditRound_revertsGivenRoundStartIsInThePast(uint roundStart_)
         public
     {
         testCreateRound();
         uint64 roundId = fundingPot.getRoundCount();
         _editedRoundParams;
-        vm.assume(roundStartP_ < block.timestamp);
+        vm.assume(roundStart_ < block.timestamp);
+        _editedRoundParams.roundStart = roundStart_;
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1436,7 +1437,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         fundingPot.setAccessCriteriaForRound(roundId, accessCriteria);
         _helper_callSetAccessCriteriaPrivileges(
-            roundId, accessId, 500, 0, 0, 0, false, 0, 0, 0
+            roundId, accessId, 200, 0, 0, 0, false, 0, 0, 0
         );
 
         (uint roundStart,, uint roundCap,,,,) =
@@ -1658,8 +1659,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Round 2 with a different cap
         uint round2Cap = 500;
         fundingPot.createRound(
-            _defaultRoundParams.roundStart,
-            _defaultRoundParams.roundEnd,
+            _defaultRoundParams.roundStart + 3 days,
+            _defaultRoundParams.roundEnd + 3 days,
             round2Cap,
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
@@ -1688,10 +1689,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Move to Round 2
         vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
 
-        uint unusedCapacityFromRound1 = _defaultRoundParams.roundCap
-            - fundingPot.exposed_getTotalRoundContributions(round1Id);
-        uint totalAvailableCapacityRound2 = round2Cap + unusedCapacityFromRound1;
-
         // Round 2: Contributors try to use the accumulated capacity
 
         vm.startPrank(contributor2_);
@@ -1700,8 +1697,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.stopPrank();
 
         vm.startPrank(contributor3_);
-        _token.approve(address(fundingPot), 600);
-        fundingPot.contributeToRound(round2Id, 600, accessId, new bytes32[](0));
+        _token.approve(address(fundingPot), 300);
+        fundingPot.contributeToRound(round2Id, 300, accessId, new bytes32[](0));
         vm.stopPrank();
 
         // Verify Round 1 contributions
@@ -1720,7 +1717,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
 
         // Verify Round 2 contributions
-        assertEq(fundingPot.exposed_getTotalRoundContributions(round2Id), 1000);
+        assertEq(fundingPot.exposed_getTotalRoundContributions(round2Id), 700);
         assertEq(
             fundingPot.exposed_getUserContributionToRound(
                 round2Id, contributor2_
@@ -1731,13 +1728,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             fundingPot.exposed_getUserContributionToRound(
                 round2Id, contributor3_
             ),
-            600
+            300
         );
 
-        assertEq(
-            fundingPot.exposed_getTotalRoundContributions(round2Id),
-            totalAvailableCapacityRound2
-        );
+        assertEq(fundingPot.exposed_getTotalRoundContributions(round2Id), 700);
     }
 
     // -------------------------------------------------------------------------

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1769,6 +1769,77 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     // -------------------------------------------------------------------------
     // Internal Functions
+    function testFuzz_validateAccessCriteria(
+        uint64 roundId_,
+        uint8 accessId_,
+        bytes32[] calldata merkleProof_
+    ) external {
+        vm.assume(roundId_ <= fundingPot.getRoundCount() + 1);
+        vm.assume(accessId_ <= 4);
+
+        try fundingPot.exposed_validateAccessCriteria(
+            roundId_, accessId_, merkleProof_
+        ) {
+            assert(true);
+        } catch (bytes memory) {
+            assert(false);
+        }
+    }
+
+    function testFuzz_validateAndAdjustCaps(
+        uint64 roundId_,
+        uint amount_,
+        uint8 accessId_,
+        bool canOverrideContributionSpan_
+    ) external {
+        vm.assume(roundId_ > 0 && roundId_ >= fundingPot.getRoundCount());
+        vm.assume(amount_ <= 1000);
+        vm.assume(accessId_ <= 4);
+
+        uint initialTotalContribution =
+            fundingPot.exposed_getTotalRoundContributions(roundId_);
+        uint initialUserContribution =
+            fundingPot.exposed_getUserContributionToRound(roundId_, msg.sender);
+
+        try fundingPot.exposed_validateAndAdjustCaps(
+            roundId_, amount_, accessId_, canOverrideContributionSpan_
+        ) returns (uint adjustedAmount) {
+            assertLe(
+                adjustedAmount, amount_, "Adjusted amount should be <= amount_"
+            );
+            assertGe(adjustedAmount, 0, "Adjusted amount should be >= 0");
+        } catch (bytes memory reason) {
+            // Compare using keccak256 hash rather than direct string comparison
+            bytes32 roundCapReachedSelector = keccak256(
+                abi.encodeWithSignature(
+                    "Module__LM_PC_FundingPot__RoundCapReached()"
+                )
+            );
+            bytes32 personalCapReachedSelector = keccak256(
+                abi.encodeWithSignature(
+                    "Module__LM_PC_FundingPot__PersonalCapReached()"
+                )
+            );
+
+            if (keccak256(reason) == roundCapReachedSelector) {
+                assertTrue(
+                    !canOverrideContributionSpan_,
+                    "Should not revert RoundCapReached when canOverrideContributionSpan is true"
+                );
+                // Additional assertions commented out for now
+                // assert(roundCap > 0, "Round cap should be > 0");
+                // assert(
+                //     initialTotalContribution >= effectiveRoundCap,
+                //     "Total contribution should be >= effectiveRoundCap"
+                // );
+            } else if (keccak256(reason) == personalCapReachedSelector) {
+                // We expect this sometimes
+                assertTrue(true, "Personal cap reached as expected");
+            } else {
+                assertTrue(false, "Unexpected revert reason");
+            }
+        }
+    }
 
     // -------------------------------------------------------------------------
     // Helper Functions

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1768,6 +1768,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     }
 
     // -------------------------------------------------------------------------
+    // Internal Functions
+
+    // -------------------------------------------------------------------------
     // Helper Functions
 
     // @notice Creates a default funding round

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -85,10 +85,11 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
         uint64 roundId_,
         uint8 accessCriteriaId_,
         bytes32[] calldata merkleProof_,
-        uint amount_
+        uint amount_,
+        address user_
     ) external view returns (uint) {
         return _validateRoundContribution(
-            roundId_, accessCriteriaId_, merkleProof_, amount_
+            roundId_, accessCriteriaId_, merkleProof_, amount_, user_
         );
     }
 
@@ -112,9 +113,10 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     function exposed_validateAccessCriteria(
         uint64 roundId_,
         uint8 accessId_,
-        bytes32[] calldata merkleProof_
+        bytes32[] calldata merkleProof_,
+        address user_
     ) external view {
-        _validateAccessCriteria(roundId_, accessId_, merkleProof_);
+        _validateAccessCriteria(roundId_, accessId_, merkleProof_, user_);
     }
 
     /**
@@ -148,16 +150,5 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
         uint64 roundId_
     ) external pure returns (bool) {
         return _validateMerkleProof(root_, merkleProof_, user_, roundId_);
-    }
-
-    /**
-     * @notice Exposes the internal _recordContribution function for testing
-     */
-    function exposed_recordContribution(
-        uint64 roundId_,
-        address user_,
-        uint amount_
-    ) external {
-        _recordContribution(roundId_, user_, amount_);
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -7,6 +7,43 @@ import {LM_PC_FundingPot_v1} from
 
 // Access Mock of the PP_Template_v1 contract for Testing.
 contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
-// Use the `exposed_` prefix for functions to expose internal functions for
-// testing.
+    // Use the `exposed_` prefix for functions to expose internal functions for
+    // testing.
+
+    function exposed_getTotalRoundContributions(uint64 roundId_)
+        external
+        view
+        returns (uint)
+    {
+        return _getTotalRoundContribution(roundId_);
+    }
+
+    function exposed_getUserContribution(uint64 roundId_, address user_)
+        external
+        view
+        returns (uint)
+    {
+        return _getUserContribution(roundId_, user_);
+    }
+
+    /**
+     * @notice Exposes the internal _getUserPersonalCap function for testing
+     */
+    function exposed_getUserPersonalCap(uint64 roundId_, address user_)
+        external
+        view
+        returns (uint)
+    {
+        return _getUserPersonalCap(roundId_, user_);
+    }
+
+    /**
+     * @notice Exposes the internal _getUnusedCapacityFromPreviousRounds function for testing
+     */
+    function exposed_getUnusedCapacityFromPreviousRounds(
+        address user_,
+        uint64 currentRoundId_
+    ) external view returns (uint) {
+        return _getUnusedCapacityFromPreviousRounds(user_, currentRoundId_);
+    }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -131,4 +131,33 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     ) external pure returns (bool) {
         return _validateMerkleProof(root_, merkleProof_, user_, roundId_);
     }
+
+    /**
+     * @notice Exposes the internal _calculateUnusedCapacityFromPreviousRounds function for testing
+     */
+    function exposed_calculateUnusedCapacityFromPreviousRounds(uint64 roundId_)
+        external
+        view
+        returns (uint)
+    {
+        return _calculateUnusedCapacityFromPreviousRounds(roundId_);
+    }
+
+    /**
+     * @notice Exposes the internal _closeRound function for testing
+     */
+    function exposed_closeRound(uint64 roundId_) external {
+        _closeRound(roundId_);
+    }
+
+    /**
+     * @notice Exposes the internal _checkRoundClosureConditions function for testing
+     */
+    function exposed_checkRoundClosureConditions(uint64 roundId_)
+        external
+        view
+        returns (bool)
+    {
+        return _checkRoundClosureConditions(roundId_);
+    }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -10,6 +10,9 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     // Use the `exposed_` prefix for functions to expose internal functions for
     // testing.
 
+    /**
+     * @notice Exposes the internal _getTotalRoundContribution function for testing
+     */
     function exposed_getTotalRoundContributions(uint64 roundId_)
         external
         view
@@ -18,33 +21,15 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
         return _getTotalRoundContribution(roundId_);
     }
 
+    /**
+     * @notice Exposes the internal _getUserContributionToRound function for testing
+     */
     function exposed_getUserContributionToRound(uint64 roundId_, address user_)
         external
         view
         returns (uint)
     {
         return _getUserContributionToRound(roundId_, user_);
-    }
-
-    /**
-     * @notice Exposes the internal _getUserPersonalCapForRound function for testing
-     */
-    function exposed_getUserPersonalCapForRound(
-        uint64 roundId_,
-        uint8 accessId_,
-        address user_
-    ) external view returns (uint) {
-        return _getUserPersonalCapForRound(roundId_, accessId_, user_);
-    }
-
-    /**
-     * @notice Exposes the internal _getUserUnusedCapacityFromPreviousRounds function for testing
-     */
-    function exposed_getUserUnusedCapacityFromPreviousRounds(
-        address user_,
-        uint64 currentRoundId_
-    ) external view returns (uint) {
-        return _getUserUnusedCapacityFromPreviousRounds(user_, currentRoundId_);
     }
 
     /**
@@ -59,31 +44,21 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     }
 
     /**
-     * @notice Exposes the internal _validateRoundContribution function for testing
+     * @notice Exposes the internal _validateAndAdjustCapsWithUnspentCap function for testing
      */
-    function exposed_validateRoundContribution(
-        uint64 roundId_,
-        uint8 accessCriteriaId_,
-        bytes32[] calldata merkleProof_,
-        uint amount_,
-        address user_
-    ) external view returns (uint) {
-        return _validateRoundContribution(
-            roundId_, accessCriteriaId_, merkleProof_, amount_, user_
-        );
-    }
-
-    /**
-     * @notice Exposes the internal _validateAndAdjustCaps function for testing
-     */
-    function exposed_validateAndAdjustCaps(
+    function exposed_validateAndAdjustCapsWithUnspentCap(
         uint64 roundId_,
         uint amount_,
-        uint8 accessId_,
-        bool canOverrideContributionSpan_
+        uint8 accessCriteriaId__,
+        bool canOverrideContributionSpan_,
+        uint unspentPersonalCap_
     ) external view returns (uint) {
-        return _validateAndAdjustCaps(
-            roundId_, amount_, accessId_, canOverrideContributionSpan_
+        return _validateAndAdjustCapsWithUnspentCap(
+            roundId_,
+            amount_,
+            accessCriteriaId__,
+            canOverrideContributionSpan_,
+            unspentPersonalCap_
         );
     }
 
@@ -97,6 +72,20 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
         address user_
     ) external view {
         _validateAccessCriteria(roundId_, accessId_, merkleProof_, user_);
+    }
+
+    /**
+     * @notice Exposes the internal _checkAccessCriteriaEligibility function for testing
+     */
+    function exposed_checkAccessCriteriaEligibility(
+        uint64 roundId_,
+        uint8 accessCriteriaId_,
+        bytes32[] memory merkleProof_,
+        address user_
+    ) external view returns (bool) {
+        return _checkAccessCriteriaEligibility(
+            roundId_, accessCriteriaId_, merkleProof_, user_
+        );
     }
 
     /**

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -50,22 +50,22 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     /**
      * @notice Exposes the internal _validateRoundParameters function for testing
      */
-    function exposed_validateRoundParameters(Round storage round_)
-        external
-        view
-    {
-        _validateRoundParameters(round_);
-    }
+    // function exposed_validateRoundParameters(Round memory round_)
+    //     external
+    //     view
+    // {
+    //     _validateRoundParameters(round_);
+    // }
 
     /**
      * @notice Exposes the internal _validateEditRoundParameters function for testing
      */
-    function exposed_validateEditRoundParameters(Round storage round_)
-        external
-        view
-    {
-        _validateEditRoundParameters(round_);
-    }
+    // function exposed_validateEditRoundParameters(Round storage round_)
+    //     external
+    //     view
+    // {
+    //     _validateEditRoundParameters(round_);
+    // }
 
     /**
      * @notice Exposes the internal _validTimes function for testing
@@ -98,12 +98,11 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     function exposed_validateAndAdjustCaps(
         uint64 roundId_,
         uint amount_,
-        Round storage round_,
         uint8 accessId_,
         bool canOverrideContributionSpan_
     ) external view returns (uint) {
         return _validateAndAdjustCaps(
-            roundId_, amount_, round_, accessId_, canOverrideContributionSpan_
+            roundId_, amount_, accessId_, canOverrideContributionSpan_
         );
     }
 

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -27,7 +27,7 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     }
 
     /**
-     * @notice Exposes the internal _getUserPersonalCap function for testing
+     * @notice Exposes the internal _getUserPersonalCapForRound function for testing
      */
     function exposed_getUserPersonalCapForRound(
         uint64 roundId_,
@@ -38,12 +38,127 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     }
 
     /**
-     * @notice Exposes the internal _getUnusedCapacityFromPreviousRounds function for testing
+     * @notice Exposes the internal _getUserUnusedCapacityFromPreviousRounds function for testing
      */
     function exposed_getUserUnusedCapacityFromPreviousRounds(
         address user_,
         uint64 currentRoundId_
     ) external view returns (uint) {
         return _getUserUnusedCapacityFromPreviousRounds(user_, currentRoundId_);
+    }
+
+    /**
+     * @notice Exposes the internal _validateRoundParameters function for testing
+     */
+    function exposed_validateRoundParameters(Round storage round_)
+        external
+        view
+    {
+        _validateRoundParameters(round_);
+    }
+
+    /**
+     * @notice Exposes the internal _validateEditRoundParameters function for testing
+     */
+    function exposed_validateEditRoundParameters(Round storage round_)
+        external
+        view
+    {
+        _validateEditRoundParameters(round_);
+    }
+
+    /**
+     * @notice Exposes the internal _validTimes function for testing
+     */
+    function exposed_validTimes(uint start_, uint cliff_, uint end_)
+        external
+        pure
+        returns (bool)
+    {
+        return _validTimes(start_, cliff_, end_);
+    }
+
+    /**
+     * @notice Exposes the internal _validateRoundContribution function for testing
+     */
+    function exposed_validateRoundContribution(
+        uint64 roundId_,
+        uint8 accessCriteriaId_,
+        bytes32[] calldata merkleProof_,
+        uint amount_
+    ) external view returns (uint) {
+        return _validateRoundContribution(
+            roundId_, accessCriteriaId_, merkleProof_, amount_
+        );
+    }
+
+    /**
+     * @notice Exposes the internal _validateAndAdjustCaps function for testing
+     */
+    function exposed_validateAndAdjustCaps(
+        uint64 roundId_,
+        uint amount_,
+        Round storage round_,
+        uint8 accessId_,
+        bool canOverrideContributionSpan_
+    ) external view returns (uint) {
+        return _validateAndAdjustCaps(
+            roundId_, amount_, round_, accessId_, canOverrideContributionSpan_
+        );
+    }
+
+    /**
+     * @notice Exposes the internal _validateAccessCriteria function for testing
+     */
+    function exposed_validateAccessCriteria(
+        uint64 roundId_,
+        uint8 accessId_,
+        bytes32[] calldata merkleProof_
+    ) external view {
+        _validateAccessCriteria(roundId_, accessId_, merkleProof_);
+    }
+
+    /**
+     * @notice Exposes the internal _checkAllowedAddressList function for testing
+     */
+    function exposed_checkAllowedAddressList(
+        address[] memory allowedAddresses_,
+        address sender_
+    ) external pure returns (bool) {
+        return _checkAllowedAddressList(allowedAddresses_, sender_);
+    }
+
+    /**
+     * @notice Exposes the internal _checkNftOwnership function for testing
+     */
+    function exposed_checkNftOwnership(address nftContract_, address user_)
+        external
+        view
+        returns (bool)
+    {
+        return _checkNftOwnership(nftContract_, user_);
+    }
+
+    /**
+     * @notice Exposes the internal _validateMerkleProof function for testing
+     */
+    function exposed_validateMerkleProof(
+        bytes32 root_,
+        bytes32[] memory merkleProof_,
+        address user_,
+        uint64 roundId_
+    ) external pure returns (bool) {
+        return _validateMerkleProof(root_, merkleProof_, user_, roundId_);
+    }
+
+    /**
+     * @notice Exposes the internal _recordContribution function for testing
+     */
+    function exposed_recordContribution(
+        uint64 roundId_,
+        address user_,
+        uint amount_
+    ) external {
+        _recordContribution(roundId_, user_, amount_);
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -100,16 +100,6 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     }
 
     /**
-     * @notice Exposes the internal _checkAllowedAddressList function for testing
-     */
-    function exposed_checkAllowedAddressList(
-        address[] memory allowedAddresses_,
-        address sender_
-    ) external pure returns (bool) {
-        return _checkAllowedAddressList(allowedAddresses_, sender_);
-    }
-
-    /**
      * @notice Exposes the internal _checkNftOwnership function for testing
      */
     function exposed_checkNftOwnership(address nftContract_, address user_)

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -18,32 +18,32 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
         return _getTotalRoundContribution(roundId_);
     }
 
-    function exposed_getUserContribution(uint64 roundId_, address user_)
+    function exposed_getUserContributionToRound(uint64 roundId_, address user_)
         external
         view
         returns (uint)
     {
-        return _getUserContribution(roundId_, user_);
+        return _getUserContributionToRound(roundId_, user_);
     }
 
     /**
      * @notice Exposes the internal _getUserPersonalCap function for testing
      */
-    function exposed_getUserPersonalCap(uint64 roundId_, address user_)
-        external
-        view
-        returns (uint)
-    {
-        return _getUserPersonalCap(roundId_, user_);
+    function exposed_getUserPersonalCapForRound(
+        uint64 roundId_,
+        uint8 accessId_,
+        address user_
+    ) external view returns (uint) {
+        return _getUserPersonalCapForRound(roundId_, accessId_, user_);
     }
 
     /**
      * @notice Exposes the internal _getUnusedCapacityFromPreviousRounds function for testing
      */
-    function exposed_getUnusedCapacityFromPreviousRounds(
+    function exposed_getUserUnusedCapacityFromPreviousRounds(
         address user_,
         uint64 currentRoundId_
     ) external view returns (uint) {
-        return _getUnusedCapacityFromPreviousRounds(user_, currentRoundId_);
+        return _getUserUnusedCapacityFromPreviousRounds(user_, currentRoundId_);
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1_Exposed.sol
@@ -48,26 +48,6 @@ contract LM_PC_FundingPot_v1_Exposed is LM_PC_FundingPot_v1 {
     }
 
     /**
-     * @notice Exposes the internal _validateRoundParameters function for testing
-     */
-    // function exposed_validateRoundParameters(Round memory round_)
-    //     external
-    //     view
-    // {
-    //     _validateRoundParameters(round_);
-    // }
-
-    /**
-     * @notice Exposes the internal _validateEditRoundParameters function for testing
-     */
-    // function exposed_validateEditRoundParameters(Round storage round_)
-    //     external
-    //     view
-    // {
-    //     _validateEditRoundParameters(round_);
-    // }
-
-    /**
      * @notice Exposes the internal _validTimes function for testing
      */
     function exposed_validTimes(uint start_, uint cliff_, uint end_)

--- a/test/utils/mocks/modules/logicModules/LM_PC_FundingPot_v2NFTMock.sol
+++ b/test/utils/mocks/modules/logicModules/LM_PC_FundingPot_v2NFTMock.sol
@@ -1,0 +1,44 @@
+// // SPDX-License-Identifier: LGPL-3.0-only
+// pragma solidity 0.8.23;
+
+// // External Dependencies
+// import "@oz/token/ERC721/ERC721.sol";
+// import "@oz/token/ERC721/extensions/ERC721URIStorage.sol";
+// import "@oz/access/Ownable.sol";
+// import "@oz/utils/Counters.sol";
+
+// contract MockNFT is ERC721URIStorage, Ownable {
+//     using Counters for Counters.Counter;
+
+//     Counters.Counter private _tokenIds;
+
+//     string public baseURI;
+
+//     constructor(string memory name, string memory symbol)
+//         ERC721(name, symbol)
+//         Ownable(msg.sender)
+//     {}
+
+//     function _baseURI() internal view override returns (string memory) {
+//         return baseURI;
+//     }
+
+//     function setBaseURI(string memory newBaseURI) public onlyOwner {
+//         baseURI = newBaseURI;
+//     }
+
+//     function mint(address to) public onlyOwner returns (uint) {
+//         uint newTokenId = _tokenIds.current();
+//         _safeMint(to, newTokenId);
+//         _tokenIds.increment();
+
+//         return newTokenId;
+//     }
+
+//     function setTokenURI(uint tokenId, string memory tokenURI)
+//         public
+//         onlyOwner
+//     {
+//         _setTokenURI(tokenId, tokenURI);
+//     }
+// }

--- a/test/utils/mocks/modules/logicModules/LM_PC_FundingPot_v2NFTMock.sol
+++ b/test/utils/mocks/modules/logicModules/LM_PC_FundingPot_v2NFTMock.sol
@@ -1,44 +1,40 @@
-// // SPDX-License-Identifier: LGPL-3.0-only
-// pragma solidity 0.8.23;
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.23;
 
-// // External Dependencies
-// import "@oz/token/ERC721/ERC721.sol";
-// import "@oz/token/ERC721/extensions/ERC721URIStorage.sol";
-// import "@oz/access/Ownable.sol";
-// import "@oz/utils/Counters.sol";
+// External Dependencies
+import "@oz/token/ERC721/ERC721.sol";
+import "@oz/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@oz/access/Ownable.sol";
 
-// contract MockNFT is ERC721URIStorage, Ownable {
-//     using Counters for Counters.Counter;
+contract ERC721Mock is ERC721URIStorage, Ownable {
+    uint private _nextTokenId;
+    string public baseURI;
 
-//     Counters.Counter private _tokenIds;
+    constructor(string memory name, string memory symbol)
+        ERC721(name, symbol)
+        Ownable(msg.sender)
+    {}
 
-//     string public baseURI;
+    function _baseURI() internal view override returns (string memory) {
+        return baseURI;
+    }
 
-//     constructor(string memory name, string memory symbol)
-//         ERC721(name, symbol)
-//         Ownable(msg.sender)
-//     {}
+    function setBaseURI(string memory newBaseURI) public onlyOwner {
+        baseURI = newBaseURI;
+    }
 
-//     function _baseURI() internal view override returns (string memory) {
-//         return baseURI;
-//     }
+    function mint(address to) public onlyOwner returns (uint) {
+        uint tokenId = _nextTokenId;
+        _safeMint(to, tokenId);
+        _nextTokenId++;
 
-//     function setBaseURI(string memory newBaseURI) public onlyOwner {
-//         baseURI = newBaseURI;
-//     }
+        return tokenId;
+    }
 
-//     function mint(address to) public onlyOwner returns (uint) {
-//         uint newTokenId = _tokenIds.current();
-//         _safeMint(to, newTokenId);
-//         _tokenIds.increment();
-
-//         return newTokenId;
-//     }
-
-//     function setTokenURI(uint tokenId, string memory tokenURI)
-//         public
-//         onlyOwner
-//     {
-//         _setTokenURI(tokenId, tokenURI);
-//     }
-// }
+    function setTokenURI(uint tokenId, string memory tokenURI)
+        public
+        onlyOwner
+    {
+        _setTokenURI(tokenId, tokenURI);
+    }
+}


### PR DESCRIPTION
# Funding Pot v1: Round Contribution and Closure Implementation

## Overview
This pull request completes the Funding Pot v1 implementation by adding round contribution for users, auto round closure conditions, and capacity roll over. This builds upon the previous PR's foundation of round creation and access criteria.

## Key Changes

### Round Contribution System
- Added contribution validation with time window checks
- Implemented personal and round-wide cap enforcement
- Added access criteria validation (NFT, Merkle, List)
- Implemented token transfer and accounting logic

### Round Closure Mechanism
- Implemented automatic closure conditions (cap/time-based)
- Added hook execution system for round closure
- Implemented unused capacity calculations

### Capacity Management
- Added cross-round capacity tracking
- Implemented global accumulative caps system
- Added personal cap accumulation logic
- Implemented round-to-round capacity transfer

## Notable Commits
- Apr 7, 2025: Fix variable shadowing warning
- Apr 7, 2025: Rename accessId to accessCriteriaId
- [Previous dates]: Implementation of contribution and closure mechanics
