### PR TITLE
Feat: Dynamic cross round behavior & contract size

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,7 @@ optimizer = true
 optimizer_runs = 750
 via_ir = false
 
+additional_compiler_profiles = [ { name = "large-contracts", optimizer = true, optimizer_runs = 200 } ]
 compilation_restrictions = [
     { paths = "src/modules/logicModule/LM_PC_FundingPot_v1.sol", optimizer = true, optimizer_runs = 200 },
 ]

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,9 +10,9 @@ optimizer = true
 optimizer_runs = 750
 via_ir = false
 
-additional_compiler_profiles = [ { name = "large-contracts", optimizer = true, optimizer_runs = 200 } ]
+additional_compiler_profiles = [ { name = "large-contracts", optimizer = true, optimizer_runs = 100 } ]
 compilation_restrictions = [
-    { paths = "src/modules/logicModule/LM_PC_FundingPot_v1.sol", optimizer = true, optimizer_runs = 200 },
+    { paths = "src/modules/logicModule/LM_PC_FundingPot_v1.sol", optimizer = true, optimizer_runs = 100 },
 ]
 
 [fuzz]

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,10 @@ optimizer = true
 optimizer_runs = 750
 via_ir = false
 
+compilation_restrictions = [
+    { paths = "src/modules/logicModule/LM_PC_FundingPot_v1.sol", optimizer = true, optimizer_runs = 200 },
+]
+
 [fuzz]
 runs = 256
 

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -171,11 +171,10 @@ contract LM_PC_FundingPot_v1 is
     /// @dev    MUST call `__Module_init()`.
     /// @param  orchestrator_ The orchestrator contract.
     /// @param  metadata_ The metadata of the module.
-    /// @param  configData_ The config data of the module, comprised of:
     function init(
         IOrchestrator_v1 orchestrator_,
         Metadata memory metadata_,
-        bytes memory configData_
+        bytes memory
     ) external override(Module_v1) initializer {
         __Module_init(orchestrator_, metadata_);
         // Set the flags for the PaymentOrders (this module uses 3 flags).

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -1036,8 +1036,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         // --- Personal Cap Check ---
-        // Skip personal cap check if adjustedAmount is already 0
-        if (adjustedAmount > 0) {
+        {
             uint userPreviousContribution =
                 roundIdToUserToContribution[roundId_][user_];
 

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -184,6 +184,8 @@ contract LM_PC_FundingPot_v1 is
         flags |= bytes32(1 << FLAG_END);
 
         __ERC20PaymentClientBase_v2_init(flags);
+        // Explicitly initialize the global start round ID
+        globalAccumulationStartRoundId = 1;
     }
 
     // -------------------------------------------------------------------------
@@ -652,27 +654,39 @@ contract LM_PC_FundingPot_v1 is
 
         // Process each previous round cap that the user wants to carry over
         for (uint i = 0; i < unspentPersonalRoundCaps_.length; i++) {
-            UnspentPersonalRoundCap memory roundCap =
+            UnspentPersonalRoundCap memory roundCapInfo =
                 unspentPersonalRoundCaps_[i];
 
-            Round storage prevRound = rounds[roundCap.roundId];
-            if (prevRound.accumulationMode == AccumulationMode.Disabled) continue;
+            // Skip if this round is before the global accumulation start round
+            if (roundCapInfo.roundId < globalAccumulationStartRoundId) {
+                continue;
+            }
+
+            // For PERSONAL cap rollover, the PREVIOUS round must have allowed it (Personal or All).
+            if (
+                rounds[roundCapInfo.roundId].accumulationMode
+                    != AccumulationMode.Personal
+                    && rounds[roundCapInfo.roundId].accumulationMode
+                        != AccumulationMode.All
+            ) {
+                continue;
+            }
 
             // Verify the user was eligible for this access criteria in the previous round
             bool isEligible = _checkAccessCriteriaEligibility(
-                uint32(roundCap.roundId),
-                roundCap.accessCriteriaId,
-                roundCap.merkleProof,
+                roundCapInfo.roundId,
+                roundCapInfo.accessCriteriaId,
+                roundCapInfo.merkleProof,
                 user_
             );
 
             if (isEligible) {
                 AccessCriteriaPrivileges storage privileges =
-                roundIdToAccessCriteriaIdToPrivileges[roundCap.roundId][roundCap
+                roundIdToAccessCriteriaIdToPrivileges[roundCapInfo.roundId][roundCapInfo
                     .accessCriteriaId];
 
                 uint userContribution =
-                    roundIdToUserToContribution[roundCap.roundId][user_];
+                    roundIdToUserToContribution[roundCapInfo.roundId][user_];
                 uint personalCap = privileges.personalCap;
 
                 if (userContribution < personalCap) {
@@ -765,7 +779,6 @@ contract LM_PC_FundingPot_v1 is
 
         roundIdToNextUnprocessedIndex[roundId_] = endIndex;
     }
-
 
     /// @inheritdoc ILM_PC_FundingPot_v1
     function setGlobalAccumulationStart(uint32 startRoundId_)
@@ -1005,14 +1018,15 @@ contract LM_PC_FundingPot_v1 is
 
             if (totalRoundContribution >= effectiveRoundCap) {
                 // If user tries to contribute a non-zero amount when cap is full, revert.
-                if (amount_ > 0) { 
+                if (amount_ > 0) {
                     revert Module__LM_PC_FundingPot__RoundCapReached();
                 }
-                 // If user tries to contribute zero when cap is full, allow adjustedAmount = 0.
-                 adjustedAmount = 0; 
+                // If user tries to contribute zero when cap is full, allow adjustedAmount = 0.
+                adjustedAmount = 0;
             } else {
                 // Cap is not full, calculate remaining and clamp if necessary
-                uint remainingRoundCap = effectiveRoundCap - totalRoundContribution;
+                uint remainingRoundCap =
+                    effectiveRoundCap - totalRoundContribution;
                 if (adjustedAmount > remainingRoundCap) {
                     adjustedAmount = remainingRoundCap;
                 }
@@ -1023,18 +1037,19 @@ contract LM_PC_FundingPot_v1 is
         // If original amount was 0, adjustedAmount is 0, so we can proceed to personal cap check which will also result in 0.
         // If adjustedAmount > 0, proceed to personal cap check.
         if (adjustedAmount == 0 && amount_ > 0) {
-             // This state should ideally not be reached due to the revert above if cap was full.
-             // But as a safeguard, if amount_ was > 0 and adjustedAmount is now 0, return 0.
-             return 0; 
+            // This state should ideally not be reached due to the revert above if cap was full.
+            // But as a safeguard, if amount_ was > 0 and adjustedAmount is now 0, return 0.
+            return 0;
         }
 
-        // --- Personal Cap Check --- 
+        // --- Personal Cap Check ---
         // Only proceed if adjustedAmount wasn't already set to 0 by round cap or initial amount.
         if (adjustedAmount > 0) {
-            uint userPreviousContribution = roundIdToUserToContribution[roundId_][user_];
+            uint userPreviousContribution =
+                roundIdToUserToContribution[roundId_][user_];
 
             AccessCriteriaPrivileges storage privileges =
-                roundIdToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId_];
+            roundIdToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId_];
             uint userPersonalCap = privileges.personalCap;
 
             // Add unspent personal capacity if personal accumulation is enabled for this round (Personal or All)
@@ -1050,14 +1065,16 @@ contract LM_PC_FundingPot_v1 is
             if (userPreviousContribution + adjustedAmount > userPersonalCap) {
                 // If user hasn't reached personal cap yet, clamp further to remaining personal cap.
                 if (userPreviousContribution < userPersonalCap) {
-                    uint remainingPersonalCap = userPersonalCap - userPreviousContribution;
+                    uint remainingPersonalCap =
+                        userPersonalCap - userPreviousContribution;
                     // Ensure we don't accidentally increase amount, only clamp down.
-                    if (remainingPersonalCap < adjustedAmount) { 
+                    if (remainingPersonalCap < adjustedAmount) {
                         adjustedAmount = remainingPersonalCap;
                     }
-                } else { // User is already at or over personal cap.
+                } else {
+                    // User is already at or over personal cap.
                     // If they tried to contribute a non-zero amount initially, revert.
-                    if (amount_ > 0) { 
+                    if (amount_ > 0) {
                         revert Module__LM_PC_FundingPot__PersonalCapReached();
                     }
                     // If initial amount was 0, just ensure adjustedAmount remains 0.

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -195,7 +195,7 @@ contract LM_PC_FundingPot_v1 is
             address hookContract,
             bytes memory hookFunction,
             bool autoClosure,
-            bool globalAccumulativeCaps
+            AccumulationMode accumulationMode
         )
     {
         Round storage round = rounds[roundId_];
@@ -206,7 +206,7 @@ contract LM_PC_FundingPot_v1 is
             round.hookContract,
             round.hookFunction,
             round.autoClosure,
-            round.globalAccumulativeCaps
+            round.accumulationMode
         );
     }
 
@@ -381,7 +381,7 @@ contract LM_PC_FundingPot_v1 is
         address hookContract_,
         bytes memory hookFunction_,
         bool autoClosure_,
-        bool globalAccumulativeCaps_
+        AccumulationMode accumulationMode_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) returns (uint32) {
         unchecked {
             roundCount++;
@@ -396,7 +396,7 @@ contract LM_PC_FundingPot_v1 is
         round.hookContract = hookContract_;
         round.hookFunction = hookFunction_;
         round.autoClosure = autoClosure_;
-        round.globalAccumulativeCaps = globalAccumulativeCaps_;
+        round.accumulationMode = accumulationMode_;
 
         _validateRoundParameters(round);
 
@@ -408,7 +408,7 @@ contract LM_PC_FundingPot_v1 is
             hookContract_,
             hookFunction_,
             autoClosure_,
-            globalAccumulativeCaps_
+            accumulationMode_
         );
 
         return uint32(roundId);
@@ -423,7 +423,7 @@ contract LM_PC_FundingPot_v1 is
         address hookContract_,
         bytes memory hookFunction_,
         bool autoClosure_,
-        bool globalAccumulativeCaps_
+        AccumulationMode accumulationMode_
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
 
@@ -435,7 +435,7 @@ contract LM_PC_FundingPot_v1 is
         round.hookContract = hookContract_;
         round.hookFunction = hookFunction_;
         round.autoClosure = autoClosure_;
-        round.globalAccumulativeCaps = globalAccumulativeCaps_;
+        round.accumulationMode = accumulationMode_;
 
         _validateRoundParameters(round);
 
@@ -447,7 +447,7 @@ contract LM_PC_FundingPot_v1 is
             hookContract_,
             hookFunction_,
             autoClosure_,
-            globalAccumulativeCaps_
+            accumulationMode_
         );
     }
 
@@ -642,7 +642,7 @@ contract LM_PC_FundingPot_v1 is
                 unspentPersonalRoundCaps_[i];
 
             Round storage prevRound = rounds[roundCap.roundId];
-            if (!prevRound.globalAccumulativeCaps) continue;
+            if (prevRound.accumulationMode == AccumulationMode.Disabled) continue;
 
             // Verify the user was eligible for this access criteria in the previous round
             bool isEligible = _checkAccessCriteriaEligibility(
@@ -957,49 +957,81 @@ contract LM_PC_FundingPot_v1 is
             uint totalRoundContribution = roundIdToTotalContributions[roundId_];
             uint effectiveRoundCap = round.roundCap;
 
-            // If global accumulative caps are enabled,
-            // adjust the round cap to acommodate unused capacity from previous rounds
-            if (round.globalAccumulativeCaps) {
+            // If total accumulative caps are enabled for this round,
+            // adjust the effective round cap to accommodate unused capacity from previous rounds
+            // NOTE: This part is relevant for Total/All modes, but the check itself is needed here.
+            if (
+                round.accumulationMode == AccumulationMode.Total
+                    || round.accumulationMode == AccumulationMode.All
+            ) {
                 uint unusedCapacityFromPrevious =
                     _calculateUnusedCapacityFromPreviousRounds(roundId_);
                 effectiveRoundCap += unusedCapacityFromPrevious;
             }
 
             if (totalRoundContribution >= effectiveRoundCap) {
-                revert Module__LM_PC_FundingPot__RoundCapReached();
-            }
-
-            // Allow the user to contribute up to the remaining round cap
-            uint remainingRoundCap;
-            unchecked {
-                remainingRoundCap = effectiveRoundCap - totalRoundContribution;
-            }
-            if (adjustedAmount > remainingRoundCap) {
-                adjustedAmount = remainingRoundCap;
-            }
-        }
-
-        // Check and adjust for personal cap
-        uint userPreviousContribution =
-            roundIdToUserToContribution[roundId_][user_];
-
-        // Get the base personal cap for this round and criteria
-        AccessCriteriaPrivileges storage privileges =
-            roundIdToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId_];
-        uint userPersonalCap = privileges.personalCap;
-
-        // Add unspent capacity if global accumulative caps are enabled
-        if (round.globalAccumulativeCaps) {
-            userPersonalCap += unspentPersonalCap_;
-        }
-
-        if (userPreviousContribution + adjustedAmount > userPersonalCap) {
-            if (userPreviousContribution < userPersonalCap) {
-                adjustedAmount = userPersonalCap - userPreviousContribution;
+                // If user tries to contribute a non-zero amount when cap is full, revert.
+                if (amount_ > 0) { 
+                    revert Module__LM_PC_FundingPot__RoundCapReached();
+                }
+                 // If user tries to contribute zero when cap is full, allow adjustedAmount = 0.
+                 adjustedAmount = 0; 
             } else {
-                revert Module__LM_PC_FundingPot__PersonalCapReached();
+                // Cap is not full, calculate remaining and clamp if necessary
+                uint remainingRoundCap = effectiveRoundCap - totalRoundContribution;
+                if (adjustedAmount > remainingRoundCap) {
+                    adjustedAmount = remainingRoundCap;
+                }
             }
         }
+
+        // If round cap check clamped adjustedAmount to 0, and original amount was > 0, we already reverted.
+        // If original amount was 0, adjustedAmount is 0, so we can proceed to personal cap check which will also result in 0.
+        // If adjustedAmount > 0, proceed to personal cap check.
+        if (adjustedAmount == 0 && amount_ > 0) {
+             // This state should ideally not be reached due to the revert above if cap was full.
+             // But as a safeguard, if amount_ was > 0 and adjustedAmount is now 0, return 0.
+             return 0; 
+        }
+
+        // --- Personal Cap Check --- 
+        // Only proceed if adjustedAmount wasn't already set to 0 by round cap or initial amount.
+        if (adjustedAmount > 0) {
+            uint userPreviousContribution = roundIdToUserToContribution[roundId_][user_];
+
+            AccessCriteriaPrivileges storage privileges =
+                roundIdToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId_];
+            uint userPersonalCap = privileges.personalCap;
+
+            // Add unspent personal capacity if personal accumulation is enabled for this round (Personal or All)
+            // Explicitly exclude Total mode here.
+            if (
+                round.accumulationMode == AccumulationMode.Personal
+                    || round.accumulationMode == AccumulationMode.All
+            ) {
+                userPersonalCap += unspentPersonalCap_;
+            }
+
+            // Check if the already potentially-clamped amount exceeds personal cap
+            if (userPreviousContribution + adjustedAmount > userPersonalCap) {
+                // If user hasn't reached personal cap yet, clamp further to remaining personal cap.
+                if (userPreviousContribution < userPersonalCap) {
+                    uint remainingPersonalCap = userPersonalCap - userPreviousContribution;
+                    // Ensure we don't accidentally increase amount, only clamp down.
+                    if (remainingPersonalCap < adjustedAmount) { 
+                        adjustedAmount = remainingPersonalCap;
+                    }
+                } else { // User is already at or over personal cap.
+                    // If they tried to contribute a non-zero amount initially, revert.
+                    if (amount_ > 0) { 
+                        revert Module__LM_PC_FundingPot__PersonalCapReached();
+                    }
+                    // If initial amount was 0, just ensure adjustedAmount remains 0.
+                    adjustedAmount = 0;
+                }
+            }
+        }
+        // --- End Personal Cap Check --- '
 
         return adjustedAmount;
     }
@@ -1051,7 +1083,13 @@ contract LM_PC_FundingPot_v1 is
         // Iterate through all previous rounds (1 to roundId_-1)
         for (uint32 i = 1; i < roundId_; ++i) {
             Round storage prevRound = rounds[i];
-            if (!prevRound.globalAccumulativeCaps) continue;
+            // Only consider previous rounds that allowed total accumulation
+            if (
+                prevRound.accumulationMode != AccumulationMode.Total
+                    && prevRound.accumulationMode != AccumulationMode.All
+            ) {
+                continue;
+            }
 
             uint prevRoundTotal = roundIdToTotalContributions[i];
             if (prevRoundTotal < prevRound.roundCap) {

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -1007,13 +1007,13 @@ contract LM_PC_FundingPot_v1 is
 
         Round storage round = rounds[roundId_];
 
+        // --- Round Cap Check ---
         if (!canOverrideContributionSpan_ && round.roundCap > 0) {
             uint totalRoundContribution = roundIdToTotalContributions[roundId_];
             uint effectiveRoundCap = round.roundCap;
 
             // If total accumulative caps are enabled for this round,
             // adjust the effective round cap to accommodate unused capacity from previous rounds
-            // NOTE: This part is relevant for Total/All modes, but the check itself is needed here.
             if (
                 round.accumulationMode == AccumulationMode.Total
                     || round.accumulationMode == AccumulationMode.All
@@ -1024,12 +1024,8 @@ contract LM_PC_FundingPot_v1 is
             }
 
             if (totalRoundContribution >= effectiveRoundCap) {
-                // If user tries to contribute a non-zero amount when cap is full, revert.
-                if (amount_ > 0) {
-                    revert Module__LM_PC_FundingPot__RoundCapReached();
-                }
-                // If user tries to contribute zero when cap is full, allow adjustedAmount = 0.
-                adjustedAmount = 0;
+                // If round cap is reached, revert (we know amount_ > 0 from parent function)
+                revert Module__LM_PC_FundingPot__RoundCapReached();
             } else {
                 // Cap is not full, calculate remaining and clamp if necessary
                 uint remainingRoundCap =
@@ -1041,7 +1037,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         // --- Personal Cap Check ---
-        // Only proceed if adjustedAmount wasn't already set to 0 by round cap or initial amount.
+        // Skip personal cap check if adjustedAmount is already 0
         if (adjustedAmount > 0) {
             uint userPreviousContribution =
                 roundIdToUserToContribution[roundId_][user_];
@@ -1050,8 +1046,7 @@ contract LM_PC_FundingPot_v1 is
             roundIdToAccessCriteriaIdToPrivileges[roundId_][accessCriteriaId_];
             uint userPersonalCap = privileges.personalCap;
 
-            // Add unspent personal capacity if personal accumulation is enabled for this round (Personal or All)
-            // Explicitly exclude Total mode here.
+            // Add unspent personal capacity if personal accumulation is enabled for this round
             if (
                 round.accumulationMode == AccumulationMode.Personal
                     || round.accumulationMode == AccumulationMode.All
@@ -1059,28 +1054,18 @@ contract LM_PC_FundingPot_v1 is
                 userPersonalCap += unspentPersonalCap_;
             }
 
-            // Check if the already potentially-clamped amount exceeds personal cap
-            if (userPreviousContribution + adjustedAmount > userPersonalCap) {
-                // If user hasn't reached personal cap yet, clamp further to remaining personal cap.
-                if (userPreviousContribution < userPersonalCap) {
-                    uint remainingPersonalCap =
-                        userPersonalCap - userPreviousContribution;
-                    // Ensure we don't accidentally increase amount, only clamp down.
-                    if (remainingPersonalCap < adjustedAmount) {
-                        adjustedAmount = remainingPersonalCap;
-                    }
-                } else {
-                    // User is already at or over personal cap.
-                    // If they tried to contribute a non-zero amount initially, revert.
-                    if (amount_ > 0) {
-                        revert Module__LM_PC_FundingPot__PersonalCapReached();
-                    }
-                    // If initial amount was 0, just ensure adjustedAmount remains 0.
-                    adjustedAmount = 0;
-                }
+            // If user already reached their cap, revert
+            if (userPreviousContribution >= userPersonalCap) {
+                revert Module__LM_PC_FundingPot__PersonalCapReached();
+            }
+
+            // Calculate remaining personal cap and take minimum
+            uint remainingPersonalCap =
+                userPersonalCap - userPreviousContribution;
+            if (remainingPersonalCap < adjustedAmount) {
+                adjustedAmount = remainingPersonalCap;
             }
         }
-        // --- End Personal Cap Check --- '
 
         return adjustedAmount;
     }

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -644,49 +644,62 @@ contract LM_PC_FundingPot_v1 is
         bytes32[] memory merkleProof_,
         UnspentPersonalRoundCap[] calldata unspentPersonalRoundCaps_
     ) external {
-        uint unspentPersonalCap;
+        uint unspentPersonalCap = 0; // Initialize to 0
+        uint32 lastSeenRoundId = 0; // Tracks the last seen roundId to ensure strictly increasing order
 
         // Process each previous round cap that the user wants to carry over
         for (uint i = 0; i < unspentPersonalRoundCaps_.length; i++) {
             UnspentPersonalRoundCap memory roundCapInfo =
                 unspentPersonalRoundCaps_[i];
+            uint32 currentProcessingRoundId = roundCapInfo.roundId;
+
+            // Enforcement: Round IDs in the array must be strictly increasing.
+            if (currentProcessingRoundId <= lastSeenRoundId) {
+                revert
+                    Module__LM_PC_FundingPot__UnspentCapsRoundIdsNotStrictlyIncreasing(
+                );
+            }
 
             // Skip if this round is before the global accumulation start round
-            if (roundCapInfo.roundId < globalAccumulationStartRoundId) {
+            if (currentProcessingRoundId < globalAccumulationStartRoundId) {
+                lastSeenRoundId = currentProcessingRoundId; // Update lastSeenRoundId before continuing
                 continue;
             }
 
             // For PERSONAL cap rollover, the PREVIOUS round must have allowed it (Personal or All).
             if (
-                rounds[roundCapInfo.roundId].accumulationMode
+                rounds[currentProcessingRoundId].accumulationMode
                     != AccumulationMode.Personal
-                    && rounds[roundCapInfo.roundId].accumulationMode
+                    && rounds[currentProcessingRoundId].accumulationMode
                         != AccumulationMode.All
             ) {
+                lastSeenRoundId = currentProcessingRoundId; // Update lastSeenRoundId before continuing
                 continue;
             }
 
-            // Verify the user was eligible for this access criteria in the previous round
-            bool isEligible = _checkAccessCriteriaEligibility(
-                roundCapInfo.roundId,
-                roundCapInfo.accessCriteriaId,
-                roundCapInfo.merkleProof,
-                user_
-            );
-
-            if (isEligible) {
+            if (
+                _checkAccessCriteriaEligibility(
+                    currentProcessingRoundId,
+                    roundCapInfo.accessCriteriaId,
+                    roundCapInfo.merkleProof,
+                    user_
+                )
+            ) {
                 AccessCriteriaPrivileges storage privileges =
-                roundIdToAccessCriteriaIdToPrivileges[roundCapInfo.roundId][roundCapInfo
+                roundIdToAccessCriteriaIdToPrivileges[currentProcessingRoundId][roundCapInfo
                     .accessCriteriaId];
 
                 uint userContribution =
-                    roundIdToUserToContribution[roundCapInfo.roundId][user_];
+                    roundIdToUserToContribution[currentProcessingRoundId][user_];
                 uint personalCap = privileges.personalCap;
+                uint unspentForThisEntry = 0;
 
                 if (userContribution < personalCap) {
-                    unspentPersonalCap += (personalCap - userContribution);
+                    unspentForThisEntry = personalCap - userContribution;
                 }
+                unspentPersonalCap += unspentForThisEntry;
             }
+            lastSeenRoundId = currentProcessingRoundId; // Update after processing or skipping
         }
 
         _contributeToRoundFor(

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -151,6 +151,11 @@ contract LM_PC_FundingPot_v1 is
     /// @notice The next available access criteria ID for each round
     mapping(uint32 => uint8) private roundIdToNextAccessCriteriaId;
 
+    /// @notice The minimum round ID (inclusive, >= 1) to consider for accumulation calculations.
+    /// @dev    Defaults to 1. If a target round's mode allows accumulation,
+    ///         only previous rounds with roundId >= globalAccumulationStartRoundId will be included.
+    uint32 internal globalAccumulationStartRoundId;
+
     /// @notice Storage gap for future upgrades.
     uint[50] private __gap;
 
@@ -368,6 +373,15 @@ contract LM_PC_FundingPot_v1 is
         returns (uint)
     {
         return roundIdToUserToContribution[roundId_][user_];
+    }
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function getGlobalAccumulationStartRoundId()
+        external
+        view
+        returns (uint32)
+    {
+        return globalAccumulationStartRoundId;
     }
 
     // -------------------------------------------------------------------------
@@ -752,6 +766,26 @@ contract LM_PC_FundingPot_v1 is
         roundIdToNextUnprocessedIndex[roundId_] = endIndex;
     }
 
+
+    /// @inheritdoc ILM_PC_FundingPot_v1
+    function setGlobalAccumulationStart(uint32 startRoundId_)
+        external
+        onlyModuleRole(FUNDING_POT_ADMIN_ROLE)
+    {
+        if (startRoundId_ == 0) {
+            revert Module__LM_PC_FundingPot__StartRoundCannotBeZero();
+        }
+        if (startRoundId_ > roundCount) {
+            revert Module__LM_PC_FundingPot__StartRoundGreaterThanRoundCount(
+                startRoundId_, roundCount
+            );
+        }
+
+        globalAccumulationStartRoundId = startRoundId_;
+
+        emit GlobalAccumulationStartSet(startRoundId_);
+    }
+
     // -------------------------------------------------------------------------
     // Internal
 
@@ -1080,8 +1114,14 @@ contract LM_PC_FundingPot_v1 is
         view
         returns (uint unusedCapacityFromPrevious)
     {
-        // Iterate through all previous rounds (1 to roundId_-1)
-        for (uint32 i = 1; i < roundId_; ++i) {
+        uint32 startAccumulationFrom = globalAccumulationStartRoundId;
+
+        if (startAccumulationFrom >= roundId_) {
+            return 0; // No rounds to consider for accumulation
+        }
+
+        // Iterate through previous rounds starting from the globalAccumulationStartRoundId
+        for (uint32 i = startAccumulationFrom; i < roundId_; ++i) {
             Round storage prevRound = rounds[i];
             // Only consider previous rounds that allowed total accumulation
             if (

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -16,6 +16,7 @@ import {
 } from "@lm/abstracts/ERC20PaymentClientBase_v2.sol";
 import {IBondingCurveBase_v1} from
     "@fm/bondingCurve/interfaces/IBondingCurveBase_v1.sol";
+import {IFundingManager_v1} from "@fm/IFundingManager_v1.sol";
 
 // External
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
@@ -228,33 +229,24 @@ contract LM_PC_FundingPot_v1 is
             bool isList_
         )
     {
-        Round storage round = rounds[roundId_];
         AccessCriteria storage accessCriteria =
-            round.accessCriterias[accessCriteriaId_];
+            rounds[roundId_].accessCriterias[accessCriteriaId_];
+        ILM_PC_FundingPot_v1.AccessCriteriaType acType =
+            accessCriteria.accessCriteriaType;
 
-        if (accessCriteria.accessCriteriaType == AccessCriteriaType.OPEN) {
-            return (
-                true,
-                accessCriteria.nftContract,
-                accessCriteria.merkleRoot,
-                true
-            );
-        } else if (accessCriteria.accessCriteriaType == AccessCriteriaType.LIST)
-        {
-            return (
-                false,
-                accessCriteria.nftContract,
-                accessCriteria.merkleRoot,
-                true
-            );
-        } else {
-            return (
-                false,
-                accessCriteria.nftContract,
-                accessCriteria.merkleRoot,
-                false
-            );
-        }
+        bool isRoundOpen =
+            (acType == ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN);
+        bool isList = (
+            acType == ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN
+                || acType == ILM_PC_FundingPot_v1.AccessCriteriaType.LIST
+        );
+
+        return (
+            isRoundOpen,
+            accessCriteria.nftContract,
+            accessCriteria.merkleRoot,
+            isList
+        );
     }
 
     /// @inheritdoc ILM_PC_FundingPot_v1
@@ -406,15 +398,16 @@ contract LM_PC_FundingPot_v1 is
         uint32 roundId = roundCount;
 
         Round storage round = rounds[roundId];
-        round.roundStart = roundStart_;
-        round.roundEnd = roundEnd_;
-        round.roundCap = roundCap_;
-        round.hookContract = hookContract_;
-        round.hookFunction = hookFunction_;
-        round.autoClosure = autoClosure_;
-        round.accumulationMode = accumulationMode_;
-
-        _validateRoundParameters(round);
+        _setAndValidateRoundParameters(
+            round,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            autoClosure_,
+            accumulationMode_
+        );
 
         emit RoundCreated(
             roundId,
@@ -445,15 +438,16 @@ contract LM_PC_FundingPot_v1 is
 
         _validateEditRoundParameters(round);
 
-        round.roundStart = roundStart_;
-        round.roundEnd = roundEnd_;
-        round.roundCap = roundCap_;
-        round.hookContract = hookContract_;
-        round.hookFunction = hookFunction_;
-        round.autoClosure = autoClosure_;
-        round.accumulationMode = accumulationMode_;
-
-        _validateRoundParameters(round);
+        _setAndValidateRoundParameters(
+            round,
+            roundStart_,
+            roundEnd_,
+            roundCap_,
+            hookContract_,
+            hookFunction_,
+            autoClosure_,
+            accumulationMode_
+        );
 
         emit RoundEdited(
             roundId_,
@@ -1033,15 +1027,6 @@ contract LM_PC_FundingPot_v1 is
             }
         }
 
-        // If round cap check clamped adjustedAmount to 0, and original amount was > 0, we already reverted.
-        // If original amount was 0, adjustedAmount is 0, so we can proceed to personal cap check which will also result in 0.
-        // If adjustedAmount > 0, proceed to personal cap check.
-        if (adjustedAmount == 0 && amount_ > 0) {
-            // This state should ideally not be reached due to the revert above if cap was full.
-            // But as a safeguard, if amount_ was > 0 and adjustedAmount is now 0, return 0.
-            return 0;
-        }
-
         // --- Personal Cap Check ---
         // Only proceed if adjustedAmount wasn't already set to 0 by round cap or initial amount.
         if (adjustedAmount > 0) {
@@ -1172,10 +1157,7 @@ contract LM_PC_FundingPot_v1 is
         }
 
         try IERC721(nftContract_).balanceOf(user_) returns (uint balance) {
-            if (balance == 0) {
-                return false;
-            }
-            return true;
+            return balance > 0;
         } catch {
             return false;
         }
@@ -1196,11 +1178,7 @@ contract LM_PC_FundingPot_v1 is
     ) internal pure returns (bool) {
         bytes32 leaf = keccak256(abi.encodePacked(user_, roundId_));
 
-        if (!MerkleProof.verify(merkleProof_, root_, leaf)) {
-            return false;
-        }
-
-        return true;
+        return MerkleProof.verify(merkleProof_, root_, leaf);
     }
 
     /// @notice Handles round closure logic.
@@ -1211,7 +1189,7 @@ contract LM_PC_FundingPot_v1 is
 
         roundIdToClosedStatus[roundId_] = true;
 
-        if (round.hookContract != address(0) && round.hookFunction.length > 0) {
+        if (round.hookContract != address(0)) {
             (bool success,) = round.hookContract.call(round.hookFunction);
             if (!success) {
                 revert Module__LM_PC_FundingPot__HookExecutionFailed();
@@ -1264,7 +1242,7 @@ contract LM_PC_FundingPot_v1 is
             if (contributorTotal == 0) continue;
 
             for (
-                uint8 accessCriteriaId = 0;
+                uint8 accessCriteriaId = 1;
                 accessCriteriaId <= MAX_ACCESS_CRITERIA_ID;
                 accessCriteriaId++
             ) {
@@ -1306,40 +1284,38 @@ contract LM_PC_FundingPot_v1 is
         returns (bytes32 flags, bytes32[] memory finalData)
     {
         if (start_ == 0) start_ = block.timestamp;
-        if (end_ == 0) end_ = block.timestamp;
+        if (end_ == 0) end_ = block.timestamp; // Note: cliff_ is not defaulted here.
 
         flags = 0;
-        bytes32[] memory data = new bytes32[](3); // For start, cliff, and end
         uint8 flagCount = 0;
+        bytes32[3] memory tempData; // Fixed-size array on stack for intermediate values
 
-        if (start_ > 0) {
-            flags |= bytes32(uint(1) << FLAG_START);
-            data[flagCount] = bytes32(start_);
-            unchecked {
-                flagCount++;
-            }
+        // Start time
+        flags |= bytes32(uint(1) << FLAG_START);
+        tempData[flagCount] = bytes32(start_);
+        unchecked {
+            flagCount++;
         }
 
         if (cliff_ > 0) {
             flags |= bytes32(uint(1) << FLAG_CLIFF);
-            data[flagCount] = bytes32(cliff_);
+            tempData[flagCount] = bytes32(cliff_);
             unchecked {
                 flagCount++;
             }
         }
 
-        if (end_ > 0) {
-            flags |= bytes32(uint(1) << FLAG_END);
-            data[flagCount] = bytes32(end_);
-            unchecked {
-                flagCount++;
-            }
+        // End time
+        flags |= bytes32(uint(1) << FLAG_END);
+        tempData[flagCount] = bytes32(end_);
+        unchecked {
+            flagCount++;
         }
 
         finalData = new bytes32[](flagCount);
         for (uint8 j = 0; j < flagCount; ++j) {
             unchecked {
-                finalData[j] = data[j];
+                finalData[j] = tempData[j];
             }
         }
 
@@ -1399,15 +1375,22 @@ contract LM_PC_FundingPot_v1 is
         if (totalContributions == 0) {
             revert Module__LM_PC_FundingPot__NoContributions();
         }
-        // approve the fundingManager to spend the contribution token
-        IERC20(__Module_orchestrator.fundingManager().token()).approve(
-            address(__Module_orchestrator.fundingManager()), totalContributions
-        );
-        uint minAmountOut = IBondingCurveBase_v1(
-            address(__Module_orchestrator.fundingManager())
-        ).calculatePurchaseReturn(totalContributions);
-        IBondingCurveBase_v1(address(__Module_orchestrator.fundingManager()))
-            .buyFor(address(this), totalContributions, minAmountOut);
+
+        // Cache the funding manager instance and its address
+        IFundingManager_v1 fundingManager =
+            __Module_orchestrator.fundingManager();
+
+        // Get the contribution token from the cached funding manager instance and approve it
+        IERC20 contributionToken = fundingManager.token();
+        contributionToken.approve(address(fundingManager), totalContributions);
+
+        // Cast the cached funding manager address to the bonding curve interface
+        IBondingCurveBase_v1 bondingCurve =
+            IBondingCurveBase_v1(address(fundingManager));
+
+        uint minAmountOut =
+            bondingCurve.calculatePurchaseReturn(totalContributions);
+        bondingCurve.buyFor(address(this), totalContributions, minAmountOut);
 
         roundTokensBought[roundId_] = minAmountOut;
     }
@@ -1426,5 +1409,35 @@ contract LM_PC_FundingPot_v1 is
             round.roundCap > 0 && totalContribution == round.roundCap;
         bool timeEnded = round.roundEnd > 0 && block.timestamp >= round.roundEnd;
         return capReached || timeEnded;
+    }
+
+    /// @notice Sets and validates the round parameters.
+    /// @param  roundToSet_ The round storage object to set parameters for.
+    /// @param  roundStart_ Start timestamp for the round.
+    /// @param  roundEnd_ End timestamp for the round.
+    /// @param  roundCap_ Maximum contribution cap.
+    /// @param  hookContract_ Address of contract to call after round closure.
+    /// @param  hookFunction_ Encoded function call for the hook.
+    /// @param  autoClosure_ Whether hook closure coincides with contribution span end.
+    /// @param  accumulationMode_ Defines how caps accumulate.
+    function _setAndValidateRoundParameters(
+        Round storage roundToSet_,
+        uint roundStart_,
+        uint roundEnd_,
+        uint roundCap_,
+        address hookContract_,
+        bytes memory hookFunction_,
+        bool autoClosure_,
+        AccumulationMode accumulationMode_
+    ) internal {
+        roundToSet_.roundStart = roundStart_;
+        roundToSet_.roundEnd = roundEnd_;
+        roundToSet_.roundCap = roundCap_;
+        roundToSet_.hookContract = hookContract_;
+        roundToSet_.hookFunction = hookFunction_;
+        roundToSet_.autoClosure = autoClosure_;
+        roundToSet_.accumulationMode = accumulationMode_;
+
+        _validateRoundParameters(roundToSet_);
     }
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -16,7 +16,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  hookContract Address of an optional hook contract to be called after round closure.
     /// @param  hookFunction Encoded function call to be executed on the `hookContract` after round closure.
     /// @param  autoClosure Indicates whether the hook closure coincides with the contribution span end.
-    /// @param  globalAccumulativeCaps Indicates whether contribution caps accumulate globally across rounds.
+    /// @param  accumulationMode Defines how caps accumulate across rounds (see AccumulationMode enum).
     /// @param  accessCriterias Mapping of access criteria IDs to their respective access criteria.
     struct Round {
         uint roundStart;
@@ -25,7 +25,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         address hookContract;
         bytes hookFunction;
         bool autoClosure;
-        bool globalAccumulativeCaps;
+        AccumulationMode accumulationMode;
         mapping(uint32 id => AccessCriteria) accessCriterias;
     }
 
@@ -94,6 +94,17 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     }
 
+    /// @notice Enum used to define how caps accumulate across rounds.
+    /// @dev    Determines whether unused personal caps or round caps from previous
+    ///         rounds can affect the limits of the current round.
+    enum AccumulationMode {
+        Disabled, // 0 - No accumulation. Personal and round caps are isolated to this round.
+        Personal, // 1 - Only personal caps roll over from previous compatible rounds. Round cap is isolated.
+        Total, // 2 - Only total round caps expand based on previous compatible rounds' undersubscription. Personal caps are isolated.
+        All // 3 - Both personal caps roll over and total round caps expand based on previous compatible rounds.
+
+    }
+
     // -------------------------------------------------------------------------
     // Events
 
@@ -106,7 +117,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  hookContract_ The address of an optional hook contract for custom logic.
     /// @param  hookFunction_ The encoded function call for the hook.
     /// @param  autoClosure_ A boolean indicating whether a specific closure mechanism is enabled.
-    /// @param  globalAccumulativeCaps_ A boolean indicating whether global accumulative caps are enforced.
+    /// @param  accumulationMode_ Defines how caps accumulate across rounds (see AccumulationMode enum).
     event RoundCreated(
         uint indexed roundId_,
         uint roundStart_,
@@ -115,7 +126,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         address hookContract_,
         bytes hookFunction_,
         bool autoClosure_,
-        bool globalAccumulativeCaps_
+        AccumulationMode accumulationMode_
     );
 
     /// @notice Emitted when an existing round is edited.
@@ -127,7 +138,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  hookContract_ The address of an optional hook contract for custom logic.
     /// @param  hookFunction_ The updated encoded function call for the hook.
     /// @param  autoClosure_ A boolean indicating whether a specific closure mechanism is enabled.
-    /// @param  globalAccumulativeCaps_ A boolean indicating whether global accumulative caps are enforced.
+    /// @param accumulationMode_ The accumulation mode for this round (see AccumulationMode enum).
     event RoundEdited(
         uint indexed roundId_,
         uint roundStart_,
@@ -136,7 +147,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         address hookContract_,
         bytes hookFunction_,
         bool autoClosure_,
-        bool globalAccumulativeCaps_
+        AccumulationMode accumulationMode_
     );
 
     /// @notice Emitted when access criteria is set for a round.
@@ -303,7 +314,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @return hookContract_ The address of the hook contract.
     /// @return hookFunction_ The encoded function call for the hook.
     /// @return autoClosure_ Whether hook closure coincides with contribution span end.
-    /// @return globalAccumulativeCaps_ Whether caps accumulate globally across rounds.
+    /// @return accumulationMode_ The accumulation mode for the round.
     function getRoundGenericParameters(uint32 roundId_)
         external
         view
@@ -314,7 +325,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
             address hookContract_,
             bytes memory hookFunction_,
             bool autoClosure_,
-            bool globalAccumulativeCaps_
+            AccumulationMode accumulationMode_
         );
 
     /// @notice Retrieves the access criteria for a specific funding round.
@@ -410,7 +421,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  hookContract_ Address of contract to call after round closure.
     /// @param  hookFunction_ Encoded function call for the hook.
     /// @param  autoClosure_ Whether hook closure coincides with contribution span end.
-    /// @param  globalAccumulativeCaps_ Whether caps accumulate globally.
+    /// @param  accumulationMode_ Defines how caps accumulate across rounds (see AccumulationMode enum).
     /// @return The ID of the newly created round.
     function createRound(
         uint roundStart_,
@@ -419,7 +430,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         address hookContract_,
         bytes memory hookFunction_,
         bool autoClosure_,
-        bool globalAccumulativeCaps_
+        AccumulationMode accumulationMode_
     ) external returns (uint32);
 
     /// @notice Edits an existing funding round.
@@ -431,7 +442,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
     /// @param  hookContract_ New hook contract address.
     /// @param  hookFunction_ New encoded function call.
     /// @param  autoClosure_ New closure mechanism setting.
-    /// @param  globalAccumulativeCaps_ New global accumulative caps setting.
+    /// @param  accumulationMode_ New accumulation mode setting.
     function editRound(
         uint32 roundId_,
         uint roundStart_,
@@ -440,7 +451,7 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         address hookContract_,
         bytes memory hookFunction_,
         bool autoClosure_,
-        bool globalAccumulativeCaps_
+        AccumulationMode accumulationMode_
     ) external;
 
     /// @notice Set Access Control Check.

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -317,6 +317,9 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint32 startRoundId_, uint32 currentRoundCount_
     );
 
+    /// @notice Thrown when round IDs in UnspentPersonalRoundCap array are not strictly increasing.
+    error Module__LM_PC_FundingPot__UnspentCapsRoundIdsNotStrictlyIncreasing();
+
     // -------------------------------------------------------------------------
     // Public - Getters
 

--- a/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_FundingPot_v1.sol
@@ -225,6 +225,10 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint32 indexed roundId_, uint startIndex_, uint endIndex_
     );
 
+    /// @notice Emitted when the global accumulation start round ID is updated.
+    /// @param startRoundId The new round ID from which accumulation calculations will begin (inclusive, must be >= 1).
+    event GlobalAccumulationStartSet(uint32 startRoundId);
+
     // -------------------------------------------------------------------------
     // Errors
 
@@ -302,6 +306,16 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Invalid batch parameters.
     error Module__LM_PC_FundingPot__InvalidBatchParameters();
+
+    /// @notice Start round ID must be greater than zero.
+    error Module__LM_PC_FundingPot__StartRoundCannotBeZero();
+
+    /// @notice Start round ID cannot be greater than the current round count.
+    /// @param startRoundId_ The provided start round ID.
+    /// @param currentRoundCount_ The current total number of rounds.
+    error Module__LM_PC_FundingPot__StartRoundGreaterThanRoundCount(
+        uint32 startRoundId_, uint32 currentRoundCount_
+    );
 
     // -------------------------------------------------------------------------
     // Public - Getters
@@ -409,6 +423,16 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         external
         view
         returns (uint);
+
+    /// @notice Retrieves the globally configured start round ID for accumulation calculations.
+    /// @dev    Accumulation (both personal and total) will only consider previous rounds
+    ///         with IDs greater than or equal to this value, provided the target round's
+    ///         AccumulationMode allows it. Defaults to 1.
+    /// @return The first round ID (inclusive) to consider for accumulation.
+    function getGlobalAccumulationStartRoundId()
+        external
+        view
+        returns (uint32);
 
     // -------------------------------------------------------------------------
     // Public - Mutating
@@ -543,4 +567,10 @@ interface ILM_PC_FundingPot_v1 is IERC20PaymentClientBase_v2 {
         uint32 roundId_,
         uint batchSize_
     ) external;
+
+    /// @notice Sets the global minimum round ID from which accumulation calculations should begin.
+    /// @dev    Only callable by `FUNDING_POT_ADMIN_ROLE`. This setting affects all future
+    ///         accumulation calculations across the module. The start round must be >= 1 and cannot exceed the current round count.
+    /// @param  startRoundId_ The first round ID (inclusive, >= 1) to consider for accumulation.
+    function setGlobalAccumulationStart(uint32 startRoundId_) external;
 }

--- a/test/e2e/logicModules/FundingPotE2E.t.sol
+++ b/test/e2e/logicModules/FundingPotE2E.t.sol
@@ -178,7 +178,7 @@ contract FundingPotE2E is E2ETest {
             address(0), // no hook
             bytes(""), // no hook function
             false, // auto closure
-            false // no global caps
+            ILM_PC_FundingPot_v1.AccumulationMode.Disabled // no global caps
         );
 
         // Round 2
@@ -189,7 +189,7 @@ contract FundingPotE2E is E2ETest {
             address(0), // no hook
             bytes(""), // no hook function
             true, // auto closure
-            false // no global caps
+            ILM_PC_FundingPot_v1.AccumulationMode.Disabled // no global caps
         );
 
         // 4. Set access criteria for the rounds

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -2012,7 +2012,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testContributeToRoundFor_worksGivenPersonalCapAccumulation()
         public
     {
-        _defaultRoundParams.accumulationMode = ILM_PC_FundingPot_v1.AccumulationMode.Personal;
+        _defaultRoundParams.accumulationMode =
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal;
         fundingPot.createRound(
             _defaultRoundParams.roundStart,
             _defaultRoundParams.roundEnd,
@@ -2118,7 +2119,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testContributeToRoundFor_worksGivenTotalRoundCapAccumulation()
         public
     {
-        _defaultRoundParams.accumulationMode = ILM_PC_FundingPot_v1.AccumulationMode.All;
+        _defaultRoundParams.accumulationMode =
+            ILM_PC_FundingPot_v1.AccumulationMode.All;
 
         // Create Round 1
         fundingPot.createRound(
@@ -3282,9 +3284,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-        function testContribute_PersonalMode_AccumulatesPersonalOnly() public {
+    function testContribute_PersonalMode_AccumulatesPersonalOnly() public {
         // 1. Create the first round with AccumulationMode.Personal
-        _defaultRoundParams.accumulationMode = ILM_PC_FundingPot_v1.AccumulationMode.Personal;
+        _defaultRoundParams.accumulationMode =
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal;
 
         fundingPot.createRound(
             _defaultRoundParams.roundStart,
@@ -3303,7 +3306,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address nftContract,
             bytes32 merkleRoot,
             address[] memory allowedAddresses
-        ) = _helper_createAccessCriteria(uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id);
+        ) = _helper_createAccessCriteria(
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id
+        );
 
         fundingPot.setAccessCriteria(
             round1Id,
@@ -3369,10 +3374,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Verify contribution to round 1
         assertEq(
-            fundingPot.getUserContributionToRound(
-                round1Id, contributor1_
-            ),
-            200
+            fundingPot.getUserContributionToRound(round1Id, contributor1_), 200
         );
 
         // Move to round 2
@@ -3404,11 +3406,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Verify contributions to round 2 - should be more than the personal cap of round 2 (400)
         // This verifies personal caps DO accumulate
-        uint contributionAmount = fundingPot.getUserContributionToRound(
-            round2Id, contributor1_
-        );
+        uint contributionAmount =
+            fundingPot.getUserContributionToRound(round2Id, contributor1_);
         assertEq(contributionAmount, 450);
-        assertTrue(contributionAmount > 400, "Personal cap should accumulate"); 
+        assertTrue(contributionAmount > 400, "Personal cap should accumulate");
 
         // ------------ PART 2: VERIFY TOTAL CAP NON-ACCUMULATION ------------
         // Attempt to contribute more than the remaining round cap
@@ -3422,7 +3423,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             contributor2_, round2Id, 100, accessCriteriaId, new bytes32[](0)
         );
         // Verify contributor 2's contribution was clamped to the remaining 50.
-        assertEq(fundingPot.getUserContributionToRound(round2Id, contributor2_), 50);
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor2_), 50
+        );
         vm.stopPrank();
 
         // Verify total contributions to round 2 is exactly the round cap (450 + 50 = 500).
@@ -3436,7 +3439,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         // Expect revert because the round cap (500) is already met.
         vm.expectRevert(
             abi.encodeWithSelector(
-                ILM_PC_FundingPot_v1.Module__LM_PC_FundingPot__RoundCapReached.selector
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundCapReached
+                    .selector
             )
         );
         fundingPot.contributeToRoundFor(
@@ -3450,7 +3455,8 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testContribute_TotalMode_AccumulatesTotalOnly() public {
         // 1. Create the first round with AccumulationMode.Total
-        _defaultRoundParams.accumulationMode = ILM_PC_FundingPot_v1.AccumulationMode.Total;
+        _defaultRoundParams.accumulationMode =
+            ILM_PC_FundingPot_v1.AccumulationMode.Total;
 
         fundingPot.createRound(
             _defaultRoundParams.roundStart,
@@ -3464,9 +3470,14 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         uint32 round1Id = fundingPot.getRoundCount();
 
         // Set up access criteria for round 1 (Open)
-        uint8 accessCriteriaId = 1; 
-        (address nftContract, bytes32 merkleRoot, address[] memory allowedAddresses) =
-            _helper_createAccessCriteria(uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id);
+        uint8 accessCriteriaId = 1;
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id
+        );
 
         fundingPot.setAccessCriteria(
             round1Id,
@@ -3530,7 +3541,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Verify contribution to round 1
-        assertEq(fundingPot.getUserContributionToRound(round1Id, contributor1_), 600);
+        assertEq(
+            fundingPot.getUserContributionToRound(round1Id, contributor1_), 600
+        );
         assertEq(fundingPot.getTotalRoundContribution(round1Id), 600);
 
         // Move to round 2
@@ -3541,17 +3554,25 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         vm.startPrank(contributor2_);
         _token.approve(address(fundingPot), 1000); // Approve enough
 
-        // Contributor 2 attempts to contribute 700. 
+        // Contributor 2 attempts to contribute 700.
         // Personal Cap (R2) is 300. Gets clamped to 300.
         fundingPot.contributeToRoundFor(
             contributor2_, round2Id, 700, accessCriteriaId, new bytes32[](0)
         );
         // Verify contributor 2's contribution was clamped by personal cap.
-        assertEq(fundingPot.getUserContributionToRound(round2Id, contributor2_), 300, "C2 contribution should be clamped by personal cap");
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor2_),
+            300,
+            "C2 contribution should be clamped by personal cap"
+        );
         vm.stopPrank();
 
         // Verify total contributions after C2 is 300
-        assertEq(fundingPot.getTotalRoundContribution(round2Id), 300, "Total after C2 should be 300");
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            300,
+            "Total after C2 should be 300"
+        );
 
         // ------------ PART 2: VERIFY PERSONAL CAP NON-ACCUMULATION ------------
         // Contributor 1 had 800 personal cap in R1, contributed 600, unused = 200.
@@ -3568,7 +3589,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         });
 
         vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 500); 
+        _token.approve(address(fundingPot), 500);
 
         // Attempt to contribute 400 ( > R2 personal cap 300)
         // Total contributions = 300. Effective Round Cap = 900. Remaining Round Cap = 600.
@@ -3578,17 +3599,25 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.contributeToRoundFor(
             contributor1_,
             round2Id,
-            400, 
+            400,
             accessCriteriaId,
             new bytes32[](0),
             unspentCaps // Provide unspent caps, although they should be ignored for personal limit
         );
         // Verify contributor 1's contribution was clamped to their R2 personal cap.
-        assertEq(fundingPot.getUserContributionToRound(round2Id, contributor1_), 300, "C1 contribution should be clamped by personal cap");
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            300,
+            "C1 contribution should be clamped by personal cap"
+        );
         vm.stopPrank();
 
         // Verify total round contributions: 300 (C2) + 300 (C1) = 600
-        assertEq(fundingPot.getTotalRoundContribution(round2Id), 600, "Total after C1 and C2 should be 600"); 
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            600,
+            "Total after C1 and C2 should be 600"
+        );
         // Effective cap 900, current total 600. Remaining = 300.
 
         // Contributor 3 contributes 300. Personal Cap = 300. Remaining Round Cap = 300. Should succeed.
@@ -3598,11 +3627,19 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             contributor3_, round2Id, 300, accessCriteriaId, new bytes32[](0)
         );
         // Verify C3 contributed 300
-        assertEq(fundingPot.getUserContributionToRound(round2Id, contributor3_), 300, "C3 contributes remaining 300");
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor3_),
+            300,
+            "C3 contributes remaining 300"
+        );
         vm.stopPrank();
 
         // Total contributions should now be 900 (300 + 300 + 300), matching the effective cap.
-        assertEq(fundingPot.getTotalRoundContribution(round2Id), 900, "Total should match effective cap after C3");
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            900,
+            "Total should match effective cap after C3"
+        );
 
         // Now the effective cap is full. Try contributing 1 again.
         vm.startPrank(contributor3_); // Can use C3 or another contributor
@@ -3610,17 +3647,1661 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         // Try contributing 1, expect revert as cap is full
         vm.expectRevert(
-             abi.encodeWithSelector(
-                 ILM_PC_FundingPot_v1.Module__LM_PC_FundingPot__RoundCapReached.selector
-             )
-         );
-         fundingPot.contributeToRoundFor(
-             contributor3_, round2Id, 1, accessCriteriaId, new bytes32[](0)
-         );
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundCapReached
+                    .selector
+            )
+        );
+        fundingPot.contributeToRoundFor(
+            contributor3_, round2Id, 1, accessCriteriaId, new bytes32[](0)
+        );
         vm.stopPrank();
 
         // Final total check should remain 900
-         assertEq(fundingPot.getTotalRoundContribution(round2Id), 900, "Final total should be effective cap"); 
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            900,
+            "Final total should be effective cap"
+        );
+    }
 
+    // -------------------------------------------------------------------------
+    // Test: Global Accumulation Start Round Settings
+    // -------------------------------------------------------------------------
+
+    /* Test getGlobalAccumulationStartRoundId() and setGlobalAccumulationStart()
+    ├── For getGlobalAccumulationStartRoundId()
+    │   └── When no explicit value has been set
+    │       └── Then it should return the default value of 1
+    │
+    └── For setGlobalAccumulationStart()
+        ├── Given user does not have FUNDING_POT_ADMIN_ROLE
+        │   └── When user attempts to set the global accumulation start round
+        │       └── Then it should revert
+        │
+        ├── Given user has FUNDING_POT_ADMIN_ROLE
+        │   ├── And the provided start round ID is 0
+        │   │   └── When user attempts to set the global accumulation start round
+        │   │       └── Then it should revert
+        │   │
+        │   ├── And the provided start round ID is greater than the current round count
+        │   │   └── When user attempts to set the global accumulation start round
+        │   │       └── Then it should revert
+        │   │
+        │   └── And a valid start round ID is provided
+        │       └── When user attempts to set the global accumulation start round
+        │           ├── Then it should update the globalAccumulationStartRoundId state variable
+        │           ├── Then it should emit a GlobalAccumulationStartSet event
+        │           └── Then getGlobalAccumulationStartRoundId() should return the new value
+    */
+
+    function testGetGlobalAccumulationStartRoundId_returnsDefaultWhenNotSet()
+        public
+    {
+        // Expecting default value to be 1 as per AC
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default start round ID should be 1"
+        );
+    }
+
+    function testSetGlobalAccumulationStart_revertsGivenUserIsNotFundingPotAdmin(
+        address unauthorizedUser,
+        uint32 startRoundId
+    ) public {
+        vm.assume(unauthorizedUser != address(this));
+        vm.assume(startRoundId >= 1);
+
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
+        );
+
+        vm.startPrank(unauthorizedUser);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IModule_v1.Module__CallerNotAuthorized.selector,
+                roleId,
+                unauthorizedUser
+            )
+        );
+        fundingPot.setGlobalAccumulationStart(startRoundId);
+        vm.stopPrank();
+    }
+
+    function testSetGlobalAccumulationStart_revertsGivenStartRoundIsZero()
+        public
+    {
+        // AC: Must revert if startRoundId_ == 0
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__StartRoundCannotBeZero
+                    .selector
+            )
+        );
+        fundingPot.setGlobalAccumulationStart(0);
+    }
+
+    function testSetGlobalAccumulationStart_revertsGivenStartRoundGreaterThanCurrentRoundCount(
+        uint32 startRoundIdOffset
+    ) public {
+        testCreateRound(); // Ensure roundCount is at least 1
+        uint32 currentRoundCount = fundingPot.getRoundCount();
+
+        vm.assume(startRoundIdOffset > 0); // Ensure invalidStartRoundId will be greater
+        vm.assume(startRoundIdOffset <= type(uint32).max - currentRoundCount);
+
+        uint32 invalidStartRoundId = currentRoundCount + startRoundIdOffset;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__StartRoundGreaterThanRoundCount
+                    .selector,
+                invalidStartRoundId,
+                currentRoundCount
+            )
+        );
+        fundingPot.setGlobalAccumulationStart(invalidStartRoundId);
+    }
+
+    function testSetGlobalAccumulationStart_worksGivenValidParameters(
+        uint32 startRoundId
+    ) public {
+        // Ensure we have at least startRoundId rounds created if startRoundId > 0
+        if (startRoundId > 0) {
+            vm.assume(startRoundId <= 10); // Bound the fuzzing
+            for (
+                uint32 i = fundingPot.getRoundCount() + 1;
+                i <= startRoundId;
+                i++
+            ) {
+                fundingPot.createRound(
+                    _defaultRoundParams.roundStart + (i * 3 days),
+                    _defaultRoundParams.roundEnd + (i * 3 days),
+                    _defaultRoundParams.roundCap,
+                    _defaultRoundParams.hookContract,
+                    _defaultRoundParams.hookFunction,
+                    _defaultRoundParams.autoClosure,
+                    _defaultRoundParams.accumulationMode
+                );
+            }
+            vm.assume(startRoundId <= fundingPot.getRoundCount()); // Final check
+        } else {
+            vm.assume(startRoundId == 0);
+            // For startRoundId = 0, test should actually fail based on the revert check above
+            // However, fuzzing might pass 0. Let's test non-zero valid cases.
+            vm.assume(false); // This will cause fuzz to skip startRoundId = 0 here
+        }
+
+        // Expect event emission
+        vm.expectEmit(true, true, true, true);
+        emit ILM_PC_FundingPot_v1.GlobalAccumulationStartSet(startRoundId);
+
+        // Set the value
+        fundingPot.setGlobalAccumulationStart(startRoundId);
+
+        // Verify the value using the getter
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            startRoundId,
+            "Getter should return the set value"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test: Global Accumulation Start Round - Logic Integration
+    // -------------------------------------------------------------------------
+
+    /* Test Accumulation Logic with Global Start Round
+    │
+    ├── Scenario: Global start round restricts accumulation
+    │   ├── Given globalAccumulationStartRoundId is set to 2 (e.g., R2)
+    │   │   ├── And target round (e.g., R3) uses AccumulationMode.Personal
+    │   │   │   └── When contributing to R3 with unspent capacity from R1 and R2
+    │   │   │       └── Then only unspent personal capacity from R2 should be considered
+    │   │   ├── And target round (e.g., R3) uses AccumulationMode.Total
+    │   │   │   └── When contributing to R3
+    │   │   │       └── Then only unspent total capacity from R2 should expand R3's effective cap
+    │   │   └── And target round (e.g., R3) uses AccumulationMode.All
+    │   │       ├── When contributing to R3 with unspent personal capacity from R1 and R2
+    │   │       │   └── Then only unspent personal capacity from R2 should be considered
+    │   │       └── When calculating R3's effective total cap
+    │   │           └── Then only unspent total capacity from R2 should expand R3's effective cap
+    │
+    ├── Scenario: Default global start round (1) allows accumulation from all previous applicable rounds
+    │   ├── Given globalAccumulationStartRoundId is 1 (default)
+    │   │   ├── And target round (e.g., R2 or R3) uses AccumulationMode.Personal
+    │   │   │   └── When contributing with unspent capacity from all previous valid rounds (e.g., R1 for R2; R1 & R2 for R3)
+    │   │   │       └── Then unspent personal capacity from all applicable previous rounds should be considered
+    │   │   ├── And target round (e.g., R2 or R3) uses AccumulationMode.Total
+    │   │   │   └── When calculating effective total cap
+    │   │   │       └── Then unspent total capacity from all applicable previous rounds should expand the effective cap
+    │   │   └── And target round (e.g., R2 or R3) uses AccumulationMode.All
+    │   │       ├── When contributing with unspent personal capacity from all previous valid rounds
+    │   │       │   └── Then unspent personal capacity from all applicable previous rounds should be considered
+    │   │       └── When calculating effective total cap
+    │   │           └── Then unspent total capacity from all applicable previous rounds should expand the effective cap
+    │
+    ├── Scenario: Interaction with AccumulationMode.Disabled
+    │   └── Given target round's AccumulationMode is Disabled
+    │       └── When globalAccumulationStartRoundId is set to allow previous rounds
+    │           └── Then no accumulation (personal or total) should occur for the target round
+    │
+    └── Scenario: Global start round equals target round
+        └── Given globalAccumulationStartRoundId is set to the target round's ID
+            └── When target round's AccumulationMode would normally allow accumulation
+                └── Then no accumulation (personal or total) from any *previous* round should occur
+    */
+
+    function testContribute_personalMode_globalStartRestrictsAccumulationFromEarlierRounds(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 2 restricts accumulation from Round 1 for Personal mode
+        // 1. Setup: Round 1, Round 2, Round 3. Partial contributions in R1 & R2.
+        // 2. Action: setGlobalAccumulationStart(2)
+        // 3. Verification: For contributions to R3 (Personal mode), only unused personal from R2 rolls over.
+
+        uint initialTimestamp = block.timestamp;
+
+        // --- Setup Rounds ---
+        uint r1PersonalCap = 500;
+        uint r1Contribution = 100;
+        // uint r1UnusedPersonal = r1PersonalCap - r1Contribution; // Not used in this restricted scenario directly for R3 calc
+
+        uint r2PersonalCap = 600;
+        uint r2Contribution = 200;
+        uint r2UnusedPersonal = r2PersonalCap - r2Contribution; // This IS used for R3 calculation
+
+        uint r3BasePersonalCap = 300;
+
+        // Round 1
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            10_000, // large round cap
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
+        ); // Open access
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, 1, r1PersonalCap, false, 0, 0, 0
+        );
+
+        // Round 2
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            10_000, // large round cap
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, 1, r2PersonalCap, false, 0, 0, 0
+        );
+
+        // Round 3
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            10_000, // large round cap
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round3Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, 1, r3BasePersonalCap, false, 0, 0, 0
+        );
+
+        // --- Contributions ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+
+        vm.warp(initialTimestamp + 1 days + 1 hours); // Enter Round 1
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, r1Contribution, 1, new bytes32[](0)
+        );
+
+        vm.warp(initialTimestamp + 3 days + 1 hours); // Enter Round 2
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, r2Contribution, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Set Global Start ---
+        fundingPot.setGlobalAccumulationStart(2);
+        assertEq(fundingPot.getGlobalAccumulationStartRoundId(), 2);
+
+        // --- Attempt Contribution in Round 3 ---
+        vm.warp(initialTimestamp + 5 days + 1 hours); // Enter Round 3
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
+        // User claims unspent from R1 (should be ignored due to global start)
+        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, 1, new bytes32[](0)
+        );
+        // User claims unspent from R2 (should be counted)
+        unspentCaps[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round2Id, 1, new bytes32[](0)
+        );
+
+        uint expectedR3PersonalCap = r3BasePersonalCap + r2Contribution; // Only R2's unused personal cap
+
+        vm.startPrank(contributor1_);
+        // Attempt to contribute up to the expected new personal cap
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round3Id,
+            expectedR3PersonalCap,
+            1,
+            new bytes32[](0),
+            unspentCaps
+        );
+        vm.stopPrank();
+
+        // --- Assertion ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor1_),
+            expectedR3PersonalCap,
+            "R3 personal contribution incorrect"
+        );
+    }
+
+    function testContribute_totalMode_globalStartRestrictsAccumulationFromEarlierRounds(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 2 restricts accumulation from Round 1 for Total mode
+        // 1. Setup: Round 1, Round 2, Round 3. Partial contributions in R1 & R2.
+        // 2. Action: setGlobalAccumulationStart(2)
+        // 3. Verification: For contributions to R3 (Total mode), only unused total from R2 expands R3 cap.
+
+        uint initialTimestamp = block.timestamp;
+
+        // --- Setup Rounds ---
+        uint r1BaseCap = 1000;
+        uint r1Contribution = 400;
+        // uint r1UnusedTotal = r1BaseCap - r1Contribution;
+
+        uint r2BaseCap = 1200;
+        uint r2Contribution = 500;
+        // uint r2UnusedTotal = r2BaseCap - r2Contribution;
+
+        uint r3BaseCap = 300;
+
+        // Round 1
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
+        ); // Open access
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, 1, r1BaseCap, false, 0, 0, 0
+        ); // Personal cap equals round cap
+
+        // Round 2
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, 1, r2BaseCap, false, 0, 0, 0
+        );
+
+        // Round 3
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            r3BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round3Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, 1, r3BaseCap + r2Contribution, false, 0, 0, 0
+        ); // Allow full contribution for testing effective cap
+
+        // --- Contributions ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+
+        vm.warp(initialTimestamp + 1 days + 1 hours); // Enter Round 1
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, r1Contribution, 1, new bytes32[](0)
+        );
+
+        vm.warp(initialTimestamp + 3 days + 1 hours); // Enter Round 2
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, r2Contribution, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Set Global Start ---
+        fundingPot.setGlobalAccumulationStart(2);
+        assertEq(fundingPot.getGlobalAccumulationStartRoundId(), 2);
+
+        // --- Attempt Contribution in Round 3 ---
+        vm.warp(initialTimestamp + 5 days + 1 hours); // Enter Round 3
+
+        uint expectedR3EffectiveCap = r3BaseCap + r2Contribution; // Only R2's unused total cap
+
+        vm.startPrank(contributor1_);
+        // Attempt to contribute up to the expected new effective cap
+        fundingPot.contributeToRoundFor(
+            contributor1_, round3Id, expectedR3EffectiveCap, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertion ---
+        assertEq(
+            fundingPot.getTotalRoundContribution(round3Id),
+            expectedR3EffectiveCap,
+            "R3 total contribution incorrect, effective cap not as expected"
+        );
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor1_),
+            expectedR3EffectiveCap,
+            "R3 user contribution incorrect"
+        );
+    }
+
+    function testContribute_personalMode_defaultGlobalStartAllowsAccumulationFromAllPrevious(
+    ) public {
+        // SCENARIO: Default globalAccumulationStartRoundId = 1 allows accumulation from R1 for R2 (Personal mode)
+        // 1. Setup: Round 1 (Personal), Round 2 (Personal).
+        //    Partial contribution by C1 in R1.
+        // 2. Action: Verify getGlobalAccumulationStartRoundId() == 1 (default).
+        // 3. Verification: For C1's contribution to R2, unused personal capacity from R1 rolls over.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round Parameters & Contributions for C1 ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100; // C1 leaves 400 personal unused from R1
+
+        uint r2BasePersonalCapC1 = 300; // C1's base personal cap in R2
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Personal Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            10_000, // Large round cap, not relevant for personal accumulation focus
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Create Round 2 (Personal Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            10_000, // Large round cap
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.startPrank(contributor1_);
+        vm.warp(initialTimestamp + 1 days + 1 hours); // Enter Round 1
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Verify Default Global Start Round ID ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours); // Enter Round 2
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id,
+            accessId,
+            new bytes32[](0) // Should be counted
+        );
+
+        uint r1UnusedPersonalC1 = r1PersonalCapC1 - r1ContributionC1; // 400
+
+        // Expected C1 effective personal cap in R2 = R2_Base (300) + R1_Unused (400) = 700
+        uint expectedC1EffectivePersonalCapR2 =
+            r2BasePersonalCapC1 + r1UnusedPersonalC1;
+
+        uint c1AttemptR2 = expectedC1EffectivePersonalCapR2 + 50; // Try to contribute slightly more
+        uint expectedC1ContributionR2 = expectedC1EffectivePersonalCapR2; // Should be clamped
+
+        // Ensure the attempt is not clamped by the round cap (which is large)
+        if (expectedC1ContributionR2 > 10_000) {
+            // 10_000 is round cap for R2
+            expectedC1ContributionR2 = 10_000;
+        }
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertion ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            expectedC1ContributionR2,
+            "R2 C1 personal contribution incorrect (should use R1 unused)"
+        );
+    }
+
+    function testContribute_totalMode_defaultGlobalStartAllowsAccumulationFromAllPrevious(
+    ) public {
+        // SCENARIO: Default globalAccumulationStartRoundId = 1 allows total cap accumulation from R1 to R2 (Total mode)
+        // Simplified to reduce stack depth.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters & Contribution ---
+        uint r1BaseCap = 1000;
+        uint r1ContributionC1 = 600; // Leaves 400 unused total from R1
+        uint r1PersonalCap = 1000;
+
+        // --- Round 2 Parameters ---
+        uint r2BaseCap = 500;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Total Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+        uint r1UnusedTotal = r1BaseCap - r1ContributionC1; // Should be 400
+
+        // --- Create Round 2 (Total Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        // Set personal cap for R2 to be at least the expected effective total cap
+        uint r2ExpectedEffectiveTotalCap = r2BaseCap + r1UnusedTotal; // 500 + 400 = 900
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2ExpectedEffectiveTotalCap, false, 0, 0, 0
+        );
+
+        // --- Verify Default Global Start Round ID ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2ExpectedEffectiveTotalCap - 100; // e.g., 900 - 100 = 800. Utilizes expanded cap.
+        assertTrue(
+            c1AttemptR2 > r2BaseCap, "C1 R2 attempt should be > R2 base cap"
+        );
+        assertTrue(
+            c1AttemptR2 <= r2ExpectedEffectiveTotalCap,
+            "C1 R2 attempt should be <= R2 effective cap"
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, c1AttemptR2, accessId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            c1AttemptR2,
+            "R2 C1 contribution incorrect"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            c1AttemptR2,
+            "R2 Total contributions after C1 incorrect"
+        );
+
+        // Verify that the total contributions possible is indeed the effective cap
+        uint remainingToFill = r2ExpectedEffectiveTotalCap - c1AttemptR2;
+        if (remainingToFill > 0) {
+            vm.startPrank(contributor1_);
+            fundingPot.contributeToRoundFor(
+                contributor1_,
+                round2Id,
+                remainingToFill,
+                accessId,
+                new bytes32[](0)
+            );
+            vm.stopPrank();
+        }
+
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2ExpectedEffectiveTotalCap,
+            "R2 final total contributions should match effective total cap"
+        );
+    }
+
+    function testContribute_disabledMode_ignoresGlobalStartAndPreventsAccumulation(
+    ) public {
+        // SCENARIO: AccumulationMode.Disabled on a target round (R2) prevents any accumulation
+        // from a previous round (R1), even if globalAccumulationStartRoundId would allow it.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100;
+        uint r1BaseCap = 1000;
+
+        // --- Round 2 Parameters (Disabled Mode) ---
+        uint r2BasePersonalCapC1 = 50;
+        uint r2BaseCap = 200;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Personal Mode to generate unused personal capacity) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Create Round 2 (Disabled Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Disabled
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Set Global Start Round ID to allow R1 (to show it's ignored by R2's Disabled mode) ---
+        fundingPot.setGlobalAccumulationStart(1);
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2BasePersonalCapC1 + 100;
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2BasePersonalCapC1,
+            "R2 C1 personal contribution should be clamped by R2's base personal cap (Disabled mode)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2BasePersonalCapC1,
+            "R2 Total contributions should not be expanded by R1 (Disabled mode)"
+        );
+        assertTrue(
+            fundingPot.getTotalRoundContribution(round2Id) <= r2BaseCap,
+            "R2 Total contributions exceeded R2's original base cap (Disabled mode)"
+        );
+    }
+
+    function testContribute_anyAccumulativeMode_noAccumulationWhenGlobalStartEqualsTargetRound(
+    ) public {
+        // SCENARIO: If globalAccumulationStartRoundId is set to the target round's ID (R2),
+        // no accumulation from any previous round (R1) occurs for R2, even if R2's mode would allow it.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100;
+        uint r1BaseCap = 1000;
+
+        // --- Round 2 Parameters (Mode that would normally allow accumulation, e.g., Personal) ---
+        uint r2BasePersonalCapC1 = 50;
+        uint r2BaseCap = 200;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Personal Mode to generate unused personal capacity) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Create Round 2 (Personal Mode - would normally allow accumulation from R1) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Set Global Start Round ID to be Round 2's ID ---
+        fundingPot.setGlobalAccumulationStart(round2Id);
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            round2Id,
+            "Global start round ID not set to R2 ID"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2BasePersonalCapC1 + 100;
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2BasePersonalCapC1,
+            "R2 C1 personal contribution should be clamped by R2's base personal cap (global start = R2)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2BasePersonalCapC1,
+            "R2 Total contributions should not be expanded by R1 (global start = R2)"
+        );
+        assertTrue(
+            fundingPot.getTotalRoundContribution(round2Id) <= r2BaseCap,
+            "R2 Total contributions exceeded R2's original base cap (global start = R2)"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test: Global Accumulation Start Round - Logic Integration - Remaining Tests
+    // (Covers multi-round accumulation where global start allows all previous)
+    // -------------------------------------------------------------------------
+
+    function testContribute_personalMode_defaultGlobalStartAllowsAccumulationFromMultiplePreviousRounds(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 1 allows personal cap accumulation from R1 AND R2
+        // for contributions to R3, when all rounds are in Personal mode.
+        // 1. Setup: R1, R2, R3 in Personal mode. C1 makes partial contributions in R1 & R2.
+        // 2. Action: Verify globalAccumulationStartRoundId = 1. C1 contributes to R3.
+        // 3. Verification: C1's effective personal cap in R3 includes unused from R1 and R2.
+
+        uint initialTimestamp = block.timestamp;
+
+        // --- Round Parameters, Personal Caps, and Contributions for contributor1_ ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 200;
+
+        uint r2PersonalCapC1 = 600;
+        uint r2ContributionC1 = 250;
+
+        uint r3BasePersonalCapC1 = 300;
+
+        uint largeRoundCap = 1_000_000;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Personal Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            largeRoundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, 1, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, r1ContributionC1, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getUserContributionToRound(round1Id, contributor1_),
+            r1ContributionC1
+        );
+
+        // --- Create Round 2 (Personal Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            largeRoundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, 1, r2PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 2 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, r2ContributionC1, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2ContributionC1
+        );
+
+        // --- Create Round 3 (Personal Mode) ---
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            largeRoundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round3Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, 1, r3BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Verify Global Start Round ID ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 3 by C1 ---
+        vm.warp(initialTimestamp + 5 days + 1 hours);
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, 1, new bytes32[](0)
+        );
+        unspentCapsC1[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round2Id, 1, new bytes32[](0)
+        );
+
+        uint expectedR3PersonalCapC1 = r3BasePersonalCapC1
+            + (r1PersonalCapC1 - r1ContributionC1)
+            + (r2PersonalCapC1 - r2ContributionC1);
+
+        uint c1AttemptR3 = expectedR3PersonalCapC1;
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round3Id,
+            c1AttemptR3,
+            1,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor1_),
+            expectedR3PersonalCapC1,
+            "R3 C1 personal contribution incorrect (should use R1 & R2 unused)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round3Id),
+            expectedR3PersonalCapC1,
+            "R3 total contributions incorrect after C1"
+        );
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__PersonalCapReached
+                    .selector
+            )
+        );
+        fundingPot.contributeToRoundFor(
+            contributor1_, round3Id, 1, 1, new bytes32[](0), unspentCapsC1
+        );
+        vm.stopPrank();
+    }
+
+    function testContribute_totalMode_defaultGlobalStartAllowsAccumulationFromMultiplePreviousRounds(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 1 allows accumulation from Round 1 AND Round 2 for Total mode
+        // 1. Setup: Round 1, Round 2, Round 3. Partial total contributions in R1 & R2. All in Total mode.
+        // 2. Action: setGlobalAccumulationStart(1) (or verify default).
+        // 3. Verification: For contributions to R3 (Total mode), unused total from R1 AND R2 rolls over, expanding R3's effective cap.
+
+        uint initialTimestamp = block.timestamp;
+
+        // --- Round Parameters & Contributions ---
+        uint r1BaseCap = 1000;
+        uint r1ContributionC1 = 400;
+
+        uint r2BaseCap = 1200;
+        uint r2ContributionC2 = 700;
+
+        uint r3BaseCap = 300;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        vm.startPrank(contributor2_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        vm.startPrank(contributor3_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Total Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, 1, r1BaseCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, r1ContributionC1, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getTotalRoundContribution(round1Id), r1ContributionC1
+        );
+
+        // --- Create Round 2 (Total Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, 1, r2BaseCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C2 to Round 2 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+        vm.startPrank(contributor2_);
+        fundingPot.contributeToRoundFor(
+            contributor2_, round2Id, r2ContributionC2, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id), r2ContributionC2
+        );
+
+        // --- Create Round 3 (Total Mode) ---
+        uint r3ExpectedEffectiveCap = r3BaseCap + (r1BaseCap - r1ContributionC1)
+            + (r2BaseCap - r2ContributionC2);
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            r3BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        (address nftR3, bytes32 merkleR3, address[] memory allowedR3) =
+            _helper_createAccessCriteria(1, round3Id);
+
+        // TODO
+        fundingPot.setAccessCriteria(round3Id, 1, 0, nftR3, merkleR3, allowedR3);
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, 1, r3ExpectedEffectiveCap, false, 0, 0, 0
+        );
+
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 3 by C3 ---
+        vm.warp(initialTimestamp + 5 days + 1 hours);
+
+        vm.startPrank(contributor3_);
+        fundingPot.contributeToRoundFor(
+            contributor3_, round3Id, r3ExpectedEffectiveCap, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getTotalRoundContribution(round3Id),
+            r3ExpectedEffectiveCap,
+            "R3 total contributions should match effective cap with rollover from R1 and R2"
+        );
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor3_),
+            r3ExpectedEffectiveCap,
+            "R3 C3 contribution incorrect"
+        );
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundCapReached
+                    .selector
+            )
+        );
+        fundingPot.contributeToRoundFor(
+            contributor1_, round3Id, 1, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+    }
+
+    function testContribute_allMode_defaultGlobalStartAllowsPersonalCapAccumulationFromAllPrevious(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 1 allows personal cap
+        // accumulation from R1 to R2, when both are in All mode. (Simplified for stack)
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1;
+
+        // --- Round 1: Setup & C1 Contribution ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100;
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            1000,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+        uint r1UnusedPersonalForC1 = r1PersonalCapC1 - r1ContributionC1;
+
+        // --- Round 2: Setup ---
+        uint r2BasePersonalCapC1 = 200;
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            2000,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Global Start ID Check ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start ID is 1"
+        );
+
+        // --- C1 Contribution to Round 2 (Testing Personal Cap Rollover) ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+        uint expectedEffectivePersonalCapC1R2 =
+            r2BasePersonalCapC1 + r1UnusedPersonalForC1;
+        uint c1AttemptR2 = expectedEffectivePersonalCapC1R2 + 50;
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            expectedEffectivePersonalCapC1R2,
+            "R2 C1 personal contribution incorrect"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            expectedEffectivePersonalCapC1R2,
+            "R2 Total contributions incorrect"
+        );
+    }
+
+    function testContribute_allMode_defaultGlobalStartAllowsTotalCapAccumulationFromAllPrevious(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 1 (default or set) allows total cap
+        // accumulation from R1 to R2, when both are in All mode.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters (All Mode) ---
+        uint r1BaseTotalCap = 1000;
+        uint r1C1PersonalCap = 800;
+        uint r1C1Contribution = 600;
+
+        // --- Round 2 Parameters (All Mode) ---
+        uint r2BaseTotalCap = 500;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (All Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1C1PersonalCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1C1Contribution,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+        uint r1UnusedTotal = r1BaseTotalCap - r1C1Contribution;
+
+        // --- Create Round 2 (All Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        uint r2ExpectedEffectiveTotalCap = r2BaseTotalCap + r1UnusedTotal;
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2ExpectedEffectiveTotalCap, false, 0, 0, 0
+        );
+
+        // --- Ensure Global Start Round ID is 1 ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Global start round ID should be 1 by default"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 to fill effective total cap ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2ExpectedEffectiveTotalCap;
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, c1AttemptR2, accessId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            c1AttemptR2,
+            "R2 C1 contribution should match attempt (filling effective total cap)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2ExpectedEffectiveTotalCap,
+            "R2 Total contributions should match effective total cap (All mode, global_start=1)"
+        );
+    }
+
+    function testContribute_allMode_globalStartRestrictsPersonalCapAccumulationFromEarlierRounds(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 2 restricts personal cap accumulation
+        // from R1 for R2, when both are in All mode.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters (All Mode) ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100;
+        uint r1BaseTotalCap = 1000;
+
+        // --- Round 2 Parameters (All Mode) ---
+        uint r2BasePersonalCapC1 = 50;
+        uint r2BaseTotalCap = 1000;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (All Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Create Round 2 (All Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Set Global Start Round ID to Round 2's ID ---
+        fundingPot.setGlobalAccumulationStart(round2Id);
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            round2Id,
+            "Global start ID not set to R2 ID"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2BasePersonalCapC1 + 100;
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2BasePersonalCapC1,
+            "R2 C1 personal contribution should be clamped by R2 base personal cap (All mode, global_start=R2)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2BasePersonalCapC1,
+            "R2 Total contributions should be C1's clamped amount (All mode, global_start=R2)"
+        );
+    }
+
+    function testContribute_allMode_globalStartRestrictsTotalCapAccumulationFromEarlierRounds(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 2 restricts total cap accumulation
+        // from R1 for R2, when both are in All mode.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters (All Mode) ---
+        uint r1BaseTotalCap = 1000;
+        uint r1C1PersonalCap = 800;
+        uint r1C1Contribution = 400;
+
+        // --- Round 2 Parameters (All Mode) ---
+        uint r2BaseTotalCap = 200;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (All Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1C1PersonalCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1C1Contribution,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Create Round 2 (All Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BaseTotalCap, false, 0, 0, 0
+        );
+
+        // --- Set Global Start Round ID to Round 2's ID ---
+        fundingPot.setGlobalAccumulationStart(round2Id);
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            round2Id,
+            "Global start ID not set to R2 ID"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2BaseTotalCap + 100;
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, c1AttemptR2, accessId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2BaseTotalCap,
+            "R2 C1 contribution should be clamped by R2 base total cap (All mode, global_start=R2)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2BaseTotalCap,
+            "R2 Total contributions should be R2 base total cap (All mode, global_start=R2)"
+        );
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1829,7 +1829,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 && accessCriteriaEnumNew >= 0 && accessCriteriaEnumNew <= 4
         );
         uint8 accessCriteriaId = 1;
-        uint8 accessType = uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.NFT);
+        
         _helper_setupRoundWithAccessCriteria(accessCriteriaId);
         uint32 roundId = fundingPot.getRoundCount();
 
@@ -2315,7 +2315,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint r2PersonalCap = 600;
         uint r2Contribution = 200;
-        uint r2UnusedPersonal = r2PersonalCap - r2Contribution; // This IS used for R3 calculation
 
         uint r3BasePersonalCap = 300;
 
@@ -4355,11 +4354,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
         uint32 roundId = fundingPot.getRoundCount();
 
-        (
-            address nftContract,
-            bytes32 merkleRoot,
-            address[] memory allowedAddresses
-        ) = _helper_createAccessCriteria(accessCriteriaEnum, roundId);
+        _helper_createAccessCriteria(accessCriteriaEnum, roundId);
 
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1829,7 +1829,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                 && accessCriteriaEnumNew >= 0 && accessCriteriaEnumNew <= 4
         );
         uint8 accessCriteriaId = 1;
-        
+
         _helper_setupRoundWithAccessCriteria(accessCriteriaId);
         uint32 roundId = fundingPot.getRoundCount();
 

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -5304,4 +5304,147 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             "R2 Total contributions should be R2 base total cap (All mode, global_start=R2)"
         );
     }
+
+    function testContributeToRoundFor_revertsGivenUnspentCapsRoundIdsNotStrictlyIncreasing(
+    ) public {
+        // Setup: Round 1 (Personal), Round 2 (Personal), Round 3 (Personal for contribution)
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+        uint personalCap = 500;
+        uint roundCap = 10_000;
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // Round 1
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            roundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, personalCap, false, 0, 0, 0
+        );
+
+        // Round 2
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            roundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, personalCap, false, 0, 0, 0
+        );
+
+        // Round 3 (target for contribution)
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            roundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round3Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, accessId, personalCap, false, 0, 0, 0
+        );
+
+        vm.warp(initialTimestamp + 5 days + 1 hours); // Enter Round 3
+
+        // Case 1: Out of order
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory
+            unspentCapsOutOfOrder =
+                new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
+        unspentCapsOutOfOrder[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round2Id, accessId, new bytes32[](0)
+        );
+        unspentCapsOutOfOrder[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__UnspentCapsRoundIdsNotStrictlyIncreasing
+                .selector
+        );
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round3Id,
+            100,
+            accessId,
+            new bytes32[](0),
+            unspentCapsOutOfOrder
+        );
+        vm.stopPrank();
+
+        // Case 2: Duplicate roundId
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory
+            unspentCapsDuplicate =
+                new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
+        unspentCapsDuplicate[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+        unspentCapsDuplicate[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__UnspentCapsRoundIdsNotStrictlyIncreasing
+                .selector
+        );
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round3Id,
+            100,
+            accessId,
+            new bytes32[](0),
+            unspentCapsDuplicate
+        );
+        vm.stopPrank();
+
+        // Case 3: Correct order but first element's roundId is 0 (if lastSeenRoundId starts at 0)
+        // This specific case won't be hit if round IDs must be >0, but good to be aware.
+        // Assuming valid round IDs start from 1, this case might not be directly testable if 0 isn't a valid roundId.
+        // The current check `currentProcessingRoundId <= lastSeenRoundId` covers this if roundId can be 0.
+        // If round IDs are always >= 1, then an initial lastSeenRoundId=0 is fine.
+
+        // Case 4: Empty array (should not revert with this specific error, but pass)
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsEmpty =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](0);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor( // This should pass (or revert with a different error if amount is 0 etc.)
+            contributor1_,
+            round3Id,
+            100,
+            accessId,
+            new bytes32[](0),
+            unspentCapsEmpty
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor1_), 100
+        );
+    }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -75,7 +75,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         address hookContract;
         bytes hookFunction;
         bool autoClosure;
-        bool globalAccumulativeCaps;
+        ILM_PC_FundingPot_v1.AccumulationMode accumulationMode;
     }
 
     ERC721Mock mockNFTContract = new ERC721Mock("NFT Mock", "NFT");
@@ -117,7 +117,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             hookContract: address(0),
             hookFunction: bytes(""),
             autoClosure: false,
-            globalAccumulativeCaps: false
+            accumulationMode: ILM_PC_FundingPot_v1.AccumulationMode.All
         });
 
         // Initialize edited round parameters
@@ -128,7 +128,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address(0x1),
             bytes("test"),
             true,
-            true
+            ILM_PC_FundingPot_v1.AccumulationMode.All
         );
     }
 
@@ -209,7 +209,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
         vm.stopPrank();
     }
@@ -235,7 +235,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -260,7 +260,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -285,7 +285,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -308,7 +308,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -332,7 +332,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -352,7 +352,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
 
         uint32 roundId = fundingPot.getRoundCount();
@@ -365,7 +365,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address storedHookContract,
             bytes memory storedHookFunction,
             bool storedAutoClosure,
-            bool storedGlobalAccumulativeCaps
+            ILM_PC_FundingPot_v1.AccumulationMode storedAccumulationMode
         ) = fundingPot.getRoundGenericParameters(roundId);
 
         // Compare with expected values
@@ -375,7 +375,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(storedHookContract, params.hookContract);
         assertEq(storedHookFunction, params.hookFunction);
         assertEq(storedAutoClosure, params.autoClosure);
-        assertEq(storedGlobalAccumulativeCaps, params.globalAccumulativeCaps);
+        assertEq(uint(storedAccumulationMode), uint(params.accumulationMode));
     }
 
     /* Test editRound()
@@ -421,7 +421,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
                     ├── hookContract should be updated to the new value
                     ├── hookFunction should be updated to the new value
                     ├── autoClosure should be updated to the new value
-                    └── globalAccumulativeCaps should be updated to the new value
+                    └── accumulationMode should be updated to the new value
     */
 
     function testEditRound_revertsGivenUserIsNotFundingPotAdmin(address user_)
@@ -438,7 +438,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             hookContract: address(0x1),
             hookFunction: bytes("test"),
             autoClosure: true,
-            globalAccumulativeCaps: true
+            accumulationMode: ILM_PC_FundingPot_v1.AccumulationMode.All
         });
 
         vm.startPrank(user_);
@@ -458,7 +458,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
         vm.stopPrank();
     }
@@ -474,7 +474,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             hookContract: address(0x1),
             hookFunction: bytes("test"),
             autoClosure: true,
-            globalAccumulativeCaps: true
+            accumulationMode: ILM_PC_FundingPot_v1.AccumulationMode.All
         });
 
         vm.expectRevert(
@@ -492,7 +492,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -508,7 +508,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         ) = fundingPot.getRoundGenericParameters(roundId);
         vm.warp(params.roundStart + 1);
 
@@ -519,7 +519,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             hookContract: address(0x1),
             hookFunction: bytes("test"),
             autoClosure: true,
-            globalAccumulativeCaps: true
+            accumulationMode: ILM_PC_FundingPot_v1.AccumulationMode.All
         });
 
         vm.expectRevert(
@@ -537,7 +537,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params_.hookContract,
             params_.hookFunction,
             params_.autoClosure,
-            params_.globalAccumulativeCaps
+            params_.accumulationMode
         );
     }
 
@@ -566,7 +566,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _editedRoundParams.hookContract,
             _editedRoundParams.hookFunction,
             _editedRoundParams.autoClosure,
-            _editedRoundParams.globalAccumulativeCaps
+            _editedRoundParams.accumulationMode
         );
     }
 
@@ -581,7 +581,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             hookContract: address(0x1),
             hookFunction: bytes("test"),
             autoClosure: true,
-            globalAccumulativeCaps: true
+            accumulationMode: ILM_PC_FundingPot_v1.AccumulationMode.All
         });
 
         vm.expectRevert(
@@ -600,7 +600,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -630,7 +630,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address(0x1),
             bytes("test"),
             true,
-            true
+            ILM_PC_FundingPot_v1.AccumulationMode.All
         );
 
         vm.expectRevert(
@@ -649,7 +649,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -666,7 +666,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address(1),
             bytes(""),
             true,
-            true
+            ILM_PC_FundingPot_v1.AccumulationMode.All
         );
 
         vm.expectRevert(
@@ -685,7 +685,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -702,7 +702,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address(0),
             bytes("test"),
             true,
-            true
+            ILM_PC_FundingPot_v1.AccumulationMode.All
         );
 
         vm.expectRevert(
@@ -721,7 +721,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
     }
 
@@ -736,7 +736,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             ├── hookContract should be updated to the new value
             ├── hookFunction should be updated to the new value
             ├── autoClosure should be updated to the new value
-            └── globalAccumulativeCaps should be updated to the new value
+            └── accumulationMode should be updated to the new value
     */
 
     function testEditRound() public {
@@ -753,7 +753,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
 
         // Retrieve the stored parameters
@@ -764,7 +764,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address storedHookContract,
             bytes memory storedHookFunction,
             bool storedAutoClosure,
-            bool storedGlobalAccumulativeCaps
+            ILM_PC_FundingPot_v1.AccumulationMode storedAccumulationMode
         ) = fundingPot.getRoundGenericParameters(uint32(lastRoundId));
 
         // Compare with expected values
@@ -774,7 +774,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(storedHookContract, params.hookContract);
         assertEq(storedHookFunction, params.hookFunction);
         assertEq(storedAutoClosure, params.autoClosure);
-        assertEq(storedGlobalAccumulativeCaps, params.globalAccumulativeCaps);
+        assertEq(uint(storedAccumulationMode), uint(params.accumulationMode));
     }
 
     /* Test setAccessCriteria()
@@ -1198,7 +1198,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            _defaultRoundParams.accumulationMode
         );
 
         (
@@ -1241,7 +1241,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            _defaultRoundParams.accumulationMode
         );
 
         (
@@ -1302,7 +1302,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
 
         (
@@ -1840,7 +1840,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            _defaultRoundParams.accumulationMode
         );
 
         (
@@ -2012,7 +2012,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testContributeToRoundFor_worksGivenPersonalCapAccumulation()
         public
     {
-        _defaultRoundParams.globalAccumulativeCaps = true;
+        _defaultRoundParams.accumulationMode = ILM_PC_FundingPot_v1.AccumulationMode.Personal;
         fundingPot.createRound(
             _defaultRoundParams.roundStart,
             _defaultRoundParams.roundEnd,
@@ -2020,7 +2020,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            _defaultRoundParams.accumulationMode
         );
 
         uint32 round1Id = fundingPot.getRoundCount();
@@ -2055,7 +2055,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            _defaultRoundParams.accumulationMode
         );
         uint32 round2Id = fundingPot.getRoundCount();
 
@@ -2118,7 +2118,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     function testContributeToRoundFor_worksGivenTotalRoundCapAccumulation()
         public
     {
-        _defaultRoundParams.globalAccumulativeCaps = true;
+        _defaultRoundParams.accumulationMode = ILM_PC_FundingPot_v1.AccumulationMode.All;
 
         // Create Round 1
         fundingPot.createRound(
@@ -2128,7 +2128,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            _defaultRoundParams.accumulationMode
         );
         uint32 round1Id = fundingPot.getRoundCount();
 
@@ -2156,7 +2156,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            _defaultRoundParams.accumulationMode
         );
         uint32 round2Id = fundingPot.getRoundCount();
         fundingPot.setAccessCriteria(
@@ -2327,7 +2327,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             address(failingHook),
             abi.encodeWithSignature("executeHook()"),
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            _defaultRoundParams.accumulationMode
         );
 
         (
@@ -2831,7 +2831,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            ILM_PC_FundingPot_v1.AccumulationMode.Disabled
         );
 
         // round 2 (with accumulation)
@@ -2842,7 +2842,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            true // globalAccumulativeCaps on
+            ILM_PC_FundingPot_v1.AccumulationMode.All // globalAccumulativeCaps on
         );
 
         // round 3
@@ -2853,7 +2853,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            true
+            ILM_PC_FundingPot_v1.AccumulationMode.All
         );
 
         // Calculate unused capacity
@@ -2911,7 +2911,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
 
         // Set access criteria and privileges
@@ -2958,7 +2958,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
 
         // Move time past end time
@@ -2981,7 +2981,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
 
         assertFalse(fundingPot.exposed_checkRoundClosureConditions(roundId));
@@ -3000,7 +3000,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
 
         // Set access criteria and privileges
@@ -3057,7 +3057,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             params.hookContract,
             params.hookFunction,
             params.autoClosure,
-            params.globalAccumulativeCaps
+            params.accumulationMode
         );
 
         // Should be false before end time
@@ -3149,7 +3149,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         address hookContract_,
         bytes memory hookFunction_,
         bool autoClosure_,
-        bool globalAccumulativeCaps_
+        ILM_PC_FundingPot_v1.AccumulationMode accumulationMode_
     ) internal pure returns (RoundParams memory) {
         return RoundParams({
             roundStart: roundStart_,
@@ -3158,7 +3158,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             hookContract: hookContract_,
             hookFunction: hookFunction_,
             autoClosure: autoClosure_,
-            globalAccumulativeCaps: globalAccumulativeCaps_
+            accumulationMode: accumulationMode_
         });
     }
 
@@ -3263,7 +3263,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             _defaultRoundParams.hookContract,
             _defaultRoundParams.hookFunction,
             _defaultRoundParams.autoClosure,
-            _defaultRoundParams.globalAccumulativeCaps
+            _defaultRoundParams.accumulationMode
         );
 
         (

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -1635,19 +1635,19 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │       └── Then the funds are transferred to the funding pot
     │           And the contribution is recorded
     │
-    ├──  Given the access criteria is NFT
-    │    And the user fulfills the access criteria
-    │       └── When the user contributes to the round
-    │           └── Then the funds are transferred to the funding pot
-    │               And the contribution is recorded
-    │
-    ├──  Given the access criteria is MERKLE 
+    ├── Given the access criteria is NFT
     │   And the user fulfills the access criteria
     │   └── When the user contributes to the round
     │       └── Then the funds are transferred to the funding pot
     │           And the contribution is recorded
     │
-    ├──  Given the access criteria is LIST
+    ├── Given the access criteria is MERKLE 
+    │   And the user fulfills the access criteria
+    │   └── When the user contributes to the round
+    │       └── Then the funds are transferred to the funding pot
+    │           And the contribution is recorded
+    │
+    ├── Given the access criteria is LIST
     │   And the user fulfills the access criteria
     │   └── When the user contributes to the round
     │       └── Then the funds are transferred to the funding pot
@@ -1660,16 +1660,16 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │           And round closure is initiated
     │
     ├── Given the user fulfills the access criteria
-    │   └── And the user has already contributed their personal cap partially
-    │       └── When the user attempts to contribute more than their personal cap
-    │           └── Then only the amount up to the cap is accepted as contribution
-    │               And the contribution is recorded
+    │   And the user has already contributed their personal cap partially
+    │   └── When the user attempts to contribute more than their personal cap
+    │       └── Then only the amount up to the cap is accepted as contribution
+    │           And the contribution is recorded
     │
     ├── Given the user fulfills the access criteria
-    │   └── And their access criteria has the privilege to override the contribution span
-    │       └── When <reason for end of contribution span>
-    │           └── And the user attempts to contribute
-    │               └── Then the contribution is still recorded
+    │   And their access criteria has the privilege to override the contribution span
+    │   └── When <reason for end of contribution span>
+    │       └── And the user attempts to contribute
+    │           └── Then the contribution is still recorded
     │
     ├── Given the user fulfills the access criteria
     │   And the round is set to have global accumulative caps
@@ -1685,8 +1685,85 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │       └── Then they can in total contribute Z + X - Y
     │           And the funds are transferred into the funding pot
     │
+    ├── Given globalAccumulationStartRoundId is set to 2 (e.g., R2)
+    │   ├── And target round (e.g., R3) uses AccumulationMode.Personal
+    │   │   └── When contributing to R3 with unspent capacity from R1 and R2
+    │   │       └── Then only unspent personal capacity from R2 should be considered
+    │   ├── And target round (e.g., R3) uses AccumulationMode.Total
+    │   │   └── When contributing to R3
+    │   │       └── Then only unspent total capacity from R2 should expand R3's effective cap
+    │   └── And target round (e.g., R3) uses AccumulationMode.All
+    │       ├── When contributing to R3 with unspent personal capacity from R1 and R2
+    │       │   └── Then only unspent personal capacity from R2 should be considered
+    │       └── When calculating R3's effective total cap
+    │           └── Then only unspent total capacity from R2 should expand R3's effective cap
+    │
+    ├── Given globalAccumulationStartRoundId is 1 (default)
+    │   ├── And target round (e.g., R2 or R3) uses AccumulationMode.Personal
+    │   │   └── When contributing with unspent capacity from all previous valid rounds (e.g., R1 for R2; R1 & R2 for R3)
+    │   │       └── Then unspent personal capacity from all applicable previous rounds should be considered
+    │   ├── And target round (e.g., R2 or R3) uses AccumulationMode.Total
+    │   │   └── When calculating effective total cap
+    │   │       └── Then unspent total capacity from all applicable previous rounds should expand the effective cap
+    │   └── And target round (e.g., R2 or R3) uses AccumulationMode.All
+    │       ├── When contributing with unspent personal capacity from all previous valid rounds
+    │       │   └── Then unspent personal capacity from all applicable previous rounds should be considered
+    │       └── When calculating effective total cap
+    │           └── Then unspent total capacity from all applicable previous rounds should expand the effective cap
+    │
+    ├── Given target round's AccumulationMode is Disabled
+    │   └── When globalAccumulationStartRoundId is set to allow previous rounds
+    │       └── Then no accumulation (personal or total) should occur for the target round
+    │
+    ├── Given globalAccumulationStartRoundId is set to the target round's ID
+    │   └── When target round's AccumulationMode would normally allow accumulation
+    │       └── Then no accumulation (personal or total) from any previous round should occur
+    │
+    ├── Given globalAccumulationStartRoundId is set to R2 (or later)
+    │   ├── When target round (R3) uses AccumulationMode.Personal
+    │   │   And contributing to R3 with unspent capacity from R1 and R2
+    │   │   └── Then only unspent personal capacity from R2 (and subsequent allowed rounds) should be considered
+    │   ├── When target round (R3) uses AccumulationMode.Total
+    │   │   And calculating R3's effective total cap
+    │   │   └── Then only unspent total capacity from R2 (and subsequent allowed rounds) should expand R3's cap
+    │   └── When target round (R3) uses AccumulationMode.All
+    │       ├── And contributing to R3 with unspent personal capacity from R1 and R2
+    │       │   └── Then only unspent personal capacity from R2 (and subsequent) should be considered for personal limit
+    │       └── And calculating R3's effective total cap
+    │           └── Then only unspent total capacity from R2 (and subsequent) should expand R3's cap
+    │
+    ├── Given globalAccumulationStartRoundId is 1 (default)
+    │   ├── When target round (e.g., R2 or R3) uses AccumulationMode.Personal
+    │   │   And contributing with unspent capacity from all previous valid rounds (e.g., R1 for R2; R1 & R2 for R3)
+    │   │   └── Then unspent personal capacity from all applicable previous rounds (>= global start) should be considered
+    │   ├── When target round (e.g., R2 or R3) uses AccumulationMode.Total
+    │   │   And calculating effective total cap
+    │   │   └── Then unspent total capacity from all applicable previous rounds (>= global start) should expand the cap
+    │   └── When target round (e.g., R2 or R3) uses AccumulationMode.All
+    │       ├── And contributing with unspent personal capacity from all previous valid rounds
+    │       │   └── Then unspent personal capacity from all applicable previous rounds (>= global start) should be considered
+    │       └── And calculating effective total cap
+    │           └── Then unspent total capacity from all applicable previous rounds (>= global start) should expand the cap
+    │
+    ├── Given target round's AccumulationMode is Disabled
+    │   └── When globalAccumulationStartRoundId is set to allow previous rounds (e.g. 1)
+    │       └── Then no accumulation (personal or total) should occur for the target round from any previous round
+    │
+    ├── Given globalAccumulationStartRoundId is set to the target round's ID (or a later round ID)
+    │   └── When target round's AccumulationMode would normally allow accumulation
+    │       └── Then no accumulation (personal or total) from any previous round should occur
+    │
+    ├── Given rounds use AccumulationMode.Personal
+    │   └── When unspent capacity from previous rounds is available
+    │       └── Then only personal caps accumulate, while total caps do not accumulate
+    │
+    └── Given rounds use AccumulationMode.Total
+        └── When unspent capacity from previous rounds is available
+            └── Then only total caps accumulate, while personal caps do not accumulate
     */
-    function testcontributeToRoundFor_worksGivenAllConditionsMet() public {
+    function testContributeToRoundFor_worksGivenGenericConfigAndAccessCriteria()
+        public
+    {
         testCreateRound();
 
         uint8 accessCriteriaId = 1;
@@ -1742,7 +1819,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(personalContributions, amount);
     }
 
-    function testcontributeToRoundFor_worksGivenUserCurrentContributionExceedsTheRoundCap(
+    function testContributeToRoundFor_worksGivenAccessCriteriaNFT(
         uint8 accessCriteriaEnumOld,
         uint8 accessCriteriaEnumNew
     ) public {
@@ -2221,6 +2298,1980 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(fundingPot.getTotalRoundContribution(round2Id), 700);
     }
 
+    function testContributeToRoundFor_globalStartRestrictsPersonalAccumulation()
+        public
+    {
+        // SCENARIO: globalAccumulationStartRoundId = 2 restricts accumulation from Round 1 for Personal mode
+        // 1. Setup: Round 1, Round 2, Round 3. Partial contributions in R1 & R2.
+        // 2. Action: setGlobalAccumulationStart(2)
+        // 3. Verification: For contributions to R3 (Personal mode), only unused personal from R2 rolls over.
+
+        uint initialTimestamp = block.timestamp;
+
+        // --- Setup Rounds ---
+        uint r1PersonalCap = 500;
+        uint r1Contribution = 100;
+        // uint r1UnusedPersonal = r1PersonalCap - r1Contribution; // Not used in this restricted scenario directly for R3 calc
+
+        uint r2PersonalCap = 600;
+        uint r2Contribution = 200;
+        uint r2UnusedPersonal = r2PersonalCap - r2Contribution; // This IS used for R3 calculation
+
+        uint r3BasePersonalCap = 300;
+
+        // Round 1
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            10_000, // large round cap
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
+        ); // Open access
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, 1, r1PersonalCap, false, 0, 0, 0
+        );
+
+        // Round 2
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            10_000, // large round cap
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, 1, r2PersonalCap, false, 0, 0, 0
+        );
+
+        // Round 3
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            10_000, // large round cap
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round3Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, 1, r3BasePersonalCap, false, 0, 0, 0
+        );
+
+        // --- Contributions ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+
+        vm.warp(initialTimestamp + 1 days + 1 hours); // Enter Round 1
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, r1Contribution, 1, new bytes32[](0)
+        );
+
+        vm.warp(initialTimestamp + 3 days + 1 hours); // Enter Round 2
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, r2Contribution, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Set Global Start ---
+        fundingPot.setGlobalAccumulationStart(2);
+        assertEq(fundingPot.getGlobalAccumulationStartRoundId(), 2);
+
+        // --- Attempt Contribution in Round 3 ---
+        vm.warp(initialTimestamp + 5 days + 1 hours); // Enter Round 3
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
+        // User claims unspent from R1 (should be ignored due to global start)
+        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, 1, new bytes32[](0)
+        );
+        // User claims unspent from R2 (should be counted)
+        unspentCaps[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round2Id, 1, new bytes32[](0)
+        );
+
+        uint expectedR3PersonalCap = r3BasePersonalCap + r2Contribution; // Only R2's unused personal cap
+
+        vm.startPrank(contributor1_);
+        // Attempt to contribute up to the expected new personal cap
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round3Id,
+            expectedR3PersonalCap,
+            1,
+            new bytes32[](0),
+            unspentCaps
+        );
+        vm.stopPrank();
+
+        // --- Assertion ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor1_),
+            expectedR3PersonalCap,
+            "R3 personal contribution incorrect"
+        );
+    }
+
+    function testContributeToRoundFor_globalStartRestrictsTotalAccumulation()
+        public
+    {
+        // SCENARIO: globalAccumulationStartRoundId = 2 restricts accumulation from Round 1 for Total mode
+        // 1. Setup: Round 1, Round 2, Round 3. Partial contributions in R1 & R2.
+        // 2. Action: setGlobalAccumulationStart(2)
+        // 3. Verification: For contributions to R3 (Total mode), only unused total from R2 expands R3 cap.
+
+        uint initialTimestamp = block.timestamp;
+
+        // --- Setup Rounds ---
+        uint r1BaseCap = 1000;
+        uint r1Contribution = 400;
+        // uint r1UnusedTotal = r1BaseCap - r1Contribution;
+
+        uint r2BaseCap = 1200;
+        uint r2Contribution = 500;
+        // uint r2UnusedTotal = r2BaseCap - r2Contribution;
+
+        uint r3BaseCap = 300;
+
+        // Round 1
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
+        ); // Open access
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, 1, r1BaseCap, false, 0, 0, 0
+        ); // Personal cap equals round cap
+
+        // Round 2
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, 1, r2BaseCap, false, 0, 0, 0
+        );
+
+        // Round 3
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            r3BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round3Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, 1, r3BaseCap + r2Contribution, false, 0, 0, 0
+        ); // Allow full contribution for testing effective cap
+
+        // --- Contributions ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+
+        vm.warp(initialTimestamp + 1 days + 1 hours); // Enter Round 1
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, r1Contribution, 1, new bytes32[](0)
+        );
+
+        vm.warp(initialTimestamp + 3 days + 1 hours); // Enter Round 2
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, r2Contribution, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Set Global Start ---
+        fundingPot.setGlobalAccumulationStart(2);
+        assertEq(fundingPot.getGlobalAccumulationStartRoundId(), 2);
+
+        // --- Attempt Contribution in Round 3 ---
+        vm.warp(initialTimestamp + 5 days + 1 hours); // Enter Round 3
+
+        uint expectedR3EffectiveCap = r3BaseCap + r2Contribution; // Only R2's unused total cap
+
+        vm.startPrank(contributor1_);
+        // Attempt to contribute up to the expected new effective cap
+        fundingPot.contributeToRoundFor(
+            contributor1_, round3Id, expectedR3EffectiveCap, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertion ---
+        assertEq(
+            fundingPot.getTotalRoundContribution(round3Id),
+            expectedR3EffectiveCap,
+            "R3 total contribution incorrect, effective cap not as expected"
+        );
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor1_),
+            expectedR3EffectiveCap,
+            "R3 user contribution incorrect"
+        );
+    }
+
+    function testContributeToRoundFor_defaultGlobalStartAllowsPersonalAccumulation(
+    ) public {
+        // SCENARIO: Default globalAccumulationStartRoundId = 1 allows accumulation from R1 for R2 (Personal mode)
+        // 1. Setup: Round 1 (Personal), Round 2 (Personal).
+        //    Partial contribution by C1 in R1.
+        // 2. Action: Verify getGlobalAccumulationStartRoundId() == 1 (default).
+        // 3. Verification: For C1's contribution to R2, unused personal capacity from R1 rolls over.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round Parameters & Contributions for C1 ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100; // C1 leaves 400 personal unused from R1
+
+        uint r2BasePersonalCapC1 = 300; // C1's base personal cap in R2
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Personal Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            10_000, // Large round cap, not relevant for personal accumulation focus
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Create Round 2 (Personal Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            10_000, // Large round cap
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.startPrank(contributor1_);
+        vm.warp(initialTimestamp + 1 days + 1 hours); // Enter Round 1
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Verify Default Global Start Round ID ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours); // Enter Round 2
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id,
+            accessId,
+            new bytes32[](0) // Should be counted
+        );
+
+        uint r1UnusedPersonalC1 = r1PersonalCapC1 - r1ContributionC1; // 400
+
+        // Expected C1 effective personal cap in R2 = R2_Base (300) + R1_Unused (400) = 700
+        uint expectedC1EffectivePersonalCapR2 =
+            r2BasePersonalCapC1 + r1UnusedPersonalC1;
+
+        uint c1AttemptR2 = expectedC1EffectivePersonalCapR2 + 50; // Try to contribute slightly more
+        uint expectedC1ContributionR2 = expectedC1EffectivePersonalCapR2; // Should be clamped
+
+        // Ensure the attempt is not clamped by the round cap (which is large)
+        if (expectedC1ContributionR2 > 10_000) {
+            // 10_000 is round cap for R2
+            expectedC1ContributionR2 = 10_000;
+        }
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertion ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            expectedC1ContributionR2,
+            "R2 C1 personal contribution incorrect (should use R1 unused)"
+        );
+    }
+
+    function testContributeToRoundFor_defaultGlobalStartAllowsTotalAccumulation(
+    ) public {
+        // SCENARIO: Default globalAccumulationStartRoundId = 1 allows total cap accumulation from R1 to R2 (Total mode)
+        // Simplified to reduce stack depth.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters & Contribution ---
+        uint r1BaseCap = 1000;
+        uint r1ContributionC1 = 600; // Leaves 400 unused total from R1
+        uint r1PersonalCap = 1000;
+
+        // --- Round 2 Parameters ---
+        uint r2BaseCap = 500;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Total Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+        uint r1UnusedTotal = r1BaseCap - r1ContributionC1; // Should be 400
+
+        // --- Create Round 2 (Total Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        // Set personal cap for R2 to be at least the expected effective total cap
+        uint r2ExpectedEffectiveTotalCap = r2BaseCap + r1UnusedTotal; // 500 + 400 = 900
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2ExpectedEffectiveTotalCap, false, 0, 0, 0
+        );
+
+        // --- Verify Default Global Start Round ID ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2ExpectedEffectiveTotalCap - 100; // e.g., 900 - 100 = 800. Utilizes expanded cap.
+        assertTrue(
+            c1AttemptR2 > r2BaseCap, "C1 R2 attempt should be > R2 base cap"
+        );
+        assertTrue(
+            c1AttemptR2 <= r2ExpectedEffectiveTotalCap,
+            "C1 R2 attempt should be <= R2 effective cap"
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, c1AttemptR2, accessId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            c1AttemptR2,
+            "R2 C1 contribution incorrect"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            c1AttemptR2,
+            "R2 Total contributions after C1 incorrect"
+        );
+
+        // Verify that the total contributions possible is indeed the effective cap
+        uint remainingToFill = r2ExpectedEffectiveTotalCap - c1AttemptR2;
+        if (remainingToFill > 0) {
+            vm.startPrank(contributor1_);
+            fundingPot.contributeToRoundFor(
+                contributor1_,
+                round2Id,
+                remainingToFill,
+                accessId,
+                new bytes32[](0)
+            );
+            vm.stopPrank();
+        }
+
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2ExpectedEffectiveTotalCap,
+            "R2 final total contributions should match effective total cap"
+        );
+    }
+
+    function testContributeToRoundFor_disabledModeIgnoresAccumulation()
+        public
+    {
+        // SCENARIO: AccumulationMode.Disabled on a target round (R2) prevents any accumulation
+        // from a previous round (R1), even if globalAccumulationStartRoundId would allow it.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100;
+        uint r1BaseCap = 1000;
+
+        // --- Round 2 Parameters (Disabled Mode) ---
+        uint r2BasePersonalCapC1 = 50;
+        uint r2BaseCap = 200;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Personal Mode to generate unused personal capacity) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Create Round 2 (Disabled Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Disabled
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Set Global Start Round ID to allow R1 (to show it's ignored by R2's Disabled mode) ---
+        fundingPot.setGlobalAccumulationStart(1);
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2BasePersonalCapC1 + 100;
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2BasePersonalCapC1,
+            "R2 C1 personal contribution should be clamped by R2's base personal cap (Disabled mode)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2BasePersonalCapC1,
+            "R2 Total contributions should not be expanded by R1 (Disabled mode)"
+        );
+        assertTrue(
+            fundingPot.getTotalRoundContribution(round2Id) <= r2BaseCap,
+            "R2 Total contributions exceeded R2's original base cap (Disabled mode)"
+        );
+    }
+
+    function testContributeToRoundFor_noAccumulationWhenGlobalStartEqualsTargetRound(
+    ) public {
+        // SCENARIO: If globalAccumulationStartRoundId is set to the target round's ID (R2),
+        // no accumulation from any previous round (R1) occurs for R2, even if R2's mode would allow it.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100;
+        uint r1BaseCap = 1000;
+
+        // --- Round 2 Parameters (Mode that would normally allow accumulation, e.g., Personal) ---
+        uint r2BasePersonalCapC1 = 50;
+        uint r2BaseCap = 200;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Personal Mode to generate unused personal capacity) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Create Round 2 (Personal Mode - would normally allow accumulation from R1) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Set Global Start Round ID to be Round 2's ID ---
+        fundingPot.setGlobalAccumulationStart(round2Id);
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            round2Id,
+            "Global start round ID not set to R2 ID"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2BasePersonalCapC1 + 100;
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2BasePersonalCapC1,
+            "R2 C1 personal contribution should be clamped by R2's base personal cap (global start = R2)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2BasePersonalCapC1,
+            "R2 Total contributions should not be expanded by R1 (global start = R2)"
+        );
+        assertTrue(
+            fundingPot.getTotalRoundContribution(round2Id) <= r2BaseCap,
+            "R2 Total contributions exceeded R2's original base cap (global start = R2)"
+        );
+    }
+
+    function testContributeToRoundFor_defaultGlobalStartAllowsPersonalAccumulationFromMultipleRounds(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 1 allows personal cap accumulation from R1 AND R2
+        // for contributions to R3, when all rounds are in Personal mode.
+        // 1. Setup: R1, R2, R3 in Personal mode. C1 makes partial contributions in R1 & R2.
+        // 2. Action: Verify globalAccumulationStartRoundId = 1. C1 contributes to R3.
+        // 3. Verification: C1's effective personal cap in R3 includes unused from R1 and R2.
+
+        uint initialTimestamp = block.timestamp;
+
+        // --- Round Parameters, Personal Caps, and Contributions for contributor1_ ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 200;
+
+        uint r2PersonalCapC1 = 600;
+        uint r2ContributionC1 = 250;
+
+        uint r3BasePersonalCapC1 = 300;
+
+        uint largeRoundCap = 1_000_000;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Personal Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            largeRoundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, 1, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, r1ContributionC1, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getUserContributionToRound(round1Id, contributor1_),
+            r1ContributionC1
+        );
+
+        // --- Create Round 2 (Personal Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            largeRoundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, 1, r2PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 2 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, r2ContributionC1, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2ContributionC1
+        );
+
+        // --- Create Round 3 (Personal Mode) ---
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            largeRoundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round3Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, 1, r3BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Verify Global Start Round ID ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 3 by C1 ---
+        vm.warp(initialTimestamp + 5 days + 1 hours);
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, 1, new bytes32[](0)
+        );
+        unspentCapsC1[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round2Id, 1, new bytes32[](0)
+        );
+
+        uint expectedR3PersonalCapC1 = r3BasePersonalCapC1
+            + (r1PersonalCapC1 - r1ContributionC1)
+            + (r2PersonalCapC1 - r2ContributionC1);
+
+        uint c1AttemptR3 = expectedR3PersonalCapC1;
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round3Id,
+            c1AttemptR3,
+            1,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor1_),
+            expectedR3PersonalCapC1,
+            "R3 C1 personal contribution incorrect (should use R1 & R2 unused)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round3Id),
+            expectedR3PersonalCapC1,
+            "R3 total contributions incorrect after C1"
+        );
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__PersonalCapReached
+                    .selector
+            )
+        );
+        fundingPot.contributeToRoundFor(
+            contributor1_, round3Id, 1, 1, new bytes32[](0), unspentCapsC1
+        );
+        vm.stopPrank();
+    }
+
+    function testContributeToRoundFor_defaultGlobalStartAllowsTotalAccumulationFromMultipleRounds(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 1 allows accumulation from Round 1 AND Round 2 for Total mode
+        // 1. Setup: Round 1, Round 2, Round 3. Partial total contributions in R1 & R2. All in Total mode.
+        // 2. Action: setGlobalAccumulationStart(1) (or verify default).
+        // 3. Verification: For contributions to R3 (Total mode), unused total from R1 AND R2 rolls over, expanding R3's effective cap.
+
+        uint initialTimestamp = block.timestamp;
+
+        // --- Round Parameters & Contributions ---
+        uint r1BaseCap = 1000;
+        uint r1ContributionC1 = 400;
+
+        uint r2BaseCap = 1200;
+        uint r2ContributionC2 = 700;
+
+        uint r3BaseCap = 300;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        vm.startPrank(contributor2_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        vm.startPrank(contributor3_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (Total Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, 1, r1BaseCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, r1ContributionC1, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getTotalRoundContribution(round1Id), r1ContributionC1
+        );
+
+        // --- Create Round 2 (Total Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, 1, r2BaseCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C2 to Round 2 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+        vm.startPrank(contributor2_);
+        fundingPot.contributeToRoundFor(
+            contributor2_, round2Id, r2ContributionC2, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id), r2ContributionC2
+        );
+
+        // --- Create Round 3 (Total Mode) ---
+        uint r3ExpectedEffectiveCap = r3BaseCap + (r1BaseCap - r1ContributionC1)
+            + (r2BaseCap - r2ContributionC2);
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            r3BaseCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+        (address nftR3, bytes32 merkleR3, address[] memory allowedR3) =
+            _helper_createAccessCriteria(1, round3Id);
+
+        // TODO
+        fundingPot.setAccessCriteria(round3Id, 1, 0, nftR3, merkleR3, allowedR3);
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, 1, r3ExpectedEffectiveCap, false, 0, 0, 0
+        );
+
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start round ID should be 1"
+        );
+
+        // --- Attempt Contribution in Round 3 by C3 ---
+        vm.warp(initialTimestamp + 5 days + 1 hours);
+
+        vm.startPrank(contributor3_);
+        fundingPot.contributeToRoundFor(
+            contributor3_, round3Id, r3ExpectedEffectiveCap, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getTotalRoundContribution(round3Id),
+            r3ExpectedEffectiveCap,
+            "R3 total contributions should match effective cap with rollover from R1 and R2"
+        );
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor3_),
+            r3ExpectedEffectiveCap,
+            "R3 C3 contribution incorrect"
+        );
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundCapReached
+                    .selector
+            )
+        );
+        fundingPot.contributeToRoundFor(
+            contributor1_, round3Id, 1, 1, new bytes32[](0)
+        );
+        vm.stopPrank();
+    }
+
+    function testContributeToRoundFor_allModeAllowsPersonalAccumulation()
+        public
+    {
+        // SCENARIO: globalAccumulationStartRoundId = 1 allows personal cap
+        // accumulation from R1 to R2, when both are in All mode. (Simplified for stack)
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1;
+
+        // --- Round 1: Setup & C1 Contribution ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100;
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            1000,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+        uint r1UnusedPersonalForC1 = r1PersonalCapC1 - r1ContributionC1;
+
+        // --- Round 2: Setup ---
+        uint r2BasePersonalCapC1 = 200;
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            2000,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Global Start ID Check ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Default global start ID is 1"
+        );
+
+        // --- C1 Contribution to Round 2 (Testing Personal Cap Rollover) ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+        uint expectedEffectivePersonalCapC1R2 =
+            r2BasePersonalCapC1 + r1UnusedPersonalForC1;
+        uint c1AttemptR2 = expectedEffectivePersonalCapC1R2 + 50;
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            expectedEffectivePersonalCapC1R2,
+            "R2 C1 personal contribution incorrect"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            expectedEffectivePersonalCapC1R2,
+            "R2 Total contributions incorrect"
+        );
+    }
+
+    function testContributeToRoundFor_allModeAllowsTotalAccumulation() public {
+        // SCENARIO: globalAccumulationStartRoundId = 1 (default or set) allows total cap
+        // accumulation from R1 to R2, when both are in All mode.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters (All Mode) ---
+        uint r1BaseTotalCap = 1000;
+        uint r1C1PersonalCap = 800;
+        uint r1C1Contribution = 600;
+
+        // --- Round 2 Parameters (All Mode) ---
+        uint r2BaseTotalCap = 500;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (All Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1C1PersonalCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1C1Contribution,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+        uint r1UnusedTotal = r1BaseTotalCap - r1C1Contribution;
+
+        // --- Create Round 2 (All Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        uint r2ExpectedEffectiveTotalCap = r2BaseTotalCap + r1UnusedTotal;
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2ExpectedEffectiveTotalCap, false, 0, 0, 0
+        );
+
+        // --- Ensure Global Start Round ID is 1 ---
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            1,
+            "Global start round ID should be 1 by default"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 to fill effective total cap ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2ExpectedEffectiveTotalCap;
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, c1AttemptR2, accessId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            c1AttemptR2,
+            "R2 C1 contribution should match attempt (filling effective total cap)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2ExpectedEffectiveTotalCap,
+            "R2 Total contributions should match effective total cap (All mode, global_start=1)"
+        );
+    }
+
+    function testContributeToRoundFor_allModeWithGlobalStartRestrictsPersonalAccumulation(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 2 restricts personal cap accumulation
+        // from R1 for R2, when both are in All mode.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters (All Mode) ---
+        uint r1PersonalCapC1 = 500;
+        uint r1ContributionC1 = 100;
+        uint r1BaseTotalCap = 1000;
+
+        // --- Round 2 Parameters (All Mode) ---
+        uint r2BasePersonalCapC1 = 50;
+        uint r2BaseTotalCap = 1000;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (All Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1ContributionC1,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Create Round 2 (All Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
+        );
+
+        // --- Set Global Start Round ID to Round 2's ID ---
+        fundingPot.setGlobalAccumulationStart(round2Id);
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            round2Id,
+            "Global start ID not set to R2 ID"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2BasePersonalCapC1 + 100;
+
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            c1AttemptR2,
+            accessId,
+            new bytes32[](0),
+            unspentCapsC1
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2BasePersonalCapC1,
+            "R2 C1 personal contribution should be clamped by R2 base personal cap (All mode, global_start=R2)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2BasePersonalCapC1,
+            "R2 Total contributions should be C1's clamped amount (All mode, global_start=R2)"
+        );
+    }
+
+    function testContributeToRoundFor_allModeWithGlobalStartRestrictsTotalAccumulation(
+    ) public {
+        // SCENARIO: globalAccumulationStartRoundId = 2 restricts total cap accumulation
+        // from R1 for R2, when both are in All mode.
+
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+
+        // --- Round 1 Parameters (All Mode) ---
+        uint r1BaseTotalCap = 1000;
+        uint r1C1PersonalCap = 800;
+        uint r1C1Contribution = 400;
+
+        // --- Round 2 Parameters (All Mode) ---
+        uint r2BaseTotalCap = 200;
+
+        // --- Approvals ---
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // --- Create Round 1 (All Mode) ---
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            r1BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, r1C1PersonalCap, false, 0, 0, 0
+        );
+
+        // --- Contribution by C1 to Round 1 ---
+        vm.warp(initialTimestamp + 1 days + 1 hours);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round1Id,
+            r1C1Contribution,
+            accessId,
+            new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Create Round 2 (All Mode) ---
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            r2BaseTotalCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.All
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, r2BaseTotalCap, false, 0, 0, 0
+        );
+
+        // --- Set Global Start Round ID to Round 2's ID ---
+        fundingPot.setGlobalAccumulationStart(round2Id);
+        assertEq(
+            fundingPot.getGlobalAccumulationStartRoundId(),
+            round2Id,
+            "Global start ID not set to R2 ID"
+        );
+
+        // --- Attempt Contribution in Round 2 by C1 ---
+        vm.warp(initialTimestamp + 3 days + 1 hours);
+
+        uint c1AttemptR2 = r2BaseTotalCap + 100;
+
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round2Id, c1AttemptR2, accessId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // --- Assertions ---
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            r2BaseTotalCap,
+            "R2 C1 contribution should be clamped by R2 base total cap (All mode, global_start=R2)"
+        );
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            r2BaseTotalCap,
+            "R2 Total contributions should be R2 base total cap (All mode, global_start=R2)"
+        );
+    }
+
+    function testContributeToRoundFor_revertsGivenUnspentCapsRoundIdsNotStrictlyIncreasing(
+    ) public {
+        // Setup: Round 1 (Personal), Round 2 (Personal), Round 3 (Personal for contribution)
+        uint initialTimestamp = block.timestamp;
+        uint8 accessId = 1; // Open access
+        uint personalCap = 500;
+        uint roundCap = 10_000;
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), type(uint).max);
+        vm.stopPrank();
+
+        // Round 1
+        uint32 round1Id = fundingPot.createRound(
+            initialTimestamp + 1 days,
+            initialTimestamp + 2 days,
+            roundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessId, personalCap, false, 0, 0, 0
+        );
+
+        // Round 2
+        uint32 round2Id = fundingPot.createRound(
+            initialTimestamp + 3 days,
+            initialTimestamp + 4 days,
+            roundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessId, personalCap, false, 0, 0, 0
+        );
+
+        // Round 3 (target for contribution)
+        uint32 round3Id = fundingPot.createRound(
+            initialTimestamp + 5 days,
+            initialTimestamp + 6 days,
+            roundCap,
+            address(0),
+            bytes(""),
+            false,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+        fundingPot.setAccessCriteria(
+            round3Id, accessId, 0, address(0), bytes32(0), new address[](0)
+        );
+        fundingPot.setAccessCriteriaPrivileges(
+            round3Id, accessId, personalCap, false, 0, 0, 0
+        );
+
+        vm.warp(initialTimestamp + 5 days + 1 hours); // Enter Round 3
+
+        // Case 1: Out of order
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory
+            unspentCapsOutOfOrder =
+                new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
+        unspentCapsOutOfOrder[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round2Id, accessId, new bytes32[](0)
+        );
+        unspentCapsOutOfOrder[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__UnspentCapsRoundIdsNotStrictlyIncreasing
+                .selector
+        );
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round3Id,
+            100,
+            accessId,
+            new bytes32[](0),
+            unspentCapsOutOfOrder
+        );
+        vm.stopPrank();
+
+        // Case 2: Duplicate roundId
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory
+            unspentCapsDuplicate =
+                new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
+        unspentCapsDuplicate[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+        unspentCapsDuplicate[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
+            round1Id, accessId, new bytes32[](0)
+        );
+
+        vm.startPrank(contributor1_);
+        vm.expectRevert(
+            ILM_PC_FundingPot_v1
+                .Module__LM_PC_FundingPot__UnspentCapsRoundIdsNotStrictlyIncreasing
+                .selector
+        );
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round3Id,
+            100,
+            accessId,
+            new bytes32[](0),
+            unspentCapsDuplicate
+        );
+        vm.stopPrank();
+
+        // Case 3: Correct order but first element's roundId is 0 (if lastSeenRoundId starts at 0)
+        // This specific case won't be hit if round IDs must be >0, but good to be aware.
+        // Assuming valid round IDs start from 1, this case might not be directly testable if 0 isn't a valid roundId.
+        // The current check `currentProcessingRoundId <= lastSeenRoundId` covers this if roundId can be 0.
+        // If round IDs are always >= 1, then an initial lastSeenRoundId=0 is fine.
+
+        // Case 4: Empty array (should not revert with this specific error, but pass)
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsEmpty =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](0);
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor( // This should pass (or revert with a different error if amount is 0 etc.)
+            contributor1_,
+            round3Id,
+            100,
+            accessId,
+            new bytes32[](0),
+            unspentCapsEmpty
+        );
+        vm.stopPrank();
+        assertEq(
+            fundingPot.getUserContributionToRound(round3Id, contributor1_), 100
+        );
+    }
+
+        function testContributeToRoundFor_personalModeOnlyAccumulatesPersonalCaps()
+        public
+    {
+        // 1. Create the first round with AccumulationMode.Personal
+        _defaultRoundParams.accumulationMode =
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal;
+
+        fundingPot.createRound(
+            _defaultRoundParams.roundStart,
+            _defaultRoundParams.roundEnd,
+            1000, // Round cap of 1000
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            _defaultRoundParams.accumulationMode
+        );
+        uint32 round1Id = fundingPot.getRoundCount();
+
+        // Set up access criteria for round 1
+        uint8 accessCriteriaId = 1; // Open access
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id
+        );
+
+        fundingPot.setAccessCriteria(
+            round1Id,
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
+            0, // accessCriteriaId (0 for new)
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
+
+        // Set a personal cap of 500 for round 1
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessCriteriaId, 500, false, 0, 0, 0
+        );
+
+        // 2. Create the second round, also with AccumulationMode.Personal
+        // Use different start and end times to avoid overlap
+        RoundParams memory params = _helper_createEditRoundParams(
+            _defaultRoundParams.roundStart + 3 days,
+            _defaultRoundParams.roundEnd + 3 days,
+            500, // Round cap of 500
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.accumulationMode
+        );
+        uint32 round2Id = fundingPot.getRoundCount();
+
+        // Set up access criteria for round 2
+        fundingPot.setAccessCriteria(
+            round2Id,
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
+            0, // accessCriteriaId (0 for new)
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
+
+        // Set a personal cap of 400 for round 2
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessCriteriaId, 400, false, 0, 0, 0
+        );
+
+        // First round contribution: user contributes 200 out of their 500 personal cap
+        vm.warp(_defaultRoundParams.roundStart + 1);
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 1000);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, 200, accessCriteriaId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // Verify contribution to round 1
+        assertEq(
+            fundingPot.getUserContributionToRound(round1Id, contributor1_), 200
+        );
+
+        // Move to round 2
+        vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
+
+        // ------------ PART 1: VERIFY PERSONAL CAP ACCUMULATION ------------
+        // Create unspent capacity structure
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap({
+            roundId: round1Id,
+            accessCriteriaId: accessCriteriaId,
+            merkleProof: new bytes32[](0)
+        });
+
+        // Try to contribute more than the round 2 personal cap (400)
+        // In Personal mode, this should succeed up to the personal cap (400) + unspent from round 1 (300) = 700
+        // But capped by round cap of 500
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            450, // More than the personal cap of round 2
+            accessCriteriaId,
+            new bytes32[](0),
+            unspentCaps
+        );
+        vm.stopPrank();
+
+        // Verify contributions to round 2 - should be more than the personal cap of round 2 (400)
+        // This verifies personal caps DO accumulate
+        uint contributionAmount =
+            fundingPot.getUserContributionToRound(round2Id, contributor1_);
+        assertEq(contributionAmount, 450);
+        assertTrue(contributionAmount > 400, "Personal cap should accumulate");
+
+        // ------------ PART 2: VERIFY TOTAL CAP NON-ACCUMULATION ------------
+        // Attempt to contribute more than the remaining round cap
+        vm.startPrank(contributor2_);
+        _token.approve(address(fundingPot), 200);
+
+        // Contributor 2 attempts to contribute 100.
+        // Since contributor1 contributed 450 and round cap is 500, only 50 is remaining.
+        // The contribution should be clamped to 50.
+        fundingPot.contributeToRoundFor(
+            contributor2_, round2Id, 100, accessCriteriaId, new bytes32[](0)
+        );
+        // Verify contributor 2's contribution was clamped to the remaining 50.
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor2_), 50
+        );
+        vm.stopPrank();
+
+        // Verify total contributions to round 2 is exactly the round cap (450 + 50 = 500).
+        assertEq(fundingPot.getTotalRoundContribution(round2Id), 500);
+
+        // Additional contributor3 should not be able to contribute anything as the cap is full.
+        // Attempting to contribute when the cap is already full should revert.
+        vm.startPrank(contributor3_);
+        _token.approve(address(fundingPot), 100);
+
+        // Expect revert because the round cap (500) is already met.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundCapReached
+                    .selector
+            )
+        );
+        fundingPot.contributeToRoundFor(
+            contributor3_, round2Id, 1, accessCriteriaId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // Final check that total contributions remain at the round cap.
+        assertEq(fundingPot.getTotalRoundContribution(round2Id), 500);
+    }
+
+    function testContributeToRoundFor_totalModeOnlyAccumulatesTotalCaps() public {
+        // 1. Create the first round with AccumulationMode.Total
+        _defaultRoundParams.accumulationMode =
+            ILM_PC_FundingPot_v1.AccumulationMode.Total;
+
+        fundingPot.createRound(
+            _defaultRoundParams.roundStart,
+            _defaultRoundParams.roundEnd,
+            1000, // Round 1 cap of 1000
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            _defaultRoundParams.accumulationMode
+        );
+        uint32 round1Id = fundingPot.getRoundCount();
+
+        // Set up access criteria for round 1 (Open)
+        uint8 accessCriteriaId = 1;
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id
+        );
+
+        fundingPot.setAccessCriteria(
+            round1Id,
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
+            0, // accessCriteriaId (0 for new)
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
+
+        // Set a personal cap of 800 for round 1
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessCriteriaId, 800, false, 0, 0, 0
+        );
+
+        // 2. Create the second round, also with AccumulationMode.Total
+        RoundParams memory params = _helper_createEditRoundParams(
+            _defaultRoundParams.roundStart + 3 days,
+            _defaultRoundParams.roundEnd + 3 days,
+            500, // Round 2 base cap of 500
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.accumulationMode
+        );
+        uint32 round2Id = fundingPot.getRoundCount();
+
+        // Set up access criteria for round 2 (Open)
+        fundingPot.setAccessCriteria(
+            round2Id,
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
+            0, // accessCriteriaId (0 for new)
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
+
+        // Set a personal cap of 300 for round 2
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessCriteriaId, 300, false, 0, 0, 0
+        );
+
+        // Round 1 contribution: contributor1 contributes 600 (less than round cap 1000, less than personal 800)
+        // Undersubscription: 1000 - 600 = 400
+        vm.warp(_defaultRoundParams.roundStart + 1);
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 1000);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, 600, accessCriteriaId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // Verify contribution to round 1
+        assertEq(
+            fundingPot.getUserContributionToRound(round1Id, contributor1_), 600
+        );
+        assertEq(fundingPot.getTotalRoundContribution(round1Id), 600);
+
+        // Move to round 2
+        vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
+
+        // ------------ PART 1: VERIFY TOTAL CAP ACCUMULATION ------------
+        // Effective Round 2 Cap = Base Cap (500) + Unused from Round 1 (400) = 900
+        vm.startPrank(contributor2_);
+        _token.approve(address(fundingPot), 1000); // Approve enough
+
+        // Contributor 2 attempts to contribute 700.
+        // Personal Cap (R2) is 300. Gets clamped to 300.
+        fundingPot.contributeToRoundFor(
+            contributor2_, round2Id, 700, accessCriteriaId, new bytes32[](0)
+        );
+        // Verify contributor 2's contribution was clamped by personal cap.
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor2_),
+            300,
+            "C2 contribution should be clamped by personal cap"
+        );
+        vm.stopPrank();
+
+        // Verify total contributions after C2 is 300
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            300,
+            "Total after C2 should be 300"
+        );
+
+        // ------------ PART 2: VERIFY PERSONAL CAP NON-ACCUMULATION ------------
+        // Contributor 1 had 800 personal cap in R1, contributed 600, unused = 200.
+        // Contributor 1 has 300 personal cap in R2.
+        // In Total mode, personal cap does NOT roll over. Max contribution is 300.
+
+        // Prepare unspent caps struct (even though it shouldn't work for personal in Total mode)
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap({
+            roundId: round1Id,
+            accessCriteriaId: accessCriteriaId,
+            merkleProof: new bytes32[](0)
+        });
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 500);
+
+        // Attempt to contribute 400 ( > R2 personal cap 300)
+        // Total contributions = 300. Effective Round Cap = 900. Remaining Round Cap = 600.
+        // Personal Cap (R2) = 300. Unspent (R1) = 200, ignored in Total mode.
+        // Min(Remaining Round Cap, Remaining Personal Cap) = Min(600, 300) = 300.
+        // Should be clamped to 300.
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            400,
+            accessCriteriaId,
+            new bytes32[](0),
+            unspentCaps // Provide unspent caps, although they should be ignored for personal limit
+        );
+        // Verify contributor 1's contribution was clamped to their R2 personal cap.
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor1_),
+            300,
+            "C1 contribution should be clamped by personal cap"
+        );
+        vm.stopPrank();
+
+        // Verify total round contributions: 300 (C2) + 300 (C1) = 600
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            600,
+            "Total after C1 and C2 should be 600"
+        );
+        // Effective cap 900, current total 600. Remaining = 300.
+
+        // Contributor 3 contributes 300. Personal Cap = 300. Remaining Round Cap = 300. Should succeed.
+        vm.startPrank(contributor3_);
+        _token.approve(address(fundingPot), 300);
+        fundingPot.contributeToRoundFor(
+            contributor3_, round2Id, 300, accessCriteriaId, new bytes32[](0)
+        );
+        // Verify C3 contributed 300
+        assertEq(
+            fundingPot.getUserContributionToRound(round2Id, contributor3_),
+            300,
+            "C3 contributes remaining 300"
+        );
+        vm.stopPrank();
+
+        // Total contributions should now be 900 (300 + 300 + 300), matching the effective cap.
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            900,
+            "Total should match effective cap after C3"
+        );
+
+        // Now the effective cap is full. Try contributing 1 again.
+        vm.startPrank(contributor3_); // Can use C3 or another contributor
+        _token.approve(address(fundingPot), 1);
+
+        // Try contributing 1, expect revert as cap is full
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1
+                    .Module__LM_PC_FundingPot__RoundCapReached
+                    .selector
+            )
+        );
+        fundingPot.contributeToRoundFor(
+            contributor3_, round2Id, 1, accessCriteriaId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // Final total check should remain 900
+        assertEq(
+            fundingPot.getTotalRoundContribution(round2Id),
+            900,
+            "Final total should be effective cap"
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Test: closeRound()
 
@@ -2673,7 +4724,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
 
     function testCreatePaymentOrdersForContributorsBatch_revertsGivenRoundIsNotClosed(
     ) public {
-        testcontributeToRoundFor_worksGivenAllConditionsMet();
+        testContributeToRoundFor_worksGivenGenericConfigAndAccessCriteria();
         uint32 roundId = fundingPot.getRoundCount();
 
         vm.expectRevert(
@@ -3281,2170 +5332,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             nftContract,
             merkleRoot,
             allowedAddresses
-        );
-    }
-
-    function testContribute_PersonalMode_AccumulatesPersonalOnly() public {
-        // 1. Create the first round with AccumulationMode.Personal
-        _defaultRoundParams.accumulationMode =
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal;
-
-        fundingPot.createRound(
-            _defaultRoundParams.roundStart,
-            _defaultRoundParams.roundEnd,
-            1000, // Round cap of 1000
-            _defaultRoundParams.hookContract,
-            _defaultRoundParams.hookFunction,
-            _defaultRoundParams.autoClosure,
-            _defaultRoundParams.accumulationMode
-        );
-        uint32 round1Id = fundingPot.getRoundCount();
-
-        // Set up access criteria for round 1
-        uint8 accessCriteriaId = 1; // Open access
-        (
-            address nftContract,
-            bytes32 merkleRoot,
-            address[] memory allowedAddresses
-        ) = _helper_createAccessCriteria(
-            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id
-        );
-
-        fundingPot.setAccessCriteria(
-            round1Id,
-            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
-            0, // accessCriteriaId (0 for new)
-            nftContract,
-            merkleRoot,
-            allowedAddresses
-        );
-
-        // Set a personal cap of 500 for round 1
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessCriteriaId, 500, false, 0, 0, 0
-        );
-
-        // 2. Create the second round, also with AccumulationMode.Personal
-        // Use different start and end times to avoid overlap
-        RoundParams memory params = _helper_createEditRoundParams(
-            _defaultRoundParams.roundStart + 3 days,
-            _defaultRoundParams.roundEnd + 3 days,
-            500, // Round cap of 500
-            _defaultRoundParams.hookContract,
-            _defaultRoundParams.hookFunction,
-            _defaultRoundParams.autoClosure,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-
-        fundingPot.createRound(
-            params.roundStart,
-            params.roundEnd,
-            params.roundCap,
-            params.hookContract,
-            params.hookFunction,
-            params.autoClosure,
-            params.accumulationMode
-        );
-        uint32 round2Id = fundingPot.getRoundCount();
-
-        // Set up access criteria for round 2
-        fundingPot.setAccessCriteria(
-            round2Id,
-            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
-            0, // accessCriteriaId (0 for new)
-            nftContract,
-            merkleRoot,
-            allowedAddresses
-        );
-
-        // Set a personal cap of 400 for round 2
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessCriteriaId, 400, false, 0, 0, 0
-        );
-
-        // First round contribution: user contributes 200 out of their 500 personal cap
-        vm.warp(_defaultRoundParams.roundStart + 1);
-
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 1000);
-        fundingPot.contributeToRoundFor(
-            contributor1_, round1Id, 200, accessCriteriaId, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // Verify contribution to round 1
-        assertEq(
-            fundingPot.getUserContributionToRound(round1Id, contributor1_), 200
-        );
-
-        // Move to round 2
-        vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
-
-        // ------------ PART 1: VERIFY PERSONAL CAP ACCUMULATION ------------
-        // Create unspent capacity structure
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
-        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap({
-            roundId: round1Id,
-            accessCriteriaId: accessCriteriaId,
-            merkleProof: new bytes32[](0)
-        });
-
-        // Try to contribute more than the round 2 personal cap (400)
-        // In Personal mode, this should succeed up to the personal cap (400) + unspent from round 1 (300) = 700
-        // But capped by round cap of 500
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round2Id,
-            450, // More than the personal cap of round 2
-            accessCriteriaId,
-            new bytes32[](0),
-            unspentCaps
-        );
-        vm.stopPrank();
-
-        // Verify contributions to round 2 - should be more than the personal cap of round 2 (400)
-        // This verifies personal caps DO accumulate
-        uint contributionAmount =
-            fundingPot.getUserContributionToRound(round2Id, contributor1_);
-        assertEq(contributionAmount, 450);
-        assertTrue(contributionAmount > 400, "Personal cap should accumulate");
-
-        // ------------ PART 2: VERIFY TOTAL CAP NON-ACCUMULATION ------------
-        // Attempt to contribute more than the remaining round cap
-        vm.startPrank(contributor2_);
-        _token.approve(address(fundingPot), 200);
-
-        // Contributor 2 attempts to contribute 100.
-        // Since contributor1 contributed 450 and round cap is 500, only 50 is remaining.
-        // The contribution should be clamped to 50.
-        fundingPot.contributeToRoundFor(
-            contributor2_, round2Id, 100, accessCriteriaId, new bytes32[](0)
-        );
-        // Verify contributor 2's contribution was clamped to the remaining 50.
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor2_), 50
-        );
-        vm.stopPrank();
-
-        // Verify total contributions to round 2 is exactly the round cap (450 + 50 = 500).
-        assertEq(fundingPot.getTotalRoundContribution(round2Id), 500);
-
-        // Additional contributor3 should not be able to contribute anything as the cap is full.
-        // Attempting to contribute when the cap is already full should revert.
-        vm.startPrank(contributor3_);
-        _token.approve(address(fundingPot), 100);
-
-        // Expect revert because the round cap (500) is already met.
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__RoundCapReached
-                    .selector
-            )
-        );
-        fundingPot.contributeToRoundFor(
-            contributor3_, round2Id, 1, accessCriteriaId, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // Final check that total contributions remain at the round cap.
-        assertEq(fundingPot.getTotalRoundContribution(round2Id), 500);
-    }
-
-    function testContribute_TotalMode_AccumulatesTotalOnly() public {
-        // 1. Create the first round with AccumulationMode.Total
-        _defaultRoundParams.accumulationMode =
-            ILM_PC_FundingPot_v1.AccumulationMode.Total;
-
-        fundingPot.createRound(
-            _defaultRoundParams.roundStart,
-            _defaultRoundParams.roundEnd,
-            1000, // Round 1 cap of 1000
-            _defaultRoundParams.hookContract,
-            _defaultRoundParams.hookFunction,
-            _defaultRoundParams.autoClosure,
-            _defaultRoundParams.accumulationMode
-        );
-        uint32 round1Id = fundingPot.getRoundCount();
-
-        // Set up access criteria for round 1 (Open)
-        uint8 accessCriteriaId = 1;
-        (
-            address nftContract,
-            bytes32 merkleRoot,
-            address[] memory allowedAddresses
-        ) = _helper_createAccessCriteria(
-            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id
-        );
-
-        fundingPot.setAccessCriteria(
-            round1Id,
-            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
-            0, // accessCriteriaId (0 for new)
-            nftContract,
-            merkleRoot,
-            allowedAddresses
-        );
-
-        // Set a personal cap of 800 for round 1
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessCriteriaId, 800, false, 0, 0, 0
-        );
-
-        // 2. Create the second round, also with AccumulationMode.Total
-        RoundParams memory params = _helper_createEditRoundParams(
-            _defaultRoundParams.roundStart + 3 days,
-            _defaultRoundParams.roundEnd + 3 days,
-            500, // Round 2 base cap of 500
-            _defaultRoundParams.hookContract,
-            _defaultRoundParams.hookFunction,
-            _defaultRoundParams.autoClosure,
-            ILM_PC_FundingPot_v1.AccumulationMode.Total
-        );
-
-        fundingPot.createRound(
-            params.roundStart,
-            params.roundEnd,
-            params.roundCap,
-            params.hookContract,
-            params.hookFunction,
-            params.autoClosure,
-            params.accumulationMode
-        );
-        uint32 round2Id = fundingPot.getRoundCount();
-
-        // Set up access criteria for round 2 (Open)
-        fundingPot.setAccessCriteria(
-            round2Id,
-            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
-            0, // accessCriteriaId (0 for new)
-            nftContract,
-            merkleRoot,
-            allowedAddresses
-        );
-
-        // Set a personal cap of 300 for round 2
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessCriteriaId, 300, false, 0, 0, 0
-        );
-
-        // Round 1 contribution: contributor1 contributes 600 (less than round cap 1000, less than personal 800)
-        // Undersubscription: 1000 - 600 = 400
-        vm.warp(_defaultRoundParams.roundStart + 1);
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 1000);
-        fundingPot.contributeToRoundFor(
-            contributor1_, round1Id, 600, accessCriteriaId, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // Verify contribution to round 1
-        assertEq(
-            fundingPot.getUserContributionToRound(round1Id, contributor1_), 600
-        );
-        assertEq(fundingPot.getTotalRoundContribution(round1Id), 600);
-
-        // Move to round 2
-        vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
-
-        // ------------ PART 1: VERIFY TOTAL CAP ACCUMULATION ------------
-        // Effective Round 2 Cap = Base Cap (500) + Unused from Round 1 (400) = 900
-        vm.startPrank(contributor2_);
-        _token.approve(address(fundingPot), 1000); // Approve enough
-
-        // Contributor 2 attempts to contribute 700.
-        // Personal Cap (R2) is 300. Gets clamped to 300.
-        fundingPot.contributeToRoundFor(
-            contributor2_, round2Id, 700, accessCriteriaId, new bytes32[](0)
-        );
-        // Verify contributor 2's contribution was clamped by personal cap.
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor2_),
-            300,
-            "C2 contribution should be clamped by personal cap"
-        );
-        vm.stopPrank();
-
-        // Verify total contributions after C2 is 300
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            300,
-            "Total after C2 should be 300"
-        );
-
-        // ------------ PART 2: VERIFY PERSONAL CAP NON-ACCUMULATION ------------
-        // Contributor 1 had 800 personal cap in R1, contributed 600, unused = 200.
-        // Contributor 1 has 300 personal cap in R2.
-        // In Total mode, personal cap does NOT roll over. Max contribution is 300.
-
-        // Prepare unspent caps struct (even though it shouldn't work for personal in Total mode)
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
-        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap({
-            roundId: round1Id,
-            accessCriteriaId: accessCriteriaId,
-            merkleProof: new bytes32[](0)
-        });
-
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 500);
-
-        // Attempt to contribute 400 ( > R2 personal cap 300)
-        // Total contributions = 300. Effective Round Cap = 900. Remaining Round Cap = 600.
-        // Personal Cap (R2) = 300. Unspent (R1) = 200, ignored in Total mode.
-        // Min(Remaining Round Cap, Remaining Personal Cap) = Min(600, 300) = 300.
-        // Should be clamped to 300.
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round2Id,
-            400,
-            accessCriteriaId,
-            new bytes32[](0),
-            unspentCaps // Provide unspent caps, although they should be ignored for personal limit
-        );
-        // Verify contributor 1's contribution was clamped to their R2 personal cap.
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            300,
-            "C1 contribution should be clamped by personal cap"
-        );
-        vm.stopPrank();
-
-        // Verify total round contributions: 300 (C2) + 300 (C1) = 600
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            600,
-            "Total after C1 and C2 should be 600"
-        );
-        // Effective cap 900, current total 600. Remaining = 300.
-
-        // Contributor 3 contributes 300. Personal Cap = 300. Remaining Round Cap = 300. Should succeed.
-        vm.startPrank(contributor3_);
-        _token.approve(address(fundingPot), 300);
-        fundingPot.contributeToRoundFor(
-            contributor3_, round2Id, 300, accessCriteriaId, new bytes32[](0)
-        );
-        // Verify C3 contributed 300
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor3_),
-            300,
-            "C3 contributes remaining 300"
-        );
-        vm.stopPrank();
-
-        // Total contributions should now be 900 (300 + 300 + 300), matching the effective cap.
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            900,
-            "Total should match effective cap after C3"
-        );
-
-        // Now the effective cap is full. Try contributing 1 again.
-        vm.startPrank(contributor3_); // Can use C3 or another contributor
-        _token.approve(address(fundingPot), 1);
-
-        // Try contributing 1, expect revert as cap is full
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__RoundCapReached
-                    .selector
-            )
-        );
-        fundingPot.contributeToRoundFor(
-            contributor3_, round2Id, 1, accessCriteriaId, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // Final total check should remain 900
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            900,
-            "Final total should be effective cap"
-        );
-    }
-
-    // -------------------------------------------------------------------------
-    // Test: Global Accumulation Start Round Settings
-    // -------------------------------------------------------------------------
-
-    /* Test getGlobalAccumulationStartRoundId() and setGlobalAccumulationStart()
-    ├── For getGlobalAccumulationStartRoundId()
-    │   └── When no explicit value has been set
-    │       └── Then it should return the default value of 1
-    │
-    └── For setGlobalAccumulationStart()
-        ├── Given user does not have FUNDING_POT_ADMIN_ROLE
-        │   └── When user attempts to set the global accumulation start round
-        │       └── Then it should revert
-        │
-        ├── Given user has FUNDING_POT_ADMIN_ROLE
-        │   ├── And the provided start round ID is 0
-        │   │   └── When user attempts to set the global accumulation start round
-        │   │       └── Then it should revert
-        │   │
-        │   ├── And the provided start round ID is greater than the current round count
-        │   │   └── When user attempts to set the global accumulation start round
-        │   │       └── Then it should revert
-        │   │
-        │   └── And a valid start round ID is provided
-        │       └── When user attempts to set the global accumulation start round
-        │           ├── Then it should update the globalAccumulationStartRoundId state variable
-        │           ├── Then it should emit a GlobalAccumulationStartSet event
-        │           └── Then getGlobalAccumulationStartRoundId() should return the new value
-    */
-
-    function testGetGlobalAccumulationStartRoundId_returnsDefaultWhenNotSet()
-        public
-    {
-        // Expecting default value to be 1 as per AC
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            1,
-            "Default start round ID should be 1"
-        );
-    }
-
-    function testSetGlobalAccumulationStart_revertsGivenUserIsNotFundingPotAdmin(
-        address unauthorizedUser,
-        uint32 startRoundId
-    ) public {
-        vm.assume(unauthorizedUser != address(this));
-        vm.assume(startRoundId >= 1);
-
-        bytes32 roleId = _authorizer.generateRoleId(
-            address(fundingPot), fundingPot.FUNDING_POT_ADMIN_ROLE()
-        );
-
-        vm.startPrank(unauthorizedUser);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IModule_v1.Module__CallerNotAuthorized.selector,
-                roleId,
-                unauthorizedUser
-            )
-        );
-        fundingPot.setGlobalAccumulationStart(startRoundId);
-        vm.stopPrank();
-    }
-
-    function testSetGlobalAccumulationStart_revertsGivenStartRoundIsZero()
-        public
-    {
-        // AC: Must revert if startRoundId_ == 0
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__StartRoundCannotBeZero
-                    .selector
-            )
-        );
-        fundingPot.setGlobalAccumulationStart(0);
-    }
-
-    function testSetGlobalAccumulationStart_revertsGivenStartRoundGreaterThanCurrentRoundCount(
-        uint32 startRoundIdOffset
-    ) public {
-        testCreateRound(); // Ensure roundCount is at least 1
-        uint32 currentRoundCount = fundingPot.getRoundCount();
-
-        vm.assume(startRoundIdOffset > 0); // Ensure invalidStartRoundId will be greater
-        vm.assume(startRoundIdOffset <= type(uint32).max - currentRoundCount);
-
-        uint32 invalidStartRoundId = currentRoundCount + startRoundIdOffset;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__StartRoundGreaterThanRoundCount
-                    .selector,
-                invalidStartRoundId,
-                currentRoundCount
-            )
-        );
-        fundingPot.setGlobalAccumulationStart(invalidStartRoundId);
-    }
-
-    function testSetGlobalAccumulationStart_worksGivenValidParameters(
-        uint32 startRoundId
-    ) public {
-        // Ensure we have at least startRoundId rounds created if startRoundId > 0
-        if (startRoundId > 0) {
-            vm.assume(startRoundId <= 10); // Bound the fuzzing
-            for (
-                uint32 i = fundingPot.getRoundCount() + 1;
-                i <= startRoundId;
-                i++
-            ) {
-                fundingPot.createRound(
-                    _defaultRoundParams.roundStart + (i * 3 days),
-                    _defaultRoundParams.roundEnd + (i * 3 days),
-                    _defaultRoundParams.roundCap,
-                    _defaultRoundParams.hookContract,
-                    _defaultRoundParams.hookFunction,
-                    _defaultRoundParams.autoClosure,
-                    _defaultRoundParams.accumulationMode
-                );
-            }
-            vm.assume(startRoundId <= fundingPot.getRoundCount()); // Final check
-        } else {
-            vm.assume(startRoundId == 0);
-            // For startRoundId = 0, test should actually fail based on the revert check above
-            // However, fuzzing might pass 0. Let's test non-zero valid cases.
-            vm.assume(false); // This will cause fuzz to skip startRoundId = 0 here
-        }
-
-        // Expect event emission
-        vm.expectEmit(true, true, true, true);
-        emit ILM_PC_FundingPot_v1.GlobalAccumulationStartSet(startRoundId);
-
-        // Set the value
-        fundingPot.setGlobalAccumulationStart(startRoundId);
-
-        // Verify the value using the getter
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            startRoundId,
-            "Getter should return the set value"
-        );
-    }
-
-    // -------------------------------------------------------------------------
-    // Test: Global Accumulation Start Round - Logic Integration
-    // -------------------------------------------------------------------------
-
-    /* Test Accumulation Logic with Global Start Round
-    │
-    ├── Scenario: Global start round restricts accumulation
-    │   ├── Given globalAccumulationStartRoundId is set to 2 (e.g., R2)
-    │   │   ├── And target round (e.g., R3) uses AccumulationMode.Personal
-    │   │   │   └── When contributing to R3 with unspent capacity from R1 and R2
-    │   │   │       └── Then only unspent personal capacity from R2 should be considered
-    │   │   ├── And target round (e.g., R3) uses AccumulationMode.Total
-    │   │   │   └── When contributing to R3
-    │   │   │       └── Then only unspent total capacity from R2 should expand R3's effective cap
-    │   │   └── And target round (e.g., R3) uses AccumulationMode.All
-    │   │       ├── When contributing to R3 with unspent personal capacity from R1 and R2
-    │   │       │   └── Then only unspent personal capacity from R2 should be considered
-    │   │       └── When calculating R3's effective total cap
-    │   │           └── Then only unspent total capacity from R2 should expand R3's effective cap
-    │
-    ├── Scenario: Default global start round (1) allows accumulation from all previous applicable rounds
-    │   ├── Given globalAccumulationStartRoundId is 1 (default)
-    │   │   ├── And target round (e.g., R2 or R3) uses AccumulationMode.Personal
-    │   │   │   └── When contributing with unspent capacity from all previous valid rounds (e.g., R1 for R2; R1 & R2 for R3)
-    │   │   │       └── Then unspent personal capacity from all applicable previous rounds should be considered
-    │   │   ├── And target round (e.g., R2 or R3) uses AccumulationMode.Total
-    │   │   │   └── When calculating effective total cap
-    │   │   │       └── Then unspent total capacity from all applicable previous rounds should expand the effective cap
-    │   │   └── And target round (e.g., R2 or R3) uses AccumulationMode.All
-    │   │       ├── When contributing with unspent personal capacity from all previous valid rounds
-    │   │       │   └── Then unspent personal capacity from all applicable previous rounds should be considered
-    │   │       └── When calculating effective total cap
-    │   │           └── Then unspent total capacity from all applicable previous rounds should expand the effective cap
-    │
-    ├── Scenario: Interaction with AccumulationMode.Disabled
-    │   └── Given target round's AccumulationMode is Disabled
-    │       └── When globalAccumulationStartRoundId is set to allow previous rounds
-    │           └── Then no accumulation (personal or total) should occur for the target round
-    │
-    └── Scenario: Global start round equals target round
-        └── Given globalAccumulationStartRoundId is set to the target round's ID
-            └── When target round's AccumulationMode would normally allow accumulation
-                └── Then no accumulation (personal or total) from any *previous* round should occur
-    */
-
-    function testContribute_personalMode_globalStartRestrictsAccumulationFromEarlierRounds(
-    ) public {
-        // SCENARIO: globalAccumulationStartRoundId = 2 restricts accumulation from Round 1 for Personal mode
-        // 1. Setup: Round 1, Round 2, Round 3. Partial contributions in R1 & R2.
-        // 2. Action: setGlobalAccumulationStart(2)
-        // 3. Verification: For contributions to R3 (Personal mode), only unused personal from R2 rolls over.
-
-        uint initialTimestamp = block.timestamp;
-
-        // --- Setup Rounds ---
-        uint r1PersonalCap = 500;
-        uint r1Contribution = 100;
-        // uint r1UnusedPersonal = r1PersonalCap - r1Contribution; // Not used in this restricted scenario directly for R3 calc
-
-        uint r2PersonalCap = 600;
-        uint r2Contribution = 200;
-        uint r2UnusedPersonal = r2PersonalCap - r2Contribution; // This IS used for R3 calculation
-
-        uint r3BasePersonalCap = 300;
-
-        // Round 1
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            10_000, // large round cap
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
-        ); // Open access
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, 1, r1PersonalCap, false, 0, 0, 0
-        );
-
-        // Round 2
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            10_000, // large round cap
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, 1, r2PersonalCap, false, 0, 0, 0
-        );
-
-        // Round 3
-        uint32 round3Id = fundingPot.createRound(
-            initialTimestamp + 5 days,
-            initialTimestamp + 6 days,
-            10_000, // large round cap
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round3Id, 1, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round3Id, 1, r3BasePersonalCap, false, 0, 0, 0
-        );
-
-        // --- Contributions ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-
-        vm.warp(initialTimestamp + 1 days + 1 hours); // Enter Round 1
-        fundingPot.contributeToRoundFor(
-            contributor1_, round1Id, r1Contribution, 1, new bytes32[](0)
-        );
-
-        vm.warp(initialTimestamp + 3 days + 1 hours); // Enter Round 2
-        fundingPot.contributeToRoundFor(
-            contributor1_, round2Id, r2Contribution, 1, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Set Global Start ---
-        fundingPot.setGlobalAccumulationStart(2);
-        assertEq(fundingPot.getGlobalAccumulationStartRoundId(), 2);
-
-        // --- Attempt Contribution in Round 3 ---
-        vm.warp(initialTimestamp + 5 days + 1 hours); // Enter Round 3
-
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
-        // User claims unspent from R1 (should be ignored due to global start)
-        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id, 1, new bytes32[](0)
-        );
-        // User claims unspent from R2 (should be counted)
-        unspentCaps[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round2Id, 1, new bytes32[](0)
-        );
-
-        uint expectedR3PersonalCap = r3BasePersonalCap + r2Contribution; // Only R2's unused personal cap
-
-        vm.startPrank(contributor1_);
-        // Attempt to contribute up to the expected new personal cap
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round3Id,
-            expectedR3PersonalCap,
-            1,
-            new bytes32[](0),
-            unspentCaps
-        );
-        vm.stopPrank();
-
-        // --- Assertion ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round3Id, contributor1_),
-            expectedR3PersonalCap,
-            "R3 personal contribution incorrect"
-        );
-    }
-
-    function testContribute_totalMode_globalStartRestrictsAccumulationFromEarlierRounds(
-    ) public {
-        // SCENARIO: globalAccumulationStartRoundId = 2 restricts accumulation from Round 1 for Total mode
-        // 1. Setup: Round 1, Round 2, Round 3. Partial contributions in R1 & R2.
-        // 2. Action: setGlobalAccumulationStart(2)
-        // 3. Verification: For contributions to R3 (Total mode), only unused total from R2 expands R3 cap.
-
-        uint initialTimestamp = block.timestamp;
-
-        // --- Setup Rounds ---
-        uint r1BaseCap = 1000;
-        uint r1Contribution = 400;
-        // uint r1UnusedTotal = r1BaseCap - r1Contribution;
-
-        uint r2BaseCap = 1200;
-        uint r2Contribution = 500;
-        // uint r2UnusedTotal = r2BaseCap - r2Contribution;
-
-        uint r3BaseCap = 300;
-
-        // Round 1
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            r1BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Total
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
-        ); // Open access
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, 1, r1BaseCap, false, 0, 0, 0
-        ); // Personal cap equals round cap
-
-        // Round 2
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            r2BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Total
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, 1, r2BaseCap, false, 0, 0, 0
-        );
-
-        // Round 3
-        uint32 round3Id = fundingPot.createRound(
-            initialTimestamp + 5 days,
-            initialTimestamp + 6 days,
-            r3BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Total
-        );
-        fundingPot.setAccessCriteria(
-            round3Id, 1, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round3Id, 1, r3BaseCap + r2Contribution, false, 0, 0, 0
-        ); // Allow full contribution for testing effective cap
-
-        // --- Contributions ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-
-        vm.warp(initialTimestamp + 1 days + 1 hours); // Enter Round 1
-        fundingPot.contributeToRoundFor(
-            contributor1_, round1Id, r1Contribution, 1, new bytes32[](0)
-        );
-
-        vm.warp(initialTimestamp + 3 days + 1 hours); // Enter Round 2
-        fundingPot.contributeToRoundFor(
-            contributor1_, round2Id, r2Contribution, 1, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Set Global Start ---
-        fundingPot.setGlobalAccumulationStart(2);
-        assertEq(fundingPot.getGlobalAccumulationStartRoundId(), 2);
-
-        // --- Attempt Contribution in Round 3 ---
-        vm.warp(initialTimestamp + 5 days + 1 hours); // Enter Round 3
-
-        uint expectedR3EffectiveCap = r3BaseCap + r2Contribution; // Only R2's unused total cap
-
-        vm.startPrank(contributor1_);
-        // Attempt to contribute up to the expected new effective cap
-        fundingPot.contributeToRoundFor(
-            contributor1_, round3Id, expectedR3EffectiveCap, 1, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Assertion ---
-        assertEq(
-            fundingPot.getTotalRoundContribution(round3Id),
-            expectedR3EffectiveCap,
-            "R3 total contribution incorrect, effective cap not as expected"
-        );
-        assertEq(
-            fundingPot.getUserContributionToRound(round3Id, contributor1_),
-            expectedR3EffectiveCap,
-            "R3 user contribution incorrect"
-        );
-    }
-
-    function testContribute_personalMode_defaultGlobalStartAllowsAccumulationFromAllPrevious(
-    ) public {
-        // SCENARIO: Default globalAccumulationStartRoundId = 1 allows accumulation from R1 for R2 (Personal mode)
-        // 1. Setup: Round 1 (Personal), Round 2 (Personal).
-        //    Partial contribution by C1 in R1.
-        // 2. Action: Verify getGlobalAccumulationStartRoundId() == 1 (default).
-        // 3. Verification: For C1's contribution to R2, unused personal capacity from R1 rolls over.
-
-        uint initialTimestamp = block.timestamp;
-        uint8 accessId = 1; // Open access
-
-        // --- Round Parameters & Contributions for C1 ---
-        uint r1PersonalCapC1 = 500;
-        uint r1ContributionC1 = 100; // C1 leaves 400 personal unused from R1
-
-        uint r2BasePersonalCapC1 = 300; // C1's base personal cap in R2
-
-        // --- Approvals ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // --- Create Round 1 (Personal Mode) ---
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            10_000, // Large round cap, not relevant for personal accumulation focus
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Create Round 2 (Personal Mode) ---
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            10_000, // Large round cap
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 1 ---
-        vm.startPrank(contributor1_);
-        vm.warp(initialTimestamp + 1 days + 1 hours); // Enter Round 1
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round1Id,
-            r1ContributionC1,
-            accessId,
-            new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Verify Default Global Start Round ID ---
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            1,
-            "Default global start round ID should be 1"
-        );
-
-        // --- Attempt Contribution in Round 2 by C1 ---
-        vm.warp(initialTimestamp + 3 days + 1 hours); // Enter Round 2
-
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
-        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id,
-            accessId,
-            new bytes32[](0) // Should be counted
-        );
-
-        uint r1UnusedPersonalC1 = r1PersonalCapC1 - r1ContributionC1; // 400
-
-        // Expected C1 effective personal cap in R2 = R2_Base (300) + R1_Unused (400) = 700
-        uint expectedC1EffectivePersonalCapR2 =
-            r2BasePersonalCapC1 + r1UnusedPersonalC1;
-
-        uint c1AttemptR2 = expectedC1EffectivePersonalCapR2 + 50; // Try to contribute slightly more
-        uint expectedC1ContributionR2 = expectedC1EffectivePersonalCapR2; // Should be clamped
-
-        // Ensure the attempt is not clamped by the round cap (which is large)
-        if (expectedC1ContributionR2 > 10_000) {
-            // 10_000 is round cap for R2
-            expectedC1ContributionR2 = 10_000;
-        }
-
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round2Id,
-            c1AttemptR2,
-            accessId,
-            new bytes32[](0),
-            unspentCapsC1
-        );
-        vm.stopPrank();
-
-        // --- Assertion ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            expectedC1ContributionR2,
-            "R2 C1 personal contribution incorrect (should use R1 unused)"
-        );
-    }
-
-    function testContribute_totalMode_defaultGlobalStartAllowsAccumulationFromAllPrevious(
-    ) public {
-        // SCENARIO: Default globalAccumulationStartRoundId = 1 allows total cap accumulation from R1 to R2 (Total mode)
-        // Simplified to reduce stack depth.
-
-        uint initialTimestamp = block.timestamp;
-        uint8 accessId = 1; // Open access
-
-        // --- Round 1 Parameters & Contribution ---
-        uint r1BaseCap = 1000;
-        uint r1ContributionC1 = 600; // Leaves 400 unused total from R1
-        uint r1PersonalCap = 1000;
-
-        // --- Round 2 Parameters ---
-        uint r2BaseCap = 500;
-
-        // --- Approvals ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // --- Create Round 1 (Total Mode) ---
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            r1BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Total
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, r1PersonalCap, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 1 ---
-        vm.warp(initialTimestamp + 1 days + 1 hours);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round1Id,
-            r1ContributionC1,
-            accessId,
-            new bytes32[](0)
-        );
-        vm.stopPrank();
-        uint r1UnusedTotal = r1BaseCap - r1ContributionC1; // Should be 400
-
-        // --- Create Round 2 (Total Mode) ---
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            r2BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Total
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        // Set personal cap for R2 to be at least the expected effective total cap
-        uint r2ExpectedEffectiveTotalCap = r2BaseCap + r1UnusedTotal; // 500 + 400 = 900
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, r2ExpectedEffectiveTotalCap, false, 0, 0, 0
-        );
-
-        // --- Verify Default Global Start Round ID ---
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            1,
-            "Default global start round ID should be 1"
-        );
-
-        // --- Attempt Contribution in Round 2 by C1 ---
-        vm.warp(initialTimestamp + 3 days + 1 hours);
-
-        uint c1AttemptR2 = r2ExpectedEffectiveTotalCap - 100; // e.g., 900 - 100 = 800. Utilizes expanded cap.
-        assertTrue(
-            c1AttemptR2 > r2BaseCap, "C1 R2 attempt should be > R2 base cap"
-        );
-        assertTrue(
-            c1AttemptR2 <= r2ExpectedEffectiveTotalCap,
-            "C1 R2 attempt should be <= R2 effective cap"
-        );
-
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_, round2Id, c1AttemptR2, accessId, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Assertions ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            c1AttemptR2,
-            "R2 C1 contribution incorrect"
-        );
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            c1AttemptR2,
-            "R2 Total contributions after C1 incorrect"
-        );
-
-        // Verify that the total contributions possible is indeed the effective cap
-        uint remainingToFill = r2ExpectedEffectiveTotalCap - c1AttemptR2;
-        if (remainingToFill > 0) {
-            vm.startPrank(contributor1_);
-            fundingPot.contributeToRoundFor(
-                contributor1_,
-                round2Id,
-                remainingToFill,
-                accessId,
-                new bytes32[](0)
-            );
-            vm.stopPrank();
-        }
-
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            r2ExpectedEffectiveTotalCap,
-            "R2 final total contributions should match effective total cap"
-        );
-    }
-
-    function testContribute_disabledMode_ignoresGlobalStartAndPreventsAccumulation(
-    ) public {
-        // SCENARIO: AccumulationMode.Disabled on a target round (R2) prevents any accumulation
-        // from a previous round (R1), even if globalAccumulationStartRoundId would allow it.
-
-        uint initialTimestamp = block.timestamp;
-        uint8 accessId = 1; // Open access
-
-        // --- Round 1 Parameters ---
-        uint r1PersonalCapC1 = 500;
-        uint r1ContributionC1 = 100;
-        uint r1BaseCap = 1000;
-
-        // --- Round 2 Parameters (Disabled Mode) ---
-        uint r2BasePersonalCapC1 = 50;
-        uint r2BaseCap = 200;
-
-        // --- Approvals ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // --- Create Round 1 (Personal Mode to generate unused personal capacity) ---
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            r1BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 1 ---
-        vm.warp(initialTimestamp + 1 days + 1 hours);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round1Id,
-            r1ContributionC1,
-            accessId,
-            new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Create Round 2 (Disabled Mode) ---
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            r2BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Disabled
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Set Global Start Round ID to allow R1 (to show it's ignored by R2's Disabled mode) ---
-        fundingPot.setGlobalAccumulationStart(1);
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            1,
-            "Global start round ID should be 1"
-        );
-
-        // --- Attempt Contribution in Round 2 by C1 ---
-        vm.warp(initialTimestamp + 3 days + 1 hours);
-
-        uint c1AttemptR2 = r2BasePersonalCapC1 + 100;
-
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
-        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id, accessId, new bytes32[](0)
-        );
-
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round2Id,
-            c1AttemptR2,
-            accessId,
-            new bytes32[](0),
-            unspentCapsC1
-        );
-        vm.stopPrank();
-
-        // --- Assertions ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            r2BasePersonalCapC1,
-            "R2 C1 personal contribution should be clamped by R2's base personal cap (Disabled mode)"
-        );
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            r2BasePersonalCapC1,
-            "R2 Total contributions should not be expanded by R1 (Disabled mode)"
-        );
-        assertTrue(
-            fundingPot.getTotalRoundContribution(round2Id) <= r2BaseCap,
-            "R2 Total contributions exceeded R2's original base cap (Disabled mode)"
-        );
-    }
-
-    function testContribute_anyAccumulativeMode_noAccumulationWhenGlobalStartEqualsTargetRound(
-    ) public {
-        // SCENARIO: If globalAccumulationStartRoundId is set to the target round's ID (R2),
-        // no accumulation from any previous round (R1) occurs for R2, even if R2's mode would allow it.
-
-        uint initialTimestamp = block.timestamp;
-        uint8 accessId = 1; // Open access
-
-        // --- Round 1 Parameters ---
-        uint r1PersonalCapC1 = 500;
-        uint r1ContributionC1 = 100;
-        uint r1BaseCap = 1000;
-
-        // --- Round 2 Parameters (Mode that would normally allow accumulation, e.g., Personal) ---
-        uint r2BasePersonalCapC1 = 50;
-        uint r2BaseCap = 200;
-
-        // --- Approvals ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // --- Create Round 1 (Personal Mode to generate unused personal capacity) ---
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            r1BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 1 ---
-        vm.warp(initialTimestamp + 1 days + 1 hours);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round1Id,
-            r1ContributionC1,
-            accessId,
-            new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Create Round 2 (Personal Mode - would normally allow accumulation from R1) ---
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            r2BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Set Global Start Round ID to be Round 2's ID ---
-        fundingPot.setGlobalAccumulationStart(round2Id);
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            round2Id,
-            "Global start round ID not set to R2 ID"
-        );
-
-        // --- Attempt Contribution in Round 2 by C1 ---
-        vm.warp(initialTimestamp + 3 days + 1 hours);
-
-        uint c1AttemptR2 = r2BasePersonalCapC1 + 100;
-
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
-        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id, accessId, new bytes32[](0)
-        );
-
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round2Id,
-            c1AttemptR2,
-            accessId,
-            new bytes32[](0),
-            unspentCapsC1
-        );
-        vm.stopPrank();
-
-        // --- Assertions ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            r2BasePersonalCapC1,
-            "R2 C1 personal contribution should be clamped by R2's base personal cap (global start = R2)"
-        );
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            r2BasePersonalCapC1,
-            "R2 Total contributions should not be expanded by R1 (global start = R2)"
-        );
-        assertTrue(
-            fundingPot.getTotalRoundContribution(round2Id) <= r2BaseCap,
-            "R2 Total contributions exceeded R2's original base cap (global start = R2)"
-        );
-    }
-
-    // -------------------------------------------------------------------------
-    // Test: Global Accumulation Start Round - Logic Integration - Remaining Tests
-    // (Covers multi-round accumulation where global start allows all previous)
-    // -------------------------------------------------------------------------
-
-    function testContribute_personalMode_defaultGlobalStartAllowsAccumulationFromMultiplePreviousRounds(
-    ) public {
-        // SCENARIO: globalAccumulationStartRoundId = 1 allows personal cap accumulation from R1 AND R2
-        // for contributions to R3, when all rounds are in Personal mode.
-        // 1. Setup: R1, R2, R3 in Personal mode. C1 makes partial contributions in R1 & R2.
-        // 2. Action: Verify globalAccumulationStartRoundId = 1. C1 contributes to R3.
-        // 3. Verification: C1's effective personal cap in R3 includes unused from R1 and R2.
-
-        uint initialTimestamp = block.timestamp;
-
-        // --- Round Parameters, Personal Caps, and Contributions for contributor1_ ---
-        uint r1PersonalCapC1 = 500;
-        uint r1ContributionC1 = 200;
-
-        uint r2PersonalCapC1 = 600;
-        uint r2ContributionC1 = 250;
-
-        uint r3BasePersonalCapC1 = 300;
-
-        uint largeRoundCap = 1_000_000;
-
-        // --- Approvals ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // --- Create Round 1 (Personal Mode) ---
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            largeRoundCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, 1, r1PersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 1 ---
-        vm.warp(initialTimestamp + 1 days + 1 hours);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_, round1Id, r1ContributionC1, 1, new bytes32[](0)
-        );
-        vm.stopPrank();
-        assertEq(
-            fundingPot.getUserContributionToRound(round1Id, contributor1_),
-            r1ContributionC1
-        );
-
-        // --- Create Round 2 (Personal Mode) ---
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            largeRoundCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, 1, r2PersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 2 ---
-        vm.warp(initialTimestamp + 3 days + 1 hours);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_, round2Id, r2ContributionC1, 1, new bytes32[](0)
-        );
-        vm.stopPrank();
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            r2ContributionC1
-        );
-
-        // --- Create Round 3 (Personal Mode) ---
-        uint32 round3Id = fundingPot.createRound(
-            initialTimestamp + 5 days,
-            initialTimestamp + 6 days,
-            largeRoundCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round3Id, 1, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round3Id, 1, r3BasePersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Verify Global Start Round ID ---
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            1,
-            "Default global start round ID should be 1"
-        );
-
-        // --- Attempt Contribution in Round 3 by C1 ---
-        vm.warp(initialTimestamp + 5 days + 1 hours);
-
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
-        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id, 1, new bytes32[](0)
-        );
-        unspentCapsC1[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round2Id, 1, new bytes32[](0)
-        );
-
-        uint expectedR3PersonalCapC1 = r3BasePersonalCapC1
-            + (r1PersonalCapC1 - r1ContributionC1)
-            + (r2PersonalCapC1 - r2ContributionC1);
-
-        uint c1AttemptR3 = expectedR3PersonalCapC1;
-
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round3Id,
-            c1AttemptR3,
-            1,
-            new bytes32[](0),
-            unspentCapsC1
-        );
-        vm.stopPrank();
-
-        // --- Assertions ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round3Id, contributor1_),
-            expectedR3PersonalCapC1,
-            "R3 C1 personal contribution incorrect (should use R1 & R2 unused)"
-        );
-        assertEq(
-            fundingPot.getTotalRoundContribution(round3Id),
-            expectedR3PersonalCapC1,
-            "R3 total contributions incorrect after C1"
-        );
-
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 1);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__PersonalCapReached
-                    .selector
-            )
-        );
-        fundingPot.contributeToRoundFor(
-            contributor1_, round3Id, 1, 1, new bytes32[](0), unspentCapsC1
-        );
-        vm.stopPrank();
-    }
-
-    function testContribute_totalMode_defaultGlobalStartAllowsAccumulationFromMultiplePreviousRounds(
-    ) public {
-        // SCENARIO: globalAccumulationStartRoundId = 1 allows accumulation from Round 1 AND Round 2 for Total mode
-        // 1. Setup: Round 1, Round 2, Round 3. Partial total contributions in R1 & R2. All in Total mode.
-        // 2. Action: setGlobalAccumulationStart(1) (or verify default).
-        // 3. Verification: For contributions to R3 (Total mode), unused total from R1 AND R2 rolls over, expanding R3's effective cap.
-
-        uint initialTimestamp = block.timestamp;
-
-        // --- Round Parameters & Contributions ---
-        uint r1BaseCap = 1000;
-        uint r1ContributionC1 = 400;
-
-        uint r2BaseCap = 1200;
-        uint r2ContributionC2 = 700;
-
-        uint r3BaseCap = 300;
-
-        // --- Approvals ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        vm.startPrank(contributor2_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        vm.startPrank(contributor3_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // --- Create Round 1 (Total Mode) ---
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            r1BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Total
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, 1, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, 1, r1BaseCap, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 1 ---
-        vm.warp(initialTimestamp + 1 days + 1 hours);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_, round1Id, r1ContributionC1, 1, new bytes32[](0)
-        );
-        vm.stopPrank();
-        assertEq(
-            fundingPot.getTotalRoundContribution(round1Id), r1ContributionC1
-        );
-
-        // --- Create Round 2 (Total Mode) ---
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            r2BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Total
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, 1, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, 1, r2BaseCap, false, 0, 0, 0
-        );
-
-        // --- Contribution by C2 to Round 2 ---
-        vm.warp(initialTimestamp + 3 days + 1 hours);
-        vm.startPrank(contributor2_);
-        fundingPot.contributeToRoundFor(
-            contributor2_, round2Id, r2ContributionC2, 1, new bytes32[](0)
-        );
-        vm.stopPrank();
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id), r2ContributionC2
-        );
-
-        // --- Create Round 3 (Total Mode) ---
-        uint r3ExpectedEffectiveCap = r3BaseCap + (r1BaseCap - r1ContributionC1)
-            + (r2BaseCap - r2ContributionC2);
-        uint32 round3Id = fundingPot.createRound(
-            initialTimestamp + 5 days,
-            initialTimestamp + 6 days,
-            r3BaseCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Total
-        );
-        (address nftR3, bytes32 merkleR3, address[] memory allowedR3) =
-            _helper_createAccessCriteria(1, round3Id);
-
-        // TODO
-        fundingPot.setAccessCriteria(round3Id, 1, 0, nftR3, merkleR3, allowedR3);
-        fundingPot.setAccessCriteriaPrivileges(
-            round3Id, 1, r3ExpectedEffectiveCap, false, 0, 0, 0
-        );
-
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            1,
-            "Default global start round ID should be 1"
-        );
-
-        // --- Attempt Contribution in Round 3 by C3 ---
-        vm.warp(initialTimestamp + 5 days + 1 hours);
-
-        vm.startPrank(contributor3_);
-        fundingPot.contributeToRoundFor(
-            contributor3_, round3Id, r3ExpectedEffectiveCap, 1, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Assertions ---
-        assertEq(
-            fundingPot.getTotalRoundContribution(round3Id),
-            r3ExpectedEffectiveCap,
-            "R3 total contributions should match effective cap with rollover from R1 and R2"
-        );
-        assertEq(
-            fundingPot.getUserContributionToRound(round3Id, contributor3_),
-            r3ExpectedEffectiveCap,
-            "R3 C3 contribution incorrect"
-        );
-
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), 1);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__RoundCapReached
-                    .selector
-            )
-        );
-        fundingPot.contributeToRoundFor(
-            contributor1_, round3Id, 1, 1, new bytes32[](0)
-        );
-        vm.stopPrank();
-    }
-
-    function testContribute_allMode_defaultGlobalStartAllowsPersonalCapAccumulationFromAllPrevious(
-    ) public {
-        // SCENARIO: globalAccumulationStartRoundId = 1 allows personal cap
-        // accumulation from R1 to R2, when both are in All mode. (Simplified for stack)
-
-        uint initialTimestamp = block.timestamp;
-        uint8 accessId = 1;
-
-        // --- Round 1: Setup & C1 Contribution ---
-        uint r1PersonalCapC1 = 500;
-        uint r1ContributionC1 = 100;
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            1000,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.All
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
-        );
-
-        vm.warp(initialTimestamp + 1 days + 1 hours);
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round1Id,
-            r1ContributionC1,
-            accessId,
-            new bytes32[](0)
-        );
-        vm.stopPrank();
-        uint r1UnusedPersonalForC1 = r1PersonalCapC1 - r1ContributionC1;
-
-        // --- Round 2: Setup ---
-        uint r2BasePersonalCapC1 = 200;
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            2000,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.All
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Global Start ID Check ---
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            1,
-            "Default global start ID is 1"
-        );
-
-        // --- C1 Contribution to Round 2 (Testing Personal Cap Rollover) ---
-        vm.warp(initialTimestamp + 3 days + 1 hours);
-        uint expectedEffectivePersonalCapC1R2 =
-            r2BasePersonalCapC1 + r1UnusedPersonalForC1;
-        uint c1AttemptR2 = expectedEffectivePersonalCapC1R2 + 50;
-
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
-        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id, accessId, new bytes32[](0)
-        );
-
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round2Id,
-            c1AttemptR2,
-            accessId,
-            new bytes32[](0),
-            unspentCapsC1
-        );
-        vm.stopPrank();
-
-        // --- Assertions ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            expectedEffectivePersonalCapC1R2,
-            "R2 C1 personal contribution incorrect"
-        );
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            expectedEffectivePersonalCapC1R2,
-            "R2 Total contributions incorrect"
-        );
-    }
-
-    function testContribute_allMode_defaultGlobalStartAllowsTotalCapAccumulationFromAllPrevious(
-    ) public {
-        // SCENARIO: globalAccumulationStartRoundId = 1 (default or set) allows total cap
-        // accumulation from R1 to R2, when both are in All mode.
-
-        uint initialTimestamp = block.timestamp;
-        uint8 accessId = 1; // Open access
-
-        // --- Round 1 Parameters (All Mode) ---
-        uint r1BaseTotalCap = 1000;
-        uint r1C1PersonalCap = 800;
-        uint r1C1Contribution = 600;
-
-        // --- Round 2 Parameters (All Mode) ---
-        uint r2BaseTotalCap = 500;
-
-        // --- Approvals ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // --- Create Round 1 (All Mode) ---
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            r1BaseTotalCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.All
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, r1C1PersonalCap, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 1 ---
-        vm.warp(initialTimestamp + 1 days + 1 hours);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round1Id,
-            r1C1Contribution,
-            accessId,
-            new bytes32[](0)
-        );
-        vm.stopPrank();
-        uint r1UnusedTotal = r1BaseTotalCap - r1C1Contribution;
-
-        // --- Create Round 2 (All Mode) ---
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            r2BaseTotalCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.All
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        uint r2ExpectedEffectiveTotalCap = r2BaseTotalCap + r1UnusedTotal;
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, r2ExpectedEffectiveTotalCap, false, 0, 0, 0
-        );
-
-        // --- Ensure Global Start Round ID is 1 ---
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            1,
-            "Global start round ID should be 1 by default"
-        );
-
-        // --- Attempt Contribution in Round 2 by C1 to fill effective total cap ---
-        vm.warp(initialTimestamp + 3 days + 1 hours);
-
-        uint c1AttemptR2 = r2ExpectedEffectiveTotalCap;
-
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_, round2Id, c1AttemptR2, accessId, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Assertions ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            c1AttemptR2,
-            "R2 C1 contribution should match attempt (filling effective total cap)"
-        );
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            r2ExpectedEffectiveTotalCap,
-            "R2 Total contributions should match effective total cap (All mode, global_start=1)"
-        );
-    }
-
-    function testContribute_allMode_globalStartRestrictsPersonalCapAccumulationFromEarlierRounds(
-    ) public {
-        // SCENARIO: globalAccumulationStartRoundId = 2 restricts personal cap accumulation
-        // from R1 for R2, when both are in All mode.
-
-        uint initialTimestamp = block.timestamp;
-        uint8 accessId = 1; // Open access
-
-        // --- Round 1 Parameters (All Mode) ---
-        uint r1PersonalCapC1 = 500;
-        uint r1ContributionC1 = 100;
-        uint r1BaseTotalCap = 1000;
-
-        // --- Round 2 Parameters (All Mode) ---
-        uint r2BasePersonalCapC1 = 50;
-        uint r2BaseTotalCap = 1000;
-
-        // --- Approvals ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // --- Create Round 1 (All Mode) ---
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            r1BaseTotalCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.All
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, r1PersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 1 ---
-        vm.warp(initialTimestamp + 1 days + 1 hours);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round1Id,
-            r1ContributionC1,
-            accessId,
-            new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Create Round 2 (All Mode) ---
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            r2BaseTotalCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.All
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, r2BasePersonalCapC1, false, 0, 0, 0
-        );
-
-        // --- Set Global Start Round ID to Round 2's ID ---
-        fundingPot.setGlobalAccumulationStart(round2Id);
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            round2Id,
-            "Global start ID not set to R2 ID"
-        );
-
-        // --- Attempt Contribution in Round 2 by C1 ---
-        vm.warp(initialTimestamp + 3 days + 1 hours);
-
-        uint c1AttemptR2 = r2BasePersonalCapC1 + 100;
-
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsC1 =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
-        unspentCapsC1[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id, accessId, new bytes32[](0)
-        );
-
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round2Id,
-            c1AttemptR2,
-            accessId,
-            new bytes32[](0),
-            unspentCapsC1
-        );
-        vm.stopPrank();
-
-        // --- Assertions ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            r2BasePersonalCapC1,
-            "R2 C1 personal contribution should be clamped by R2 base personal cap (All mode, global_start=R2)"
-        );
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            r2BasePersonalCapC1,
-            "R2 Total contributions should be C1's clamped amount (All mode, global_start=R2)"
-        );
-    }
-
-    function testContribute_allMode_globalStartRestrictsTotalCapAccumulationFromEarlierRounds(
-    ) public {
-        // SCENARIO: globalAccumulationStartRoundId = 2 restricts total cap accumulation
-        // from R1 for R2, when both are in All mode.
-
-        uint initialTimestamp = block.timestamp;
-        uint8 accessId = 1; // Open access
-
-        // --- Round 1 Parameters (All Mode) ---
-        uint r1BaseTotalCap = 1000;
-        uint r1C1PersonalCap = 800;
-        uint r1C1Contribution = 400;
-
-        // --- Round 2 Parameters (All Mode) ---
-        uint r2BaseTotalCap = 200;
-
-        // --- Approvals ---
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // --- Create Round 1 (All Mode) ---
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            r1BaseTotalCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.All
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, r1C1PersonalCap, false, 0, 0, 0
-        );
-
-        // --- Contribution by C1 to Round 1 ---
-        vm.warp(initialTimestamp + 1 days + 1 hours);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round1Id,
-            r1C1Contribution,
-            accessId,
-            new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Create Round 2 (All Mode) ---
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            r2BaseTotalCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.All
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, r2BaseTotalCap, false, 0, 0, 0
-        );
-
-        // --- Set Global Start Round ID to Round 2's ID ---
-        fundingPot.setGlobalAccumulationStart(round2Id);
-        assertEq(
-            fundingPot.getGlobalAccumulationStartRoundId(),
-            round2Id,
-            "Global start ID not set to R2 ID"
-        );
-
-        // --- Attempt Contribution in Round 2 by C1 ---
-        vm.warp(initialTimestamp + 3 days + 1 hours);
-
-        uint c1AttemptR2 = r2BaseTotalCap + 100;
-
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor(
-            contributor1_, round2Id, c1AttemptR2, accessId, new bytes32[](0)
-        );
-        vm.stopPrank();
-
-        // --- Assertions ---
-        assertEq(
-            fundingPot.getUserContributionToRound(round2Id, contributor1_),
-            r2BaseTotalCap,
-            "R2 C1 contribution should be clamped by R2 base total cap (All mode, global_start=R2)"
-        );
-        assertEq(
-            fundingPot.getTotalRoundContribution(round2Id),
-            r2BaseTotalCap,
-            "R2 Total contributions should be R2 base total cap (All mode, global_start=R2)"
-        );
-    }
-
-    function testContributeToRoundFor_revertsGivenUnspentCapsRoundIdsNotStrictlyIncreasing(
-    ) public {
-        // Setup: Round 1 (Personal), Round 2 (Personal), Round 3 (Personal for contribution)
-        uint initialTimestamp = block.timestamp;
-        uint8 accessId = 1; // Open access
-        uint personalCap = 500;
-        uint roundCap = 10_000;
-
-        vm.startPrank(contributor1_);
-        _token.approve(address(fundingPot), type(uint).max);
-        vm.stopPrank();
-
-        // Round 1
-        uint32 round1Id = fundingPot.createRound(
-            initialTimestamp + 1 days,
-            initialTimestamp + 2 days,
-            roundCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round1Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round1Id, accessId, personalCap, false, 0, 0, 0
-        );
-
-        // Round 2
-        uint32 round2Id = fundingPot.createRound(
-            initialTimestamp + 3 days,
-            initialTimestamp + 4 days,
-            roundCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round2Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round2Id, accessId, personalCap, false, 0, 0, 0
-        );
-
-        // Round 3 (target for contribution)
-        uint32 round3Id = fundingPot.createRound(
-            initialTimestamp + 5 days,
-            initialTimestamp + 6 days,
-            roundCap,
-            address(0),
-            bytes(""),
-            false,
-            ILM_PC_FundingPot_v1.AccumulationMode.Personal
-        );
-        fundingPot.setAccessCriteria(
-            round3Id, accessId, 0, address(0), bytes32(0), new address[](0)
-        );
-        fundingPot.setAccessCriteriaPrivileges(
-            round3Id, accessId, personalCap, false, 0, 0, 0
-        );
-
-        vm.warp(initialTimestamp + 5 days + 1 hours); // Enter Round 3
-
-        // Case 1: Out of order
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory
-            unspentCapsOutOfOrder =
-                new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
-        unspentCapsOutOfOrder[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round2Id, accessId, new bytes32[](0)
-        );
-        unspentCapsOutOfOrder[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id, accessId, new bytes32[](0)
-        );
-
-        vm.startPrank(contributor1_);
-        vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__UnspentCapsRoundIdsNotStrictlyIncreasing
-                .selector
-        );
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round3Id,
-            100,
-            accessId,
-            new bytes32[](0),
-            unspentCapsOutOfOrder
-        );
-        vm.stopPrank();
-
-        // Case 2: Duplicate roundId
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory
-            unspentCapsDuplicate =
-                new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](2);
-        unspentCapsDuplicate[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id, accessId, new bytes32[](0)
-        );
-        unspentCapsDuplicate[1] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap(
-            round1Id, accessId, new bytes32[](0)
-        );
-
-        vm.startPrank(contributor1_);
-        vm.expectRevert(
-            ILM_PC_FundingPot_v1
-                .Module__LM_PC_FundingPot__UnspentCapsRoundIdsNotStrictlyIncreasing
-                .selector
-        );
-        fundingPot.contributeToRoundFor(
-            contributor1_,
-            round3Id,
-            100,
-            accessId,
-            new bytes32[](0),
-            unspentCapsDuplicate
-        );
-        vm.stopPrank();
-
-        // Case 3: Correct order but first element's roundId is 0 (if lastSeenRoundId starts at 0)
-        // This specific case won't be hit if round IDs must be >0, but good to be aware.
-        // Assuming valid round IDs start from 1, this case might not be directly testable if 0 isn't a valid roundId.
-        // The current check `currentProcessingRoundId <= lastSeenRoundId` covers this if roundId can be 0.
-        // If round IDs are always >= 1, then an initial lastSeenRoundId=0 is fine.
-
-        // Case 4: Empty array (should not revert with this specific error, but pass)
-        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCapsEmpty =
-            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](0);
-        vm.startPrank(contributor1_);
-        fundingPot.contributeToRoundFor( // This should pass (or revert with a different error if amount is 0 etc.)
-            contributor1_,
-            round3Id,
-            100,
-            accessId,
-            new bytes32[](0),
-            unspentCapsEmpty
-        );
-        vm.stopPrank();
-        assertEq(
-            fundingPot.getUserContributionToRound(round3Id, contributor1_), 100
         );
     }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -3281,4 +3281,346 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
             allowedAddresses
         );
     }
+
+        function testContribute_PersonalMode_AccumulatesPersonalOnly() public {
+        // 1. Create the first round with AccumulationMode.Personal
+        _defaultRoundParams.accumulationMode = ILM_PC_FundingPot_v1.AccumulationMode.Personal;
+
+        fundingPot.createRound(
+            _defaultRoundParams.roundStart,
+            _defaultRoundParams.roundEnd,
+            1000, // Round cap of 1000
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            _defaultRoundParams.accumulationMode
+        );
+        uint32 round1Id = fundingPot.getRoundCount();
+
+        // Set up access criteria for round 1
+        uint8 accessCriteriaId = 1; // Open access
+        (
+            address nftContract,
+            bytes32 merkleRoot,
+            address[] memory allowedAddresses
+        ) = _helper_createAccessCriteria(uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id);
+
+        fundingPot.setAccessCriteria(
+            round1Id,
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
+            0, // accessCriteriaId (0 for new)
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
+
+        // Set a personal cap of 500 for round 1
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessCriteriaId, 500, false, 0, 0, 0
+        );
+
+        // 2. Create the second round, also with AccumulationMode.Personal
+        // Use different start and end times to avoid overlap
+        RoundParams memory params = _helper_createEditRoundParams(
+            _defaultRoundParams.roundStart + 3 days,
+            _defaultRoundParams.roundEnd + 3 days,
+            500, // Round cap of 500
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            ILM_PC_FundingPot_v1.AccumulationMode.Personal
+        );
+
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.accumulationMode
+        );
+        uint32 round2Id = fundingPot.getRoundCount();
+
+        // Set up access criteria for round 2
+        fundingPot.setAccessCriteria(
+            round2Id,
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
+            0, // accessCriteriaId (0 for new)
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
+
+        // Set a personal cap of 400 for round 2
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessCriteriaId, 400, false, 0, 0, 0
+        );
+
+        // First round contribution: user contributes 200 out of their 500 personal cap
+        vm.warp(_defaultRoundParams.roundStart + 1);
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 1000);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, 200, accessCriteriaId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // Verify contribution to round 1
+        assertEq(
+            fundingPot.getUserContributionToRound(
+                round1Id, contributor1_
+            ),
+            200
+        );
+
+        // Move to round 2
+        vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
+
+        // ------------ PART 1: VERIFY PERSONAL CAP ACCUMULATION ------------
+        // Create unspent capacity structure
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap({
+            roundId: round1Id,
+            accessCriteriaId: accessCriteriaId,
+            merkleProof: new bytes32[](0)
+        });
+
+        // Try to contribute more than the round 2 personal cap (400)
+        // In Personal mode, this should succeed up to the personal cap (400) + unspent from round 1 (300) = 700
+        // But capped by round cap of 500
+        vm.startPrank(contributor1_);
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            450, // More than the personal cap of round 2
+            accessCriteriaId,
+            new bytes32[](0),
+            unspentCaps
+        );
+        vm.stopPrank();
+
+        // Verify contributions to round 2 - should be more than the personal cap of round 2 (400)
+        // This verifies personal caps DO accumulate
+        uint contributionAmount = fundingPot.getUserContributionToRound(
+            round2Id, contributor1_
+        );
+        assertEq(contributionAmount, 450);
+        assertTrue(contributionAmount > 400, "Personal cap should accumulate"); 
+
+        // ------------ PART 2: VERIFY TOTAL CAP NON-ACCUMULATION ------------
+        // Attempt to contribute more than the remaining round cap
+        vm.startPrank(contributor2_);
+        _token.approve(address(fundingPot), 200);
+
+        // Contributor 2 attempts to contribute 100.
+        // Since contributor1 contributed 450 and round cap is 500, only 50 is remaining.
+        // The contribution should be clamped to 50.
+        fundingPot.contributeToRoundFor(
+            contributor2_, round2Id, 100, accessCriteriaId, new bytes32[](0)
+        );
+        // Verify contributor 2's contribution was clamped to the remaining 50.
+        assertEq(fundingPot.getUserContributionToRound(round2Id, contributor2_), 50);
+        vm.stopPrank();
+
+        // Verify total contributions to round 2 is exactly the round cap (450 + 50 = 500).
+        assertEq(fundingPot.getTotalRoundContribution(round2Id), 500);
+
+        // Additional contributor3 should not be able to contribute anything as the cap is full.
+        // Attempting to contribute when the cap is already full should revert.
+        vm.startPrank(contributor3_);
+        _token.approve(address(fundingPot), 100);
+
+        // Expect revert because the round cap (500) is already met.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_FundingPot_v1.Module__LM_PC_FundingPot__RoundCapReached.selector
+            )
+        );
+        fundingPot.contributeToRoundFor(
+            contributor3_, round2Id, 1, accessCriteriaId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // Final check that total contributions remain at the round cap.
+        assertEq(fundingPot.getTotalRoundContribution(round2Id), 500);
+    }
+
+    function testContribute_TotalMode_AccumulatesTotalOnly() public {
+        // 1. Create the first round with AccumulationMode.Total
+        _defaultRoundParams.accumulationMode = ILM_PC_FundingPot_v1.AccumulationMode.Total;
+
+        fundingPot.createRound(
+            _defaultRoundParams.roundStart,
+            _defaultRoundParams.roundEnd,
+            1000, // Round 1 cap of 1000
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            _defaultRoundParams.accumulationMode
+        );
+        uint32 round1Id = fundingPot.getRoundCount();
+
+        // Set up access criteria for round 1 (Open)
+        uint8 accessCriteriaId = 1; 
+        (address nftContract, bytes32 merkleRoot, address[] memory allowedAddresses) =
+            _helper_createAccessCriteria(uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), round1Id);
+
+        fundingPot.setAccessCriteria(
+            round1Id,
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
+            0, // accessCriteriaId (0 for new)
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
+
+        // Set a personal cap of 800 for round 1
+        fundingPot.setAccessCriteriaPrivileges(
+            round1Id, accessCriteriaId, 800, false, 0, 0, 0
+        );
+
+        // 2. Create the second round, also with AccumulationMode.Total
+        RoundParams memory params = _helper_createEditRoundParams(
+            _defaultRoundParams.roundStart + 3 days,
+            _defaultRoundParams.roundEnd + 3 days,
+            500, // Round 2 base cap of 500
+            _defaultRoundParams.hookContract,
+            _defaultRoundParams.hookFunction,
+            _defaultRoundParams.autoClosure,
+            ILM_PC_FundingPot_v1.AccumulationMode.Total
+        );
+
+        fundingPot.createRound(
+            params.roundStart,
+            params.roundEnd,
+            params.roundCap,
+            params.hookContract,
+            params.hookFunction,
+            params.autoClosure,
+            params.accumulationMode
+        );
+        uint32 round2Id = fundingPot.getRoundCount();
+
+        // Set up access criteria for round 2 (Open)
+        fundingPot.setAccessCriteria(
+            round2Id,
+            uint8(ILM_PC_FundingPot_v1.AccessCriteriaType.OPEN), // accessCriteriaType
+            0, // accessCriteriaId (0 for new)
+            nftContract,
+            merkleRoot,
+            allowedAddresses
+        );
+
+        // Set a personal cap of 300 for round 2
+        fundingPot.setAccessCriteriaPrivileges(
+            round2Id, accessCriteriaId, 300, false, 0, 0, 0
+        );
+
+        // Round 1 contribution: contributor1 contributes 600 (less than round cap 1000, less than personal 800)
+        // Undersubscription: 1000 - 600 = 400
+        vm.warp(_defaultRoundParams.roundStart + 1);
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 1000);
+        fundingPot.contributeToRoundFor(
+            contributor1_, round1Id, 600, accessCriteriaId, new bytes32[](0)
+        );
+        vm.stopPrank();
+
+        // Verify contribution to round 1
+        assertEq(fundingPot.getUserContributionToRound(round1Id, contributor1_), 600);
+        assertEq(fundingPot.getTotalRoundContribution(round1Id), 600);
+
+        // Move to round 2
+        vm.warp(_defaultRoundParams.roundStart + 3 days + 1);
+
+        // ------------ PART 1: VERIFY TOTAL CAP ACCUMULATION ------------
+        // Effective Round 2 Cap = Base Cap (500) + Unused from Round 1 (400) = 900
+        vm.startPrank(contributor2_);
+        _token.approve(address(fundingPot), 1000); // Approve enough
+
+        // Contributor 2 attempts to contribute 700. 
+        // Personal Cap (R2) is 300. Gets clamped to 300.
+        fundingPot.contributeToRoundFor(
+            contributor2_, round2Id, 700, accessCriteriaId, new bytes32[](0)
+        );
+        // Verify contributor 2's contribution was clamped by personal cap.
+        assertEq(fundingPot.getUserContributionToRound(round2Id, contributor2_), 300, "C2 contribution should be clamped by personal cap");
+        vm.stopPrank();
+
+        // Verify total contributions after C2 is 300
+        assertEq(fundingPot.getTotalRoundContribution(round2Id), 300, "Total after C2 should be 300");
+
+        // ------------ PART 2: VERIFY PERSONAL CAP NON-ACCUMULATION ------------
+        // Contributor 1 had 800 personal cap in R1, contributed 600, unused = 200.
+        // Contributor 1 has 300 personal cap in R2.
+        // In Total mode, personal cap does NOT roll over. Max contribution is 300.
+
+        // Prepare unspent caps struct (even though it shouldn't work for personal in Total mode)
+        ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[] memory unspentCaps =
+            new ILM_PC_FundingPot_v1.UnspentPersonalRoundCap[](1);
+        unspentCaps[0] = ILM_PC_FundingPot_v1.UnspentPersonalRoundCap({
+            roundId: round1Id,
+            accessCriteriaId: accessCriteriaId,
+            merkleProof: new bytes32[](0)
+        });
+
+        vm.startPrank(contributor1_);
+        _token.approve(address(fundingPot), 500); 
+
+        // Attempt to contribute 400 ( > R2 personal cap 300)
+        // Total contributions = 300. Effective Round Cap = 900. Remaining Round Cap = 600.
+        // Personal Cap (R2) = 300. Unspent (R1) = 200, ignored in Total mode.
+        // Min(Remaining Round Cap, Remaining Personal Cap) = Min(600, 300) = 300.
+        // Should be clamped to 300.
+        fundingPot.contributeToRoundFor(
+            contributor1_,
+            round2Id,
+            400, 
+            accessCriteriaId,
+            new bytes32[](0),
+            unspentCaps // Provide unspent caps, although they should be ignored for personal limit
+        );
+        // Verify contributor 1's contribution was clamped to their R2 personal cap.
+        assertEq(fundingPot.getUserContributionToRound(round2Id, contributor1_), 300, "C1 contribution should be clamped by personal cap");
+        vm.stopPrank();
+
+        // Verify total round contributions: 300 (C2) + 300 (C1) = 600
+        assertEq(fundingPot.getTotalRoundContribution(round2Id), 600, "Total after C1 and C2 should be 600"); 
+        // Effective cap 900, current total 600. Remaining = 300.
+
+        // Contributor 3 contributes 300. Personal Cap = 300. Remaining Round Cap = 300. Should succeed.
+        vm.startPrank(contributor3_);
+        _token.approve(address(fundingPot), 300);
+        fundingPot.contributeToRoundFor(
+            contributor3_, round2Id, 300, accessCriteriaId, new bytes32[](0)
+        );
+        // Verify C3 contributed 300
+        assertEq(fundingPot.getUserContributionToRound(round2Id, contributor3_), 300, "C3 contributes remaining 300");
+        vm.stopPrank();
+
+        // Total contributions should now be 900 (300 + 300 + 300), matching the effective cap.
+        assertEq(fundingPot.getTotalRoundContribution(round2Id), 900, "Total should match effective cap after C3");
+
+        // Now the effective cap is full. Try contributing 1 again.
+        vm.startPrank(contributor3_); // Can use C3 or another contributor
+        _token.approve(address(fundingPot), 1);
+
+        // Try contributing 1, expect revert as cap is full
+        vm.expectRevert(
+             abi.encodeWithSelector(
+                 ILM_PC_FundingPot_v1.Module__LM_PC_FundingPot__RoundCapReached.selector
+             )
+         );
+         fundingPot.contributeToRoundFor(
+             contributor3_, round2Id, 1, accessCriteriaId, new bytes32[](0)
+         );
+        vm.stopPrank();
+
+        // Final total check should remain 900
+         assertEq(fundingPot.getTotalRoundContribution(round2Id), 900, "Final total should be effective cap"); 
+
+    }
 }

--- a/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -3888,7 +3888,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
     }
 
-        function testContributeToRoundFor_personalModeOnlyAccumulatesPersonalCaps()
+    function testContributeToRoundFor_personalModeOnlyAccumulatesPersonalCaps()
         public
     {
         // 1. Create the first round with AccumulationMode.Personal
@@ -4059,7 +4059,9 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         assertEq(fundingPot.getTotalRoundContribution(round2Id), 500);
     }
 
-    function testContributeToRoundFor_totalModeOnlyAccumulatesTotalCaps() public {
+    function testContributeToRoundFor_totalModeOnlyAccumulatesTotalCaps()
+        public
+    {
         // 1. Create the first round with AccumulationMode.Total
         _defaultRoundParams.accumulationMode =
             ILM_PC_FundingPot_v1.AccumulationMode.Total;

--- a/test/utils/mocks/modules/FundingManagerV1Mock.sol
+++ b/test/utils/mocks/modules/FundingManagerV1Mock.sol
@@ -83,11 +83,11 @@ contract FundingManagerV1Mock is IFundingManager_v1, Module_v1 {
         return address(_bondingToken);
     }
 
-    function calculatePurchaseReturn(uint amount) public view returns (uint) {
+    function calculatePurchaseReturn(uint amount) public pure returns (uint) {
         return amount;
     }
 
-    function buyFor(address to, uint amount, uint minTokens) public {
+    function buyFor(address to, uint amount, uint) public {
         _token.transferFrom(_msgSender(), address(this), amount);
         _bondingToken.mint(to, amount);
     }


### PR DESCRIPTION
**Changes**
* round contribution capacity for a user is limited by the access criteria with the highest possible personal cap
  * both for contribution to current round
  * and for the unspent cap calculation (accumulationMode == personal/all): here it is implemented such that it it expects the user to pass unspent capacities in ascending order by roundId, so that a user can only provide one unspent cap per round
* accumulative cross-round behavior can be configured to apply to only 1) personal caps, 2) total caps, 3) both, 4) none
* accumulative cross-round behavior can be restricted by admin retrospectively; admin can define from which round onwards accumulative behavior starts