### PR TITLE
Feat: Script Improvements

### DIFF
--- a/script/deploymentSuite/ProtocolConstants_v1.s.sol
+++ b/script/deploymentSuite/ProtocolConstants_v1.s.sol
@@ -213,4 +213,31 @@ contract ProtocolConstants_v1 is Script {
         // Set to 0 for Local Deployments
         return 0x0000000000000000000000000000000000000000;
     }
+
+    function currentNetworkIsMainnet() public view returns (bool) {
+        // Checks whether the current network is a mainnet
+        uint chainId = block.chainid;
+        for (uint i = 0; i < deployedMainnets.length; i++) {
+            if (chainId == deployedMainnets[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function currentNetworkIsTestnet() public view returns (bool) {
+        // Checks whether the current network is a testnet
+        uint chainId = block.chainid;
+        for (uint i = 0; i < deployedTestnets.length; i++) {
+            if (chainId == deployedTestnets[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function currentNetworkIsLocal() public view returns (bool) {
+        // Checks whether the current network is neither a mainnet nor a testnet
+        return !currentNetworkIsMainnet() && !currentNetworkIsTestnet();
+    }
 }

--- a/script/deploymentSuite/ProtocolConstants_v1.s.sol
+++ b/script/deploymentSuite/ProtocolConstants_v1.s.sol
@@ -57,7 +57,7 @@ contract ProtocolConstants_v1 is Script {
     // 137 = Polygon PoS
     // 1101 = Polygon zkEVM
     // 43114 = Avalanche C-Chain
-    uint[] public mainnets = [10, 137, 1101, 43_114];
+    uint[] public deployedMainnets = [10, 137, 1101, 43_114];
 
     // Testnets
     // 2442 = Polygon zkEVM Cardona
@@ -65,7 +65,8 @@ contract ProtocolConstants_v1 is Script {
     // 84532 = Base Sepolia
     // 11155111 = Sepolia
     // 11155420 = OP Sepolia
-    uint[] public testnets = [2442, 80_002, 84_532, 11_155_111, 11_155_420];
+    uint[] public deployedTestnets =
+        [2442, 80_002, 84_532, 11_155_111, 11_155_420];
 
     // Internal Storage for the deployment addresses
     // Note: As we deploy via a deterministic factory with the same salt across
@@ -140,15 +141,15 @@ contract ProtocolConstants_v1 is Script {
         uint chainId = block.chainid;
 
         // Mainnet Deployments
-        for (uint i = 0; i < mainnets.length; i++) {
-            if (chainId == mainnets[i]) {
+        for (uint i = 0; i < deployedMainnets.length; i++) {
+            if (chainId == deployedMainnets[i]) {
                 return orchestratorFactoryMainnet;
             }
         }
 
         // Testnet Deployments
-        for (uint i = 0; i < testnets.length; i++) {
-            if (chainId == testnets[i]) {
+        for (uint i = 0; i < deployedTestnets.length; i++) {
+            if (chainId == deployedTestnets[i]) {
                 return orchestratorFactoryTestnet;
             }
         }
@@ -175,15 +176,15 @@ contract ProtocolConstants_v1 is Script {
         uint chainId = block.chainid;
 
         // Mainnet Deployments
-        for (uint i = 0; i < mainnets.length; i++) {
-            if (chainId == mainnets[i]) {
+        for (uint i = 0; i < deployedMainnets.length; i++) {
+            if (chainId == deployedMainnets[i]) {
                 return governorMainnet;
             }
         }
 
         // Testnet Deployments
-        for (uint i = 0; i < testnets.length; i++) {
-            if (chainId == testnets[i]) {
+        for (uint i = 0; i < deployedTestnets.length; i++) {
+            if (chainId == deployedTestnets[i]) {
                 return governorTestnet;
             }
         }
@@ -196,15 +197,15 @@ contract ProtocolConstants_v1 is Script {
         uint chainId = block.chainid;
 
         // Mainnet Deployments
-        for (uint i = 0; i < mainnets.length; i++) {
-            if (chainId == mainnets[i]) {
+        for (uint i = 0; i < deployedMainnets.length; i++) {
+            if (chainId == deployedMainnets[i]) {
                 return reverterMainnet;
             }
         }
 
         // Testnet Deployments
-        for (uint i = 0; i < testnets.length; i++) {
-            if (chainId == testnets[i]) {
+        for (uint i = 0; i < deployedTestnets.length; i++) {
+            if (chainId == deployedTestnets[i]) {
                 return reverterTestnet;
             }
         }

--- a/script/deploymentSuite/ProtocolConstants_v1.s.sol
+++ b/script/deploymentSuite/ProtocolConstants_v1.s.sol
@@ -50,11 +50,13 @@ contract ProtocolConstants_v1 is Script {
     address public deployedReverter;
 
     // Chain IDs for Networks with Deployments
-    // If the current chainid is not part of any array, we assume that we are working locally.
+    // If the current chain id is not part of any array, we assume that we are working locally.
     uint[] public mainnets = [10, 137, 1101];
     uint[] public testnets = [2442, 80_002, 84_532, 11_155_111, 11_155_420];
 
-    // Internal Storage for the deployment addresses (hardcoded as they don't change)
+    // Internal Storage for the deployment addresses
+    // Note: As we deploy via a deterministic factory with the same salt across
+    //       all networks, we can use the same address for all network types.
     address private constant governorMainnet =
         0x0B7c73e778d04533286752BEb7d4BA42AEa2f57D;
     address private constant governorTestnet =

--- a/script/deploymentSuite/ProtocolConstants_v1.s.sol
+++ b/script/deploymentSuite/ProtocolConstants_v1.s.sol
@@ -55,12 +55,18 @@ contract ProtocolConstants_v1 is Script {
     uint[] public testnets = [2442, 80_002, 84_532, 11_155_111, 11_155_420];
 
     // Internal Storage for the deployment addresses (hardcoded as they don't change)
-    address private constant governorMainnet = 0x0B7c73e778d04533286752BEb7d4BA42AEa2f57D;
-    address private constant governorTestnet = 0x38D712491cC8A9B725AB867D56A4B0b25D9E0E3B;
-    address private constant orchestratorFactoryMainnet = 0x6ecA5f791d9635e4a1874cCD95564F914fBCF73d;
-    address private constant orchestratorFactoryTestnet = 0x535BdbC1D369d43fed8546024D273eE5274fFF65;
-    address private constant reverterMainnet = 0x6270b15Ac19eeC3d62920ed7f3a635a93E9C8B4C;
-    address private constant reverterTestnet = 0x54C1116BE44184619A8CB37Ef6E924f737C8F734;
+    address private constant governorMainnet =
+        0x0B7c73e778d04533286752BEb7d4BA42AEa2f57D;
+    address private constant governorTestnet =
+        0x38D712491cC8A9B725AB867D56A4B0b25D9E0E3B;
+    address private constant orchestratorFactoryMainnet =
+        0x6ecA5f791d9635e4a1874cCD95564F914fBCF73d;
+    address private constant orchestratorFactoryTestnet =
+        0x535BdbC1D369d43fed8546024D273eE5274fFF65;
+    address private constant reverterMainnet =
+        0x6270b15Ac19eeC3d62920ed7f3a635a93E9C8B4C;
+    address private constant reverterTestnet =
+        0x54C1116BE44184619A8CB37Ef6E924f737C8F734;
 
     // ------------------------------------------------------------------------
     // Important Configuration Data

--- a/script/deploymentSuite/ProtocolConstants_v1.s.sol
+++ b/script/deploymentSuite/ProtocolConstants_v1.s.sol
@@ -51,7 +51,20 @@ contract ProtocolConstants_v1 is Script {
 
     // Chain IDs for Networks with Deployments
     // If the current chain id is not part of any array, we assume that we are working locally.
-    uint[] public mainnets = [10, 137, 1101];
+
+    // Mainnets
+    // 10 = Optimism
+    // 137 = Polygon PoS
+    // 1101 = Polygon zkEVM
+    // 43114 = Avalanche C-Chain
+    uint[] public mainnets = [10, 137, 1101, 43_114];
+
+    // Testnets
+    // 2442 = Polygon zkEVM Cardona
+    // 80002 = Polygon Amoy
+    // 84532 = Base Sepolia
+    // 11155111 = Sepolia
+    // 11155420 = OP Sepolia
     uint[] public testnets = [2442, 80_002, 84_532, 11_155_111, 11_155_420];
 
     // Internal Storage for the deployment addresses

--- a/script/deploymentSuite/ProtocolConstants_v1.s.sol
+++ b/script/deploymentSuite/ProtocolConstants_v1.s.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 
 import "forge-std/Script.sol";
 
+import {OrchestratorFactory_v1} from "src/factories/OrchestratorFactory_v1.sol";
+
 /**
  * @title Inverter Protocol Deployment Constants
  *
@@ -34,12 +36,31 @@ contract ProtocolConstants_v1 is Script {
         vm.envAddress("DETERMINISTIC_FACTORY_ADDRESS");
 
     // ------------------------------------------------------------------------
-    // Deployment Salt
+    // Deployment Details
     // ------------------------------------------------------------------------
 
     string public constant factorySaltString = "inverter-deployment-1";
 
     bytes32 public factorySalt = keccak256(abi.encodePacked(factorySaltString));
+
+    // Deployment Addresses for Key Contracts needed for Protocol Updates/Maintenance
+    address public deployedOrchestratorFactory;
+    address public deployedModuleFactory;
+    address public deployedGovernor;
+    address public deployedReverter;
+
+    // Chain IDs for Networks with Deployments
+    // If the current chainid is not part of any array, we assume that we are working locally.
+    uint[] public mainnets = [10, 137, 1101];
+    uint[] public testnets = [2442, 80_002, 84_532, 11_155_111, 11_155_420];
+
+    // Internal Storage for the deployment addresses (hardcoded as they don't change)
+    address private constant governorMainnet = 0x0B7c73e778d04533286752BEb7d4BA42AEa2f57D;
+    address private constant governorTestnet = 0x38D712491cC8A9B725AB867D56A4B0b25D9E0E3B;
+    address private constant orchestratorFactoryMainnet = 0x6ecA5f791d9635e4a1874cCD95564F914fBCF73d;
+    address private constant orchestratorFactoryTestnet = 0x535BdbC1D369d43fed8546024D273eE5274fFF65;
+    address private constant reverterMainnet = 0x6270b15Ac19eeC3d62920ed7f3a635a93E9C8B4C;
+    address private constant reverterTestnet = 0x54C1116BE44184619A8CB37Ef6E924f737C8F734;
 
     // ------------------------------------------------------------------------
     // Important Configuration Data
@@ -52,6 +73,14 @@ contract ProtocolConstants_v1 is Script {
 
     // Governor
     uint public governor_timelockPeriod = 1 weeks;
+
+    // Function to load the protocol constants
+    function loadDeployedContracts() public {
+        deployedOrchestratorFactory = getDeployedOrchestratorFactory();
+        deployedModuleFactory = getDeployedModuleFactory();
+        deployedGovernor = getDeployedGovernor();
+        deployedReverter = getDeployedReverter();
+    }
 
     // Function to log data in a readable format
     function logProtocolMultisigsAndAddresses() public view {
@@ -84,5 +113,82 @@ contract ProtocolConstants_v1 is Script {
         );
         console2.log("\tGovernor:");
         console2.log("\t\tTimelock Period: %s seconds", governor_timelockPeriod);
+    }
+
+    function getDeployedOrchestratorFactory() public view returns (address) {
+        uint chainId = block.chainid;
+
+        // Mainnet Deployments
+        for (uint i = 0; i < mainnets.length; i++) {
+            if (chainId == mainnets[i]) {
+                return orchestratorFactoryMainnet;
+            }
+        }
+
+        // Testnet Deployments
+        for (uint i = 0; i < testnets.length; i++) {
+            if (chainId == testnets[i]) {
+                return orchestratorFactoryTestnet;
+            }
+        }
+
+        // Set to 0 for Local Deployments
+        return 0x0000000000000000000000000000000000000000;
+    }
+
+    function getDeployedModuleFactory() public view returns (address) {
+        if (
+            deployedOrchestratorFactory
+                != 0x0000000000000000000000000000000000000000
+        ) {
+            OrchestratorFactory_v1 orchestratorFactory =
+                OrchestratorFactory_v1(deployedOrchestratorFactory);
+            return address(orchestratorFactory.moduleFactory());
+        }
+
+        // Set to 0 for Local Deployments
+        return 0x0000000000000000000000000000000000000000;
+    }
+
+    function getDeployedGovernor() public view returns (address) {
+        uint chainId = block.chainid;
+
+        // Mainnet Deployments
+        for (uint i = 0; i < mainnets.length; i++) {
+            if (chainId == mainnets[i]) {
+                return governorMainnet;
+            }
+        }
+
+        // Testnet Deployments
+        for (uint i = 0; i < testnets.length; i++) {
+            if (chainId == testnets[i]) {
+                return governorTestnet;
+            }
+        }
+
+        // Set to 0 for Local Deployments
+        return 0x0000000000000000000000000000000000000000;
+    }
+
+    function getDeployedReverter() public view returns (address) {
+        uint chainId = block.chainid;
+
+        // Mainnet Deployments
+        for (uint i = 0; i < mainnets.length; i++) {
+            if (chainId == mainnets[i]) {
+                return reverterMainnet;
+            }
+        }
+
+        // Testnet Deployments
+        for (uint i = 0; i < testnets.length; i++) {
+            if (chainId == testnets[i]) {
+                return reverterTestnet;
+            }
+        }
+
+        // Set to 0 for Local Deployments
+        return 0x0000000000000000000000000000000000000000;
     }
 }

--- a/script/utils/DeployNewModule.s.sol
+++ b/script/utils/DeployNewModule.s.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Script.sol";
+
+import {ProtocolConstants_v1} from
+    "script/deploymentSuite/ProtocolConstants_v1.s.sol";
+
+import {ProxyAndBeaconDeployer_v1} from
+    "script/deploymentSuite/ProxyAndBeaconDeployer_v1.s.sol";
+
+import {IDeterministicFactory_v1} from
+    "@df/interfaces/IDeterministicFactory_v1.sol";
+
+import {
+    Governor_v1,
+    IModule_v1,
+    IInverterBeacon_v1
+} from "@ex/governance/Governor_v1.sol";
+
+import {Strings} from "@oz/utils/Strings.sol";
+
+contract DeployNewModule is Script, ProtocolConstants_v1 {
+    IDeterministicFactory_v1 public factory =
+        IDeterministicFactory_v1(deterministicFactory);
+
+    ProxyAndBeaconDeployer_v1 public proxyAndBeaconDeployer =
+        new ProxyAndBeaconDeployer_v1();
+
+    function run(
+        string memory moduleName,
+        uint majorVersion,
+        uint minorVersion,
+        uint patchVersion
+    ) external verifyRequiredParameters {
+        loadDeployedContracts();
+
+        string memory version =
+            _convertVersionString(majorVersion, minorVersion, patchVersion);
+
+        console2.log("----------------------------------------");
+        console2.log("Deploying new Module - %s (%s)", moduleName, version);
+        console2.log("Steps:");
+        console2.log("\t(1) Deploy Implementation");
+        console2.log("\t(2) Deploy Beacon");
+        console2.log("\t(3) Register Metadata");
+        console2.log("----------------------------------------");
+
+        console2.log("Step (1) Deploy Implementation...");
+        // Deploy the implementation
+        vm.startBroadcast(deployerPrivateKey);
+        address implementation = factory.deployWithCreate2(
+            factorySalt, abi.encodePacked(vm.getCode(moduleName), bytes(""))
+        );
+        vm.stopBroadcast();
+
+        console2.log("\t%s Implementation: %s", moduleName, implementation);
+        console2.log("----------------------------------------");
+
+        console2.log("Step (2) Deploy Beacon...");
+        // Deploy the beacon
+        address beacon = proxyAndBeaconDeployer.deployInverterBeacon(
+            moduleName,
+            deployedReverter,
+            deployedGovernor,
+            implementation,
+            majorVersion,
+            minorVersion,
+            patchVersion
+        );
+        console2.log("----------------------------------------");
+
+        console2.log("Step (3) Register Metadata in Factory...");
+        // Register the metadata
+        Governor_v1 governor = Governor_v1(deployedGovernor);
+        vm.startBroadcast(deployerPrivateKey);
+        governor.registerMetadataInModuleFactory(
+            IModule_v1.Metadata(
+                majorVersion,
+                minorVersion,
+                patchVersion,
+                moduleName,
+                "https://github.com/InverterNetwork/contracts"
+            ),
+            IInverterBeacon_v1(beacon)
+        );
+        vm.stopBroadcast();
+
+        console2.log("\t%s registered as version %s", moduleName, version);
+        console2.log("----------------------------------------");
+        console2.log("Deployment complete, Module is ready to be used!");
+        console2.log("----------------------------------------");
+    }
+
+    function _convertVersionString(uint major, uint minor, uint patch)
+        internal
+        pure
+        returns (string memory)
+    {
+        bytes memory rawVersion = abi.encodePacked(
+            "v",
+            Strings.toString(major),
+            ".",
+            Strings.toString(minor),
+            ".",
+            Strings.toString(patch)
+        );
+        return string(rawVersion);
+    }
+
+    modifier verifyRequiredParameters() {
+        require(
+            deterministicFactory != address(0),
+            "Deterministic Factory address not set - aborting!"
+        );
+        _;
+    }
+}

--- a/script/utils/UpgradeModule.s.sol
+++ b/script/utils/UpgradeModule.s.sol
@@ -186,7 +186,7 @@ contract UpgradeModule is Script, ProtocolConstants_v1 {
             );
             console2.log("\tto implementation\n\t\t%s", implementation);
             console2.log("\twith version\n\t\t%s", version);
-            console2.log("\tin the governor at\n\t\t%s", deployedGovernor); 
+            console2.log("\tin the governor at\n\t\t%s", deployedGovernor);
             console2.log("----------------------------------------");
             console2.log(
                 "Deployment complete, Module will be ready to be used once finalized via the Multisig!"

--- a/script/utils/UpgradeModule.s.sol
+++ b/script/utils/UpgradeModule.s.sol
@@ -26,6 +26,10 @@ contract UpgradeModule is Script, ProtocolConstants_v1 {
     IDeterministicFactory_v1 public factory =
         IDeterministicFactory_v1(deterministicFactory);
 
+    bytes32 _artifactNotFoundErrorHash = keccak256(
+        hex"eeaa9e6f00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000026766d2e676574436f64653a206e6f206d61746368696e6720617274696661637420666f756e640000000000000000000000000000000000000000000000000000"
+    );
+
     // This function automatically increments the minor version to the next number
     // and sets the patch version to zero.
     function run(string memory moduleName, uint majorVersion)
@@ -74,6 +78,7 @@ contract UpgradeModule is Script, ProtocolConstants_v1 {
 
     function _getCurrentVersion(string memory moduleName, uint majorVersion)
         internal
+        view
         returns (IInverterBeacon_v1, uint, string memory)
     {
         ModuleFactory_v1 moduleFactory = ModuleFactory_v1(deployedModuleFactory);
@@ -119,27 +124,88 @@ contract UpgradeModule is Script, ProtocolConstants_v1 {
         console2.log("----------------------------------------");
 
         console2.log("Step (1) Deploy Implementation...");
+
+        try vm.getCode(moduleName) {}
+        catch (bytes memory reason) {
+            if (keccak256(reason) == _artifactNotFoundErrorHash) {
+                console2.log(
+                    "\tImplementation for %s was not found, please ensure that you use the right contract name!",
+                    moduleName
+                );
+            } else {
+                console2.log(
+                    "\tFailed to import implementation of %s, raw error:",
+                    moduleName
+                );
+                console2.log(string(reason));
+            }
+            console2.log("----------------------------------------");
+            revert("Failed to import implementation of module");
+        }
+
         // Deploy the implementation
         vm.startBroadcast(deployerPrivateKey);
-        address implementation = factory.deployWithCreate2(
+        address implementation;
+        // use try catch block to catch the error if the deployment fails
+        try factory.deployWithCreate2(
             factorySalt, abi.encodePacked(vm.getCode(moduleName), bytes(""))
-        );
+        ) returns (address deployedAddress) {
+            implementation = deployedAddress;
+            console2.log("\t%s Implementation: %s", moduleName, deployedAddress);
+        } catch (bytes memory reason) {
+            bytes32 notAuthorizedError = keccak256(hex"c86af699");
+            if (keccak256(reason) == notAuthorizedError) {
+                console2.log(
+                    "\tFailed to deploy implementation of %s, you are not authorized to use the factory!",
+                    moduleName
+                );
+            } else {
+                console2.log(
+                    "\tFailed to deploy implementation of %s, raw error signature:",
+                    moduleName
+                );
+                console2.log(vm.toString(reason));
+            }
+            console2.log("-------------------w---------------------");
+            revert("Failed to deploy implementation of module");
+        }
         vm.stopBroadcast();
 
-        console2.log("\t%s Implementation: %s", moduleName, implementation);
         console2.log("----------------------------------------");
         console2.log("Step (2) Set new Version in Beacon...");
-        // Register the metadata
-        Governor_v1 governor = Governor_v1(deployedGovernor);
-        vm.startBroadcast(deployerPrivateKey);
-        governor.forceUpgradeBeaconAndRestartImplementation(
-            address(beacon), implementation, minorVersion, patchVersion
-        );
-        vm.stopBroadcast();
 
-        console2.log("\t%s updated to version %s", moduleName, version);
-        console2.log("----------------------------------------");
-        console2.log("Upgrade complete, Module is ready to be used!");
+        // If the used network is mainnet, we skip this step, as this only works
+        // on testnets or locally. On mainnets we need to use the multisig.
+        if (!currentNetworkIsMainnet()) {
+            console2.log(
+                "\tSkipping step, on mainnets the upgrade needs to be manually finalized in Multisig"
+            );
+            console2.log(
+                "\tTo do so, set new implementation for beacon\n\t\t%s",
+                address(beacon)
+            );
+            console2.log("\tto implementation\n\t\t%s", implementation);
+            console2.log("\twith version\n\t\t%s", version);
+            console2.log("\tin the governor at\n\t\t%s", deployedGovernor); 
+            console2.log("----------------------------------------");
+            console2.log(
+                "Deployment complete, Module will be ready to be used once finalized via the Multisig!"
+            );
+            // Todo: In the future, we should print the exact calldata needed for
+            //       the multisig to upgrade the beacon, so it's easy to do.
+        } else {
+            // Register the metadata
+            Governor_v1 governor = Governor_v1(deployedGovernor);
+            vm.startBroadcast(deployerPrivateKey);
+            governor.forceUpgradeBeaconAndRestartImplementation(
+                address(beacon), implementation, minorVersion, patchVersion
+            );
+            vm.stopBroadcast();
+
+            console2.log("\t%s updated to version %s", moduleName, version);
+            console2.log("----------------------------------------");
+            console2.log("Upgrade complete, Module is ready to be used!");
+        }
         console2.log("----------------------------------------");
     }
 

--- a/script/utils/UpgradeModule.s.sol
+++ b/script/utils/UpgradeModule.s.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Script.sol";
+
+import {ProtocolConstants_v1} from
+    "script/deploymentSuite/ProtocolConstants_v1.s.sol";
+
+import {ProxyAndBeaconDeployer_v1} from
+    "script/deploymentSuite/ProxyAndBeaconDeployer_v1.s.sol";
+
+import {IDeterministicFactory_v1} from
+    "@df/interfaces/IDeterministicFactory_v1.sol";
+
+import {
+    Governor_v1,
+    IModule_v1,
+    IInverterBeacon_v1
+} from "@ex/governance/Governor_v1.sol";
+
+import {ModuleFactory_v1} from "src/factories/ModuleFactory_v1.sol";
+
+import {Strings} from "@oz/utils/Strings.sol";
+
+contract UpgradeModule is Script, ProtocolConstants_v1 {
+    IDeterministicFactory_v1 public factory =
+        IDeterministicFactory_v1(deterministicFactory);
+
+    // This function automatically increments the minor version to the next number
+    // and sets the patch version to zero.
+    function run(string memory moduleName, uint majorVersion)
+        external
+        verifyRequiredParameters
+    {
+        loadDeployedContracts();
+
+        (
+            IInverterBeacon_v1 beacon,
+            uint currentMinor,
+            string memory currentVersion
+        ) = _getCurrentVersion(moduleName, majorVersion);
+
+        _upgradeModule(
+            moduleName,
+            majorVersion,
+            currentMinor + 1,
+            0,
+            beacon,
+            currentVersion
+        );
+    }
+
+    // This function allows you to manually set the minor and patch version.
+    function run(
+        string memory moduleName,
+        uint majorVersion,
+        uint minorVersion,
+        uint patchVersion
+    ) external verifyRequiredParameters {
+        loadDeployedContracts();
+
+        (IInverterBeacon_v1 beacon,, string memory currentVersion) =
+            _getCurrentVersion(moduleName, majorVersion);
+
+        _upgradeModule(
+            moduleName,
+            majorVersion,
+            minorVersion,
+            patchVersion,
+            beacon,
+            currentVersion
+        );
+    }
+
+    function _getCurrentVersion(string memory moduleName, uint majorVersion)
+        internal
+        returns (IInverterBeacon_v1, uint, string memory)
+    {
+        ModuleFactory_v1 moduleFactory = ModuleFactory_v1(deployedModuleFactory);
+        (IInverterBeacon_v1 beacon,) = moduleFactory.getBeaconAndId(
+            IModule_v1.Metadata(
+                majorVersion,
+                0,
+                0,
+                "https://github.com/InverterNetwork/contracts",
+                moduleName
+            )
+        );
+
+        (, uint currentMinor, uint currentPatch) = beacon.version();
+
+        string memory version =
+            _convertVersionString(majorVersion, currentMinor, currentPatch);
+
+        return (beacon, currentMinor, version);
+    }
+
+    function _upgradeModule(
+        string memory moduleName,
+        uint majorVersion,
+        uint minorVersion,
+        uint patchVersion,
+        IInverterBeacon_v1 beacon,
+        string memory currentVersion
+    ) internal {
+        string memory version =
+            _convertVersionString(majorVersion, minorVersion, patchVersion);
+
+        console2.log("----------------------------------------");
+        console2.log(
+            "Upgrading Module - %s (%s to %s)",
+            moduleName,
+            currentVersion,
+            version
+        );
+        console2.log("Steps:");
+        console2.log("\t(1) Deploy Implementation");
+        console2.log("\t(2) Set new Version in Beacon");
+        console2.log("----------------------------------------");
+
+        console2.log("Step (1) Deploy Implementation...");
+        // Deploy the implementation
+        vm.startBroadcast(deployerPrivateKey);
+        address implementation = factory.deployWithCreate2(
+            factorySalt, abi.encodePacked(vm.getCode(moduleName), bytes(""))
+        );
+        vm.stopBroadcast();
+
+        console2.log("\t%s Implementation: %s", moduleName, implementation);
+        console2.log("----------------------------------------");
+        console2.log("Step (2) Set new Version in Beacon...");
+        // Register the metadata
+        Governor_v1 governor = Governor_v1(deployedGovernor);
+        vm.startBroadcast(deployerPrivateKey);
+        governor.forceUpgradeBeaconAndRestartImplementation(
+            address(beacon), implementation, minorVersion, patchVersion
+        );
+        vm.stopBroadcast();
+
+        console2.log("\t%s updated to version %s", moduleName, version);
+        console2.log("----------------------------------------");
+        console2.log("Upgrade complete, Module is ready to be used!");
+        console2.log("----------------------------------------");
+    }
+
+    function _convertVersionString(uint major, uint minor, uint patch)
+        internal
+        pure
+        returns (string memory)
+    {
+        bytes memory rawVersion = abi.encodePacked(
+            "v",
+            Strings.toString(major),
+            ".",
+            Strings.toString(minor),
+            ".",
+            Strings.toString(patch)
+        );
+        return string(rawVersion);
+    }
+
+    modifier verifyRequiredParameters() {
+        require(
+            deterministicFactory != address(0),
+            "Deterministic Factory address not set - aborting!"
+        );
+        _;
+    }
+}

--- a/script/utils/UpgradeModule.s.sol
+++ b/script/utils/UpgradeModule.s.sol
@@ -176,7 +176,7 @@ contract UpgradeModule is Script, ProtocolConstants_v1 {
 
         // If the used network is mainnet, we skip this step, as this only works
         // on testnets or locally. On mainnets we need to use the multisig.
-        if (!currentNetworkIsMainnet()) {
+        if (currentNetworkIsMainnet()) {
             console2.log(
                 "\tSkipping step, on mainnets the upgrade needs to be manually finalized in Multisig"
             );


### PR DESCRIPTION
This PR will contain the following:
* Script to easily deploy modules
* Script to easily update modules
* Script that deploys the v1 version of the protocol without needing to switch to the old tag
  * Includes a new deployment script that does a full deployment with that in mind

### **Script to easily deploy modules**
The idea is to have a simple command that does all of the necessary steps for you under the hood. Called via (for example):
```bash
forge script script/utils/DeployNewModule.s.sol --rpc-url $ETHEREUM_SEPOLIA_RPC_URL --sig "run(string,uint,uint,uint)" "FM_DepositVault_v1" 3 0 0
```
This would deploy the `FM_DepositVault_v1` as a new module in version 3.0.0 to Ethereum Sepolia and add it to the factory. Output:
![Screenshot 2025-04-08 at 14 59 10](https://github.com/user-attachments/assets/821b41fc-340a-4d6b-badb-9cee49e2b11a)

### **Script to easily update modules**
Once you have a deployed module it was very annoying to update it accordingly. This script handles that for you in one command. Called via (for example):
 ```bash
forge script script/utils/UpgradeModule.s.sol --rpc-url $ETHEREUM_SEPOLIA_RPC_URL --sig "run(string,uint,uint,uint)" "FM_DepositVault_v1" 1 2 8
```
This would update the `FM_DepositVault_v1` to version 1.2.8. You can also omit the minor and patch version, in which case the script will just increase the minor version and reset the patch version - i.e. if the current version is 1.2.8 it would deploy as 1.3.0.

Output:
![Screenshot 2025-04-08 at 14 59 41](https://github.com/user-attachments/assets/e4b308a3-f164-4367-b5bc-b036be1092e8)
