### PR TITLE
Fix: Resolve Deployment Issues

### DIFF
--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -246,11 +246,7 @@ contract OrchestratorFactory_v1 is
         return _orchestratorIdCounter;
     }
 
-    /// @notice Deploys an external contract using the CREATE2 opcode.
-    /// @dev    Any further calls to the contract that serve its initialization
-    ///         can be provided via the calls array and will be executed after.
-    /// @param  code The creation code of the contract.
-    /// @param  calls Additional calls to be made to the deployed contract.
+    /// @inheritdoc IOrchestratorFactory_v1
     function deployExternalContract(bytes calldata code, bytes[] calldata calls)
         external
         returns (address deploymentAddress)

--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -37,6 +37,8 @@ import {
     Initializable
 } from "@oz-up/access/Ownable2StepUpgradeable.sol";
 
+import {Create2} from "@oz/utils/Create2.sol";
+
 /**
  * @title   Inverter Orchestrator Factory
  *
@@ -242,6 +244,22 @@ contract OrchestratorFactory_v1 is
     /// @inheritdoc IOrchestratorFactory_v1
     function getOrchestratorIDCounter() external view returns (uint) {
         return _orchestratorIdCounter;
+    }
+
+    /// @notice Deploys an external contract using the CREATE2 opcode.
+    /// @dev    Any further calls to the contract that serve its initialization
+    ///         can be provided via the calls array and will be executed after.
+    /// @param  code The creation code of the contract.
+    /// @param  calls Additional calls to be made to the deployed contract.
+    function deployExternalContract(bytes calldata code, bytes[] calldata calls)
+        external
+        returns (address deploymentAddress)
+    {
+        deploymentAddress = Create2.deploy(0, _createSalt(), code);
+        for (uint i; i < calls.length; ++i) {
+            (bool success,) = deploymentAddress.call(calls[i]);
+            require(success, "External contract deployment failed");
+        }
     }
 
     //--------------------------------------------------------------------------

--- a/src/factories/interfaces/IOrchestratorFactory_v1.sol
+++ b/src/factories/interfaces/IOrchestratorFactory_v1.sol
@@ -88,6 +88,15 @@ interface IOrchestratorFactory_v1 {
         ModuleConfig[] memory moduleConfigs
     ) external returns (IOrchestrator_v1);
 
+    /// @notice Deploys an external contract using the CREATE2 opcode.
+    /// @dev    Any further calls to the contract that serve its initialization
+    ///         can be provided via the calls array and will be executed after.
+    /// @param  code The creation code of the contract.
+    /// @param  calls Additional calls to be made to the deployed contract.
+    function deployExternalContract(bytes calldata code, bytes[] calldata calls)
+        external
+        returns (address deploymentAddress);
+
     /// @notice Returns the {IOrchestrator_v1} {IInverterBeacon_v1} address.
     /// @return OrchestratorImplementationBeacon The {IInverterBeacon_v1} of the {Orchestrator_v1} Implementation.
     function beacon() external view returns (IInverterBeacon_v1);

--- a/test/unit/factories/OrchestratorFactory_v1.t.sol
+++ b/test/unit/factories/OrchestratorFactory_v1.t.sol
@@ -342,6 +342,50 @@ contract OrchestratorFactoryV1Test is Test {
         assertEq(address(orchestrator), address(orchestrator_retry_alice));
     }
 
+    function testExternalContractDeployment() public {
+        // Prepare external contract to be deployed
+        // As this will mostly be used for IssuanceToken deployments, we will
+        // use a simple ERC20 contract.
+        bytes memory constructorArgs = abi.encode("Test Token", "TT", 18);
+        bytes memory bytecode = abi.encodePacked(
+            vm.getCode("ERC20Mock.sol:ERC20Mock"), constructorArgs
+        );
+
+        // Create encoded calls to the two function calls we want to do
+        // into a bytes array
+        address transferTarget = makeAddr("Target");
+
+        // 1. Calling the mint function with the address of the IssuanceToken
+        bytes memory mintCall = abi.encodeWithSelector(
+            ERC20Mock.mint.selector, address(factory), 100
+        );
+
+        // 2. Calling the transfer function to transfer the minted tokens
+        bytes memory transferCall = abi.encodeWithSelector(
+            ERC20Mock.transfer.selector, address(transferTarget), 100
+        );
+
+        // Assemble the calls array
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = mintCall;
+        calls[1] = transferCall;
+
+        vm.expectEmit(true, false, false, false);
+        emit IERC20.Transfer(address(0), address(factory), 100);
+        emit IERC20.Transfer(address(factory), address(transferTarget), 100);
+
+        address deployedAddress =
+            factory.deployExternalContract(bytecode, calls);
+
+        // Verify that the deployed contract exists and the post-deployment
+        // calls were executed
+        assertTrue(ERC20Mock(deployedAddress).balanceOf(address(factory)) == 0);
+        assertTrue(
+            ERC20Mock(deployedAddress).balanceOf(address(transferTarget)) == 100
+        );
+        assertTrue(ERC20Mock(deployedAddress).decimals() == 18);
+    }
+
     function _deployOrchestrator() private returns (address) {
         // Create Empty ModuleConfig
         IOrchestratorFactory_v1.ModuleConfig[] memory moduleConfigs =

--- a/test/unit/factories/OrchestratorFactory_v1.t.sol
+++ b/test/unit/factories/OrchestratorFactory_v1.t.sol
@@ -370,8 +370,10 @@ contract OrchestratorFactoryV1Test is Test {
         calls[0] = mintCall;
         calls[1] = transferCall;
 
-        vm.expectEmit(true, false, false, false);
+        vm.expectEmit(true, true, true, true);
         emit IERC20.Transfer(address(0), address(factory), 100);
+
+        vm.expectEmit(true, true, true, true);
         emit IERC20.Transfer(address(factory), address(transferTarget), 100);
 
         address deployedAddress =


### PR DESCRIPTION
This PR aims to address the following issues:
* Consistent Module Deployment Addresses (not just for the Orchestrator) that can't be disturbed by others deploying workflows
  * This new variant bases the module's address on the address of the caller (which is the orchestrator factory, so even if someone just calls the module factory directly, it won't matter), the address of the orchestrator attached to it, and a nonce
  * This way it's unique to the actual user doing the deployment and can't be sniped/disturbed
  * There was an earlier PR that tried to fix this, too, but this solution should be way better.
* Allows users to deploy and initialize/configure external contracts via the orchestrator factory
  * Main reason and idea: multicalls are only possible if you interact with our contracts, so deploying the issuance token is a problem. This fixes it, as you can deploy it and set it up all within the same call, but still keeps the factory's contract size low.

⚠️ **Current issues**: The external contract deployment function opens the contract up to a potential vulnerability in its current form, allowing you to facilitate contract calls on behalf of the orchestrator factory. We are just using this to test the frontend multicall capabilities for now and unblock them, but this needs a fix/solution before we release it to any "real" network

---

### Below is the GitHub AI summary of the changes, be wary

This pull request introduces changes to enhance the deployment logic for CREATE2-based flows, improve nonce handling, and add support for deploying external contracts. It also includes a new test to validate the external contract deployment functionality. Below is a breakdown of the most important changes:

### Enhancements to CREATE2-based deployment logic:
* Updated `_deploymentNonces` mapping in `ModuleFactory_v1` to use a hash of the caller's address and orchestrator address as the key, improving nonce uniqueness. (`src/factories/ModuleFactory_v1.sol`, [src/factories/ModuleFactory_v1.solL115-R118](diffhunk://#diff-b4ee24d902ad606bd77c7919bcafd86732fa7d24190b1ad389e8c306bc36d86cL115-R118))
* Modified `_createSalt` function to generate a salt using the hash of the caller's address and orchestrator, ensuring better handling of orchestrator-specific deployments. (`src/factories/ModuleFactory_v1.sol`, [src/factories/ModuleFactory_v1.solL289-R302](diffhunk://#diff-b4ee24d902ad606bd77c7919bcafd86732fa7d24190b1ad389e8c306bc36d86cL289-R302))
* Updated proxy creation logic to pass the orchestrator address to `_createSalt`, aligning with the new salt generation approach. (`src/factories/ModuleFactory_v1.sol`, [src/factories/ModuleFactory_v1.solL212-R226](diffhunk://#diff-b4ee24d902ad606bd77c7919bcafd86732fa7d24190b1ad389e8c306bc36d86cL212-R226))

### Support for external contract deployment:
* Added a `deployExternalContract` function in `OrchestratorFactory_v1` to deploy contracts using CREATE2 and execute initialization calls post-deployment. (`src/factories/OrchestratorFactory_v1.sol`, [src/factories/OrchestratorFactory_v1.solR249-R264](diffhunk://#diff-0292b3dfcb4d13fbd60620f76003869bc54d064ab0e242798613fb8bb2ecacaeR249-R264))
* Imported the `Create2` utility from OpenZeppelin to facilitate CREATE2-based deployments. (`src/factories/OrchestratorFactory_v1.sol`, [src/factories/OrchestratorFactory_v1.solR40-R41](diffhunk://#diff-0292b3dfcb4d13fbd60620f76003869bc54d064ab0e242798613fb8bb2ecacaeR40-R41))

### New test for external contract deployment:
* Added a unit test in `OrchestratorFactoryV1Test` to validate the deployment of an external ERC20 contract and the execution of post-deployment calls. (`test/unit/factories/OrchestratorFactory_v1.t.sol`, [test/unit/factories/OrchestratorFactory_v1.t.solR345-R388](diffhunk://#diff-1bd853f3f86b21f6d9be4adbf9435334aa3b6636768e4d8a36627e9cb49e2644R345-R388))