### PR TITLE
Omega Audit Fixes 

### DIFF
--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -109,7 +109,7 @@ contract LM_PC_FundingPot_v1 is
     uint8 internal constant FLAG_END = 3;
 
     /// @notice The maximum valid access criteria ID.
-    uint8 internal constant MAX_ACCESS_CRITERIA_ID = 4;
+    uint8 internal constant MAX_ACCESS_CRITERIA_TYPE = 4;
 
     // -------------------------------------------------------------------------
     // State
@@ -305,7 +305,7 @@ contract LM_PC_FundingPot_v1 is
         view
         returns (bool isEligible, uint remainingAmountAllowedToContribute)
     {
-        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
+        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_TYPE) {
             revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
         }
 
@@ -471,7 +471,7 @@ contract LM_PC_FundingPot_v1 is
     ) external onlyModuleRole(FUNDING_POT_ADMIN_ROLE) {
         Round storage round = rounds[roundId_];
 
-        if (accessCriteriaType_ > MAX_ACCESS_CRITERIA_ID) {
+        if (accessCriteriaType_ > MAX_ACCESS_CRITERIA_TYPE) {
             revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
         }
 
@@ -535,10 +535,8 @@ contract LM_PC_FundingPot_v1 is
         } else if (accessCriteriaType == AccessCriteriaType.LIST) {
             // For LIST type, update the allowed addresses
             for (uint i = 0; i < allowedAddresses_.length; i++) {
-                unchecked {
-                    round.accessCriterias[criteriaId].allowedAddresses[allowedAddresses_[i]]
-                    = true;
-                }
+                round.accessCriterias[criteriaId].allowedAddresses[allowedAddresses_[i]]
+                = true;
             }
         }
 
@@ -570,10 +568,8 @@ contract LM_PC_FundingPot_v1 is
         _validateEditRoundParameters(round);
 
         for (uint i = 0; i < addressesToRemove_.length; i++) {
-            unchecked {
-                round.accessCriterias[accessCriteriaId_].allowedAddresses[addressesToRemove_[i]]
-                = false;
-            }
+            round.accessCriterias[accessCriteriaId_].allowedAddresses[addressesToRemove_[i]]
+            = false;
         }
 
         emit AllowlistedAddressesRemoved(
@@ -659,9 +655,10 @@ contract LM_PC_FundingPot_v1 is
                 );
             }
 
+            lastSeenRoundId = currentProcessingRoundId; // Update lastSeenRoundId before continuing
+
             // Skip if this round is before the global accumulation start round
             if (currentProcessingRoundId < globalAccumulationStartRoundId) {
-                lastSeenRoundId = currentProcessingRoundId; // Update lastSeenRoundId before continuing
                 continue;
             }
 
@@ -672,7 +669,6 @@ contract LM_PC_FundingPot_v1 is
                     && rounds[currentProcessingRoundId].accumulationMode
                         != AccumulationMode.All
             ) {
-                lastSeenRoundId = currentProcessingRoundId; // Update lastSeenRoundId before continuing
                 continue;
             }
 
@@ -698,7 +694,6 @@ contract LM_PC_FundingPot_v1 is
                 }
                 unspentPersonalCap += unspentForThisEntry;
             }
-            lastSeenRoundId = currentProcessingRoundId; // Update after processing or skipping
         }
 
         _contributeToRoundFor(
@@ -899,7 +894,7 @@ contract LM_PC_FundingPot_v1 is
             revert Module__LM_PC_FundingPot__RoundHasNotStarted();
         }
 
-        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_ID) {
+        if (accessCriteriaId_ > MAX_ACCESS_CRITERIA_TYPE) {
             revert Module__LM_PC_FundingPot__InvalidAccessCriteriaId();
         }
 
@@ -1239,7 +1234,7 @@ contract LM_PC_FundingPot_v1 is
 
             for (
                 uint8 accessCriteriaId = 1;
-                accessCriteriaId <= MAX_ACCESS_CRITERIA_ID;
+                accessCriteriaId <= MAX_ACCESS_CRITERIA_TYPE;
                 accessCriteriaId++
             ) {
                 uint contributionByAccessCriteria =

--- a/src/modules/logicModule/LM_PC_FundingPot_v1.sol
+++ b/src/modules/logicModule/LM_PC_FundingPot_v1.sol
@@ -755,8 +755,12 @@ contract LM_PC_FundingPot_v1 is
         uint contributorCount = contributors.length;
 
         // Check batch size is not zero
-        if (batchSize_ == 0 || batchSize_ > contributorCount) {
+        if (batchSize_ == 0) {
             revert Module__LM_PC_FundingPot__InvalidBatchParameters();
+        }
+        // If batch size is greater than contributor count, set batch size to contributor count
+        if (batchSize_ > contributorCount) {
+            batchSize_ = contributorCount;
         }
 
         // If autoClosure is false, only admin can process contributors

--- a/test/unit/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -4679,10 +4679,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │   └── When user attempts to create payment orders in batch
     │       └── Then it should revert with Module__LM_PC_FundingPot__RoundNotClosed
     │
-    ├── Given start index is greater than the number of contributors
-    │   └── When user attempts to create payment orders in batch
-    │       └── Then it should revert with Module__LM_PC_FundingPot__InvalidBatchParameters
-    │
     ├── Given batch size is zero
     │   └── When user attempts to create payment orders in batch
     │       └── Then it should revert with Module__LM_PC_FundingPot__InvalidBatchParameters
@@ -4691,6 +4687,10 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │   └── Given the round is configured with autoClosure
     │   └── When user attempts to create payment orders in batch
     │       └── Then it should revert with Module__CallerNotAuthorized
+    │
+    ├── Given start index is greater than the number of contributors
+    │   └── When user attempts to create payment orders in batch
+    │       └── Then it should not revert and create payment orders
     │
     ├── Given a closed round with autoClosure
     │   └── When user attempts to create payment orders in batch
@@ -4734,21 +4734,6 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         fundingPot.createPaymentOrdersForContributorsBatch(roundId, 1);
     }
 
-    function testCreatePaymentOrdersForContributorsBatch_revertsGivenBatchSizeIsGreaterThanContributorCount(
-    ) public {
-        testCloseRound_worksWithMultipleContributors();
-        uint32 roundId = fundingPot.getRoundCount();
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILM_PC_FundingPot_v1
-                    .Module__LM_PC_FundingPot__InvalidBatchParameters
-                    .selector
-            )
-        );
-        fundingPot.createPaymentOrdersForContributorsBatch(roundId, 999);
-    }
-
     function testCreatePaymentOrdersForContributorsBatch_revertsGivenBatchSizeIsZero(
     ) public {
         testCloseRound_worksWithMultipleContributors();
@@ -4782,6 +4767,15 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
         );
         fundingPot.createPaymentOrdersForContributorsBatch(roundId, 1);
         vm.stopPrank();
+    }
+
+    function testCreatePaymentOrdersForContributorsBatch_worksGivenBatchSizeIsGreaterThanContributorCount(
+    ) public {
+        testCloseRound_worksWithMultipleContributors();
+        uint32 roundId = fundingPot.getRoundCount();
+
+        fundingPot.createPaymentOrdersForContributorsBatch(roundId, 999);
+        assertEq(fundingPot.paymentOrders().length, 3);
     }
 
     function testCreatePaymentOrdersForContributorsBatch_worksGivenRoundIsAutoClosure(

--- a/test/unit/modules/logicModule/LM_PC_FundingPot_v1.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_FundingPot_v1.t.sol
@@ -791,7 +791,7 @@ contract LM_PC_FundingPot_v1_Test is ModuleTest {
     │   └── When user attempts to set access criteria
     │       └── Then it should revert
     │
-    ├── Given AccessCriteriaId is greater than MAX_ACCESS_CRITERIA_ID
+    ├── Given AccessCriteriaId is greater than MAX_ACCESS_CRITERIA_TYPE
     │   └── When user attempts to set access criteria
     │       └── Then it should revert
     │


### PR DESCRIPTION
**This PR addresses the following three issues reported in the Omega audit:**

1. Renamed `MAX_ACCESS_CRITERIA_ID` to `MAX_ACCESS_CRITERIA_TYPE` for better clarity and alignment with its usage.
2. Removed the redundant use of the `unchecked` block where no arithmetic operations were involved.
3. Optimized gas usage by simplifying the assignment: `lastSeenRoundId = currentProcessingRoundId`.
4. set `batchSize_` to `contributorCount` instead of reverting if `batchSize_ > contributorCount`