### PR TITLE
Fix: Add project fee to payment order to calculate protocol fee in PP_Queue

### DIFF
--- a/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
@@ -231,6 +231,9 @@ contract FM_PC_Oracle_Redeeming_v1 is
     /// @notice Flag used for the payment order.
     uint internal constant FLAG_ORDER_ID = 0;
 
+    /// @notice Flag used for the payment order.
+    uint internal constant FLAG_PROJECT_FEE = 4;
+
     // -------------------------------------------------------------------------
     // State Variables
 
@@ -362,6 +365,7 @@ contract FM_PC_Oracle_Redeeming_v1 is
 
         bytes32 flags;
         flags |= bytes32(1 << FLAG_ORDER_ID);
+        flags |= bytes32(1 << FLAG_PROJECT_FEE);
 
         __ERC20PaymentClientBase_v2_init(flags);
     }
@@ -712,8 +716,10 @@ contract FM_PC_Oracle_Redeeming_v1 is
         bytes32[] memory data;
 
         {
-            bytes32[] memory paymentParameters = new bytes32[](1);
+            bytes32[] memory paymentParameters = new bytes32[](2);
             paymentParameters[0] = bytes32(_orderId);
+            // Add project collateral sell fee for calculations in payment processor
+            paymentParameters[1] = bytes32(sellFee);
 
             (flags, data) = _assemblePaymentConfig(paymentParameters);
         }

--- a/src/modules/logicModule/interfaces/IERC20PaymentClientBase_v2.sol
+++ b/src/modules/logicModule/interfaces/IERC20PaymentClientBase_v2.sol
@@ -46,6 +46,7 @@ interface IERC20PaymentClientBase_v2 {
     | 1    | uint256       | start      | Start date of the streaming period. | 
     | 2    | uint256       | cliff      | Duration of the cliff period.       |
     | 3    | uint256       | end        | Due Date of the order               |
+    | 4    | uint256       | projectFee | Project fee for the order           |
     | ...  | ...           | ...        | (yet unassigned)                    |
     | 255  | .             | .          | (Max Value).                        | 
     |------|---------------|------------|-------------------------------------|

--- a/src/modules/paymentProcessor/PP_Queue_v1.sol
+++ b/src/modules/paymentProcessor/PP_Queue_v1.sol
@@ -221,7 +221,7 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
         _setFailedOrdersTreasury(failedOrdersTreasury_);
 
         // Default value for max orders per execution to ensure not to run out of gas.
-        _maxOrdersPerExecution = 30;
+        _maxOrdersPerExecution = 50;
     }
 
     //--------------------------------------------------------------------------

--- a/src/modules/paymentProcessor/PP_Queue_v1.sol
+++ b/src/modules/paymentProcessor/PP_Queue_v1.sol
@@ -122,9 +122,6 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
     // -------------------------------------------------------------------------
     // Constants
 
-    /// @notice    Flag position in the flags byte.
-    uint8 internal constant FLAG_ORDER_ID = 0;
-
     /// @notice Role identifier for queue operations.
     /// @dev    This role cancels payments in the queue.
     bytes32 internal constant QUEUE_OPERATOR_ROLE = "QUEUE_OPERATOR_ROLE";
@@ -138,6 +135,11 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
 
     /// @notice BPS value.
     uint internal constant BPS = 10_000;
+
+    /// @dev    The flags that this PaymentProcessor uses.
+    ///         Contains the value 10001 (bits 0 and 4 set).
+    bytes32 internal constant PROCESSOR_FLAGS =
+        0x0000000000000000000000000000000000000000000000000000000000000011;
 
     // ---------------------------------------------------------------------
     // Storage
@@ -511,7 +513,8 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
             order.client_,
             _cancelledOrdersTreasury,
             order.order_.amount,
-            false // don't collect protocol fee when cancelling order
+            false, // don't collect protocol fee when cancelling order
+            0 // no project fee needed for calculations as no fee is collected
         );
         if (!success_) {
             // If tranfer to the treasury fails than this would mean that the treasury
@@ -572,13 +575,18 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
         internal
         virtual
     {
+        (, uint projectFee) = _getOrderDetailsFromFlagsAndData(
+            order_.order_.flags, order_.order_.data
+        );
+
         // Try to transfer payment from client to recipient
         bool success_ = _tryPaymentTransfer(
             order_.order_.paymentToken,
             order_.client_,
             order_.order_.recipient,
             order_.order_.amount,
-            true // collect protocol fee when processing order
+            true, // collect protocol fee when processing order
+            projectFee
         );
 
         // Update order state based on transfer success
@@ -643,20 +651,23 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
     /// @param	recipient_ The recipient address.
     /// @param	amount_ The amount to transfer.
     /// @param	collectProtocolFee_ Whether to collect the protocol fee.
+    /// @param	projectFee_ The project fee amount set in the payment client.
     /// @return	success_ True if the transfer was successful.
     function _tryPaymentTransfer(
         address token_,
         address client_,
         address recipient_,
         uint amount_,
-        bool collectProtocolFee_
+        bool collectProtocolFee_,
+        uint projectFee_
     ) internal virtual returns (bool success_) {
         // Get the protocol fee amount, net amount and treasury address to sent the fee.
         (uint protocolFeeAmount, uint netAmount, address treasury_) =
-        _getProtocolFeeDetails(
+        _calculateProtocolFeeAmount(
             amount_,
             bytes4(keccak256(bytes("processPayments(address)"))),
-            collectProtocolFee_
+            collectProtocolFee_,
+            projectFee_
         );
 
         // Try direct transfer to recipient
@@ -742,7 +753,8 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
         }
 
         // Get queue ID from flags and data, or generate new one
-        queueId_ = _getPaymentQueueId(order_.flags, order_.data);
+        (queueId_,) =
+            _getOrderDetailsFromFlagsAndData(order_.flags, order_.data);
 
         // Create new order
         _orders[client_][queueId_] = QueuedOrder({
@@ -841,23 +853,68 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
         return queueId_ > 0 && queueId_ == _currentOrderId[client_] + 1;
     }
 
-    /// @notice Gets payment queue ID from flags and data.
-    /// @param  flags_ The payment order flags.
-    /// @param  data_ Additional payment order data.
-    /// @return queueId_ The queue ID from the data or a newly generated one.
-    function _getPaymentQueueId(bytes32 flags_, bytes32[] memory data_)
+    /// @notice Validates that the order flags contain all the required flags for the processor.
+    /// @param  orderFlags_ The order flags to validate.
+    /// @return isValid_ True if the order flags are valid.
+    function _validateOrderFlags(bytes32 orderFlags_)
         internal
-        view
-        virtual
-        returns (uint queueId_)
+        pure
+        returns (bool)
     {
-        // Check if orderID flag is set (bit 0)
-        bool hasOrderId = uint(flags_) & (1 << FLAG_ORDER_ID) != 0;
+        return
+            (uint(orderFlags_) & uint(PROCESSOR_FLAGS)) == uint(PROCESSOR_FLAGS);
+    }
 
-        // If flag is set and data is provided, use that ID
-        if (hasOrderId && data_.length > FLAG_ORDER_ID) {
-            queueId_ = uint(data_[FLAG_ORDER_ID]);
+    /// @notice Gets the order details from the flags and data.
+    /// @param  flags_ The flags to get the order details from.
+    /// @param  data_ The data to get the order details from.
+    /// @return orderId_ The order ID.
+    /// @return projectFee_ The project fee.
+    function _getOrderDetailsFromFlagsAndData(
+        bytes32 flags_,
+        bytes32[] memory data_
+    ) internal view virtual returns (uint orderId_, uint projectFee_) {
+        uint[2] memory returnData;
+
+        uint8 positionInOrderData = 0;
+        uint8 positionInReturnData = 0;
+
+        for (uint i = 0; i < 256; i++) {
+            if (positionInReturnData == returnData.length) {
+                // we have either:
+                // - reached the end of the orderData_ array
+                // - already checked for all the values this P_P will need
+                //      ==> exit loop
+                break;
+            }
+
+            bool orderBit = (uint(flags_) & (1 << i)) != 0;
+            bool processorBit = (uint(PROCESSOR_FLAGS) & (1 << i)) != 0;
+
+            if (orderBit == true && processorBit == false) {
+                // the P_P does not use that value
+                //      ==> skip that data slot in the order
+                positionInOrderData++;
+            }
+            if (orderBit == false && processorBit == true) {
+                // the P_P needs the value, but it's missing in the order
+                //      ==> set value of OrderId to 0 to signal that the order
+                // is broken
+                returnData[0] = 0;
+                positionInOrderData++;
+                break;
+            }
+            if (orderBit == true && processorBit == true) {
+                // the P_P needs the value, and the order supplies it
+                //      ==> use the value from the order
+                returnData[positionInReturnData] =
+                    uint(data_[positionInOrderData]);
+                positionInOrderData++;
+                positionInReturnData++;
+            }
         }
+
+        return (returnData[0], returnData[1]);
     }
 
     /// @notice Validate total input amount.
@@ -903,6 +960,18 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
         return chainId_ == block.chainid;
     }
 
+    /// @notice Validates the project fee.
+    /// @param  projectFee_ The project fee to validate.
+    /// @return valid_ True if the project fee is valid.
+    function _validProjectFee(uint projectFee_)
+        internal
+        pure
+        virtual
+        returns (bool valid_)
+    {
+        return projectFee_ < BPS;
+    }
+
     /// @notice Validates the payment token.
     /// @param  token_ Token address to validate.
     /// @return valid_ True if token is valid.
@@ -930,17 +999,17 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
     function _validPaymentOrder(
         IERC20PaymentClientBase_v2.PaymentOrder memory order_
     ) internal view virtual returns (bool valid_) {
-        // Extract queue ID from order data.
-        uint queueId_ = _getPaymentQueueId(order_.flags, order_.data);
+        (uint orderId_, uint projectFee_) =
+            _getOrderDetailsFromFlagsAndData(order_.flags, order_.data);
 
         // Validate payment receiver, amount and queue ID.
         return _validPaymentReceiver(order_.recipient)
             && _validTotalAmount(order_.amount)
-            && _validQueueId(queueId_, address(msg.sender))
+            && _validQueueId(orderId_, address(msg.sender))
             && _validPaymentToken(order_.paymentToken)
             && _validChainId(order_.originChainId)
-            && _validChainId(order_.targetChainId)
-            && _validateFlagsAndData(order_.flags, order_.data);
+            && _validChainId(order_.targetChainId) && _validProjectFee(projectFee_)
+            && _validateOrderFlags(order_.flags);
     }
 
     /// @notice Validates a state transition.
@@ -993,29 +1062,6 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
         emit PaymentOrderStateChanged(
             orderId_, state_, order.client_, _msgSender()
         );
-    }
-
-    /// @notice Validates flags and corresponding data array.
-    /// @param  flags_ The flags to validate.
-    /// @param  data_ The data array to validate.
-    function _validateFlagsAndData(bytes32 flags_, bytes32[] memory data_)
-        internal
-        pure
-        virtual
-        returns (bool valid_)
-    {
-        uint flagsValue = uint(flags_);
-        uint requiredDataLength = 0;
-
-        // Count how many flags are set.
-        for (uint8 i; i < 8; ++i) {
-            if (flagsValue & (1 << i) != 0) {
-                requiredDataLength++;
-            }
-        }
-
-        return data_.length == requiredDataLength
-            && (flagsValue & (1 << FLAG_ORDER_ID)) != 0;
     }
 
     /// @notice Internal function to check whether the client is valid.
@@ -1075,17 +1121,21 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
     ///         selector, then calculates the actual fee amount based on the
     ///         provided total amount. If the flag is false, it returns 0 for
     ///         the fee amount and net amount is equal to total amount.
+    /// @dev    The function uses the project fee from the Payment Client to
+    ///         reproduce the same protocol fee amount calculation.
     /// @param  totalAmount_ The base amount on which to calculate the fee.
     /// @param  functionSelector_ The function selector used to look up the
     ///         appropriate fee data.
     /// @param  collectProtocolFee_ Whether to collect the protocol fee.
+    /// @param  projectFee_ The project fee used to calculate the protocol fee.
     /// @return feeAmount_ The calculated protocol fee amount.
     /// @return netAmount_ The net amount after deducting the protocol fee.
     /// @return treasury_ The treasury address where the fee should be sent.
-    function _getProtocolFeeDetails(
+    function _calculateProtocolFeeAmount(
         uint totalAmount_,
         bytes4 functionSelector_,
-        bool collectProtocolFee_
+        bool collectProtocolFee_,
+        uint projectFee_
     )
         internal
         view
@@ -1098,7 +1148,8 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
             return (0, totalAmount_, address(0));
         }
 
-        // Get the fee percentage and treasury address for the specified function selector.
+        // Get the fee percentage and treasury address for the specified
+        //function selector.
         (uint protocolFeePercentage, address treasuryAddress_) =
             _getFeeManagerCollateralFeeData(functionSelector_);
         treasury_ = treasuryAddress_;
@@ -1108,9 +1159,14 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
             revert Module__PP_Queue_FeeAmountToHigh(protocolFeePercentage);
         }
 
+        // This adjustment ensures the protocol fee collected here matches the one
+        // calculated in the sell order, despite being calculated from a base amount
+        // that has already had the project fee (conceptually) removed.
+        uint denominator = BPS - projectFee_;
+
         // Calculate protocol fee amount if applicable
         if (protocolFeePercentage > 0) {
-            feeAmount_ = totalAmount_ * protocolFeePercentage / BPS;
+            feeAmount_ = totalAmount_ * protocolFeePercentage / denominator;
         }
 
         // Calculate the net amount after deducting the protocol fee.

--- a/test/e2e/fundingManager/oracle/OracleFundingManagerAndManualQueueBasedPaymentProcessorE2E.sol
+++ b/test/e2e/fundingManager/oracle/OracleFundingManagerAndManualQueueBasedPaymentProcessorE2E.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "forge-std/console.sol";
 import "forge-std/Test.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
 

--- a/test/mocks/modules/paymentProcessor/PP_Queue_v1_Exposed.sol
+++ b/test/mocks/modules/paymentProcessor/PP_Queue_v1_Exposed.sol
@@ -50,12 +50,11 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
         _removeFromQueue(orderId_, client_);
     }
 
-    function exposed_getPaymentQueueId(bytes32 flags_, bytes32[] memory data_)
-        external
-        view
-        returns (uint)
-    {
-        return _getPaymentQueueId(flags_, data_);
+    function exposed_getOrderDetailsFromFlagsAndData(
+        bytes32 flags_,
+        bytes32[] memory data_
+    ) external view returns (uint orderId_, uint projectFee_) {
+        return _getOrderDetailsFromFlagsAndData(flags_, data_);
     }
 
     // Función para exponer _validQueueId
@@ -91,10 +90,16 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
         address client_,
         address recipient_,
         uint amount_,
-        bool collectProtocolFee_
+        bool collectProtocolFee_,
+        uint projectFee_
     ) external returns (bool) {
         return _tryPaymentTransfer(
-            token_, client_, recipient_, amount_, collectProtocolFee_
+            token_,
+            client_,
+            recipient_,
+            amount_,
+            collectProtocolFee_,
+            projectFee_
         );
     }
 
@@ -107,13 +112,14 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
         return _lowLevelTransfer(token_, client_, recipient_, amount_);
     }
 
-    function exposed_getProtocolFeeDetails(
+    function exposed_calculateProtocolFeeAmount(
         uint totalAmount_,
         bytes4 functionSelector_,
-        bool collectProtocolFee_
+        bool collectProtocolFee_,
+        uint projectFee_
     ) external view returns (uint, uint, address) {
-        return _getProtocolFeeDetails(
-            totalAmount_, functionSelector_, collectProtocolFee_
+        return _calculateProtocolFeeAmount(
+            totalAmount_, functionSelector_, collectProtocolFee_, projectFee_
         );
     }
 
@@ -170,11 +176,12 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
         return _validPaymentToken(token_);
     }
 
-    function exposed_validateFlagsAndData(
-        bytes32 flags_,
-        bytes32[] memory data_
-    ) external pure returns (bool) {
-        return _validateFlagsAndData(flags_, data_);
+    function exposed_validateOrderFlags(bytes32 flags_)
+        external
+        pure
+        returns (bool)
+    {
+        return _validateOrderFlags(flags_);
     }
 
     function exposed_validStateTransition(
@@ -191,6 +198,14 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
         address paymentReceiver_
     ) external {
         _claimPreviouslyUnclaimable(client_, token_, paymentReceiver_);
+    }
+
+    function exposed_validProjectFee(uint projectFee_)
+        external
+        pure
+        returns (bool)
+    {
+        return _validProjectFee(projectFee_);
     }
 
     // Helper functions

--- a/test/unit/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.t.sol
+++ b/test/unit/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.t.sol
@@ -18,6 +18,8 @@ import {
 } from "@fm/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol";
 import {ERC20Issuance_v1} from "@ex/token/ERC20Issuance_v1.sol";
 import {FM_BC_Tools} from "@fm/bondingCurve/FM_BC_Tools.sol";
+import {IERC20PaymentClientBase_v2} from
+    "@lm/interfaces/IERC20PaymentClientBase_v2.sol";
 
 // External imports
 import {Clones} from "@oz/proxy/Clones.sol";
@@ -52,6 +54,10 @@ contract FM_PC_ExternalPrice_Redeeming_v1_Test is ModuleTest {
     string internal constant SYMBOL = "IST";
     uint8 internal constant DECIMALS = 18;
     uint internal constant MAX_SUPPLY = type(uint).max;
+
+    // PROCESSOR_FLAGS
+    bytes32 internal constant PROCESSOR_FLAGS =
+        0x0000000000000000000000000000000000000000000000000000000000000011;
 
     // Basis points (100%)
     uint internal constant BPS = 10_000;
@@ -1718,6 +1724,58 @@ contract FM_PC_ExternalPrice_Redeeming_v1_Test is ModuleTest {
             collateralRedeemAmount_,
             projectSellFeeAmount_,
             protocolSellFeeAmount_
+        );
+
+        IERC20PaymentClientBase_v2.PaymentOrder[] memory localPaymentOrders =
+            IERC20PaymentClientBase_v2(address(fundingManager)).paymentOrders();
+
+        assertEq(
+            localPaymentOrders.length, 1, "Payment orders length should be 1"
+        );
+        assertEq(
+            localPaymentOrders[0].amount,
+            collateralRedeemAmount_ + protocolSellFeeAmount_,
+            "Payment order amount should be the same as the final redemption amount plus the protocol fee"
+        );
+        assertEq(
+            localPaymentOrders[0].recipient,
+            receiver_,
+            "Payment order recipient should be the same as the receiver"
+        );
+        assertEq(
+            localPaymentOrders[0].paymentToken,
+            address(_token),
+            "Payment order payment token should be the same as the collateral token"
+        );
+        assertEq(
+            localPaymentOrders[0].originChainId,
+            block.chainid,
+            "Payment order origin chain id should be the same as the current chain id"
+        );
+        assertEq(
+            localPaymentOrders[0].targetChainId,
+            block.chainid,
+            "Payment order target chain id should be the same as the current chain id"
+        );
+        assertEq(
+            localPaymentOrders[0].flags,
+            PROCESSOR_FLAGS,
+            "Payment order flags should be 0"
+        );
+        assertEq(
+            localPaymentOrders[0].data.length,
+            2,
+            "Payment order data length should be 2"
+        );
+        assertEq(
+            uint(localPaymentOrders[0].data[0]),
+            1,
+            "Payment order data[0] should be 1"
+        );
+        assertEq(
+            uint(localPaymentOrders[0].data[1]),
+            sellFee_,
+            "Payment order data[1] should be the sell fee"
         );
 
         // Assert

--- a/test/unit/modules/paymentProcessor/PP_Queue_ManualExecution_v1.t.sol
+++ b/test/unit/modules/paymentProcessor/PP_Queue_ManualExecution_v1.t.sol
@@ -90,7 +90,7 @@ contract PP_Queue_ManualExecution_v1_Test is PP_Queue_v1_Test {
         uint targetChainId = block.chainid;
 
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory orders =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient,
@@ -186,7 +186,7 @@ contract PP_Queue_ManualExecution_v1_Test is PP_Queue_v1_Test {
         uint targetChainId = block.chainid;
 
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
         IERC20PaymentClientBase_v2.PaymentOrder({

--- a/test/unit/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/unit/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -11,7 +11,6 @@ import {Clones} from "@oz/proxy/Clones.sol";
 import {IERC165} from "@oz/utils/introspection/IERC165.sol";
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "forge-std/console.sol";
 
 // Tests and Mocks
 import {
@@ -65,6 +64,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         bytes4(keccak256(bytes("processPayments(address)")));
     uint internal constant BPS = 10_000;
     uint internal constant DEFAULT_MAX_ORDERS_PER_EXECUTION = 30;
+    uint internal constant FLAG_ORDER_ID = 0;
+    uint internal constant FLAG_PROJECT_FEE = 4;
 
     //Role
     bytes32 internal roleIDqueue;
@@ -165,7 +166,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         _authorizer.setIsAuthorized(address(queue), true);
 
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -411,44 +412,6 @@ contract PP_Queue_v1_Test is ModuleTest {
         }
     }
 
-    /* Test testGetPaymentQueueId_GivenFlagsAndData()
-        └── Given flags and data for queue ID retrieval
-            └── When validating the payment queue ID
-                ├── If ORDER_ID bit is set and data exists
-                │   └── Then it should return the correct queue ID.
-                └── If ORDER_ID bit is not set or data is empty
-                    └── Then it should return 0.
-    */
-    function testGetPaymentQueueId_GivenFlagsAndData(
-        uint queueId_,
-        uint8 flagBits_,
-        uint8 dataLength_
-    ) public {
-        dataLength_ = uint8(bound(dataLength_, 0, 10));
-        bytes32 flags_ = bytes32(uint(flagBits_));
-
-        bytes32[] memory data_ = new bytes32[](dataLength_);
-        if (dataLength_ > 0) {
-            data_[0] = bytes32(queueId_);
-        }
-
-        uint retrievedId_ = queue.exposed_getPaymentQueueId(flags_, data_);
-
-        if ((flagBits_ & 1 == 1) && dataLength_ > 0) {
-            assertEq(
-                retrievedId_,
-                queueId_,
-                "Queue ID mismatch when flag is set and data exists."
-            );
-        } else {
-            assertEq(
-                retrievedId_,
-                0,
-                "Should return 0 when flag is not set or data is empty."
-            );
-        }
-    }
-
     // ================================================================================
     // Test Set Max Orders Per Execution
 
@@ -535,7 +498,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
 
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: makeAddr("recipient"),
@@ -596,7 +559,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         for (uint8 i = 0; i < numOrders_; i++) {
             (bytes32 flags_, bytes32[] memory data_) =
-                helper__encodePaymentOrderData(i + 1);
+                helper__encodePaymentOrderData(i + 1, 0);
             IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
             IERC20PaymentClientBase_v2.PaymentOrder({
                 recipient: makeAddr(string.concat("recipient", vm.toString(i))),
@@ -751,7 +714,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -802,7 +765,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -956,7 +919,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1018,7 +981,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1053,7 +1016,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // First order
         (bytes32 flags1_, bytes32[] memory data1_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1091,7 +1054,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // Second order with different flags/data
         (bytes32 flags2_, bytes32[] memory data2_) =
-            helper__encodePaymentOrderData(2);
+            helper__encodePaymentOrderData(2, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1130,7 +1093,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // First order
         (bytes32 flags1_, bytes32[] memory data1_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1155,7 +1118,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // Second order with different flags/data
         (bytes32 flags2_, bytes32[] memory data2_) =
-            helper__encodePaymentOrderData(2);
+            helper__encodePaymentOrderData(2, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1208,7 +1171,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // First order
         (bytes32 flags1_, bytes32[] memory data1_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1233,7 +1196,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // Second order with different flags/data
         (bytes32 flags2_, bytes32[] memory data2_) =
-            helper__encodePaymentOrderData(2);
+            helper__encodePaymentOrderData(2, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1297,7 +1260,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1332,7 +1295,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // First order
         (bytes32 flags1_, bytes32[] memory data1_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1355,7 +1318,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // Second order with different flags/data
         (bytes32 flags2_, bytes32[] memory data2_) =
-            helper__encodePaymentOrderData(2);
+            helper__encodePaymentOrderData(2, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1403,7 +1366,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // First order
         (bytes32 flags1_, bytes32[] memory data1_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1428,7 +1391,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // Second order with different flags/data
         (bytes32 flags2_, bytes32[] memory data2_) =
-            helper__encodePaymentOrderData(2);
+            helper__encodePaymentOrderData(2, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1481,7 +1444,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // First order
         (bytes32 flags1_, bytes32[] memory data1_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1506,7 +1469,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // Second order with different flags/data
         (bytes32 flags2_, bytes32[] memory data2_) =
-            helper__encodePaymentOrderData(2);
+            helper__encodePaymentOrderData(2, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1638,7 +1601,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1830,7 +1793,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(0);
+            helper__encodePaymentOrderData(0, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1864,7 +1827,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1911,7 +1874,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1959,7 +1922,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1994,7 +1957,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2236,7 +2199,8 @@ contract PP_Queue_v1_Test is ModuleTest {
             address(paymentClient),
             invalidRecipient_,
             amount_,
-            false // don't collect protocol fee when cancelling
+            false, // don't collect protocol fee when cancelling
+            0
         );
 
         // Assert post-conditions
@@ -2333,13 +2297,15 @@ contract PP_Queue_v1_Test is ModuleTest {
         emit IModule_v1.ProtocolFeeTransferred(
             address(_token), protocolTreasury_, protocolFeeAmount
         );
+
         // Test
         bool success_ = queue.exposed_tryPaymentTransfer(
             address(_token),
             address(paymentClient),
             validRecipient_,
             amount_,
-            collectProtocolFee_
+            collectProtocolFee_,
+            0
         );
 
         // Assert post-conditions
@@ -2432,7 +2398,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Add orders to queue
         for (uint i_; i_ < 3; i_++) {
             (bytes32 flags_, bytes32[] memory data_) =
-                helper__encodePaymentOrderData(i_ + 1);
+                helper__encodePaymentOrderData(i_ + 1, 0);
 
             IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
             IERC20PaymentClientBase_v2.PaymentOrder({
@@ -2545,7 +2511,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Add orders to queue
         for (uint i_; i_ < 3; i_++) {
             (bytes32 flags_, bytes32[] memory data_) =
-                helper__encodePaymentOrderData(i_ + 1);
+                helper__encodePaymentOrderData(i_ + 1, 0);
 
             IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
             IERC20PaymentClientBase_v2.PaymentOrder({
@@ -2586,7 +2552,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
@@ -2651,7 +2617,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2851,7 +2817,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
         (bytes32 flags_, bytes32[] memory data_) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -3388,24 +3354,95 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
     }
 
-    /* Test: Function _getProtocolFeeDetails()
-        └── Given valid protocol fee amount
-            ├── And the collectProtocolFee flag is true
-            │   └── When the function _getProtocolFeeDetails() is called
-            │       └── Then it should return the correct fee amount and treasury address
-            └── And the collectProtocolFee flag is false
-                └── When the function _getProtocolFeeDetails() is called
+    /*  Test: Function _calculateProtocolFeeAmount()
+        └── Given collectProtocolFee flag is set to false
+            └── When the function _calculateProtocolFeeAmount() is called
+                └── Then it should return 0 for the fee and total amount as net amount
+    */
+    function testInternalCalculateProtocolFeeAmount_worksGivenCollectProtocolFeeFlagIsFalse(
+        uint totalAmount_,
+        uint projectFee_
+    ) public {
+        // Setup
+        vm.assume(projectFee_ > 0);
+        bool collectProtocolFee_ = false;
+
+        // Test function call
+        (uint feeAmount, uint netAmount, address treasury) = queue
+            .exposed_calculateProtocolFeeAmount(
+            totalAmount_,
+            PROCESS_PAYMENTS_FUNCTION_SELECTOR,
+            collectProtocolFee_,
+            projectFee_
+        );
+
+        // Post-assertions
+        assertEq(feeAmount, 0, "Fee amount should be 0");
+        assertEq(netAmount, totalAmount_, "Net amount should be correct");
+        assertEq(treasury, address(0), "Treasury should be 0 address");
+    }
+
+    /*  Test: Function _calculateProtocolFeeAmount()
+        └── Given collectProtocolFee flag is set to true
+            └── And the protocol fee == 0
+                └── When the function _calculateProtocolFeeAmount() is called
                     └── Then it should return 0 for the fee and total amount as net amount
     */
-
-    function testInternalGetProtocolFeeAmountAndTreasury_worksGivenCorrectFeeDetailsRetrieved(
-        uint protocolFee_,
-        uint totalAmount_
+    function testInternalCalculateProtocolFeeAmount_worksGivenCollectProtocolFeeFlagIsTrueAndProtocolFeeIsZero(
+        uint totalAmount_,
+        uint projectFee_
     ) public {
-        protocolFee_ = bound(protocolFee_, 1, feeManager.maxFee());
-        totalAmount_ = bound(totalAmount_, 1e18, type(uint128).max);
+        // Setup
+        projectFee_ = 0;
         bool collectProtocolFee_ = true;
 
+        // Set protocol fee to 0
+        feeManager.setCollateralWorkflowFee(
+            address(_orchestrator),
+            address(queue),
+            PROCESS_PAYMENTS_FUNCTION_SELECTOR,
+            true,
+            0 // protocol fee is 0
+        );
+
+        // Calculate expected values
+        address expectedTreasury =
+            feeManager.getWorkflowTreasuries(address(_orchestrator));
+
+        // Test function call
+        (uint feeAmount, uint netAmount, address treasury) = queue
+            .exposed_calculateProtocolFeeAmount(
+            totalAmount_,
+            PROCESS_PAYMENTS_FUNCTION_SELECTOR,
+            collectProtocolFee_,
+            projectFee_
+        );
+
+        // Post-assertions
+        assertEq(feeAmount, 0, "Fee amount should be 0");
+        assertEq(netAmount, totalAmount_, "Net amount should be correct");
+        assertEq(treasury, expectedTreasury, "Treasury should be correct");
+    }
+
+    /*  Test: Function _calculateProtocolFeeAmount()
+        └── Given collectProtocolFee flag is set to true
+            ├── And the protocol fee is > 0
+            └── And the project fee == 0
+                └── When the function _calculateProtocolFeeAmount() is called
+                    └── Then it should return the correct fee amount and treasury address
+    */
+    function testInternalCalculateProtocolFeeAmount_worksGivenCollectProtocolFeeFlagIsTrueAndProtocolFeeIsGreaterThanZeroAndProjectFeeIsZero(
+        uint protocolFee_,
+        uint totalAmount_,
+        uint projectFee_
+    ) public {
+        // Setup
+        protocolFee_ = bound(protocolFee_, 10, 1000); // max 10%
+        totalAmount_ = bound(totalAmount_, 1e18, type(uint128).max);
+        projectFee_ = 0;
+        bool collectProtocolFee_ = true;
+
+        // Set protocol fee
         feeManager.setCollateralWorkflowFee(
             address(_orchestrator),
             address(queue),
@@ -3414,40 +3451,114 @@ contract PP_Queue_v1_Test is ModuleTest {
             protocolFee_
         );
 
-        uint expectedFeeAmount = totalAmount_ * protocolFee_ / BPS;
+        // Calculate expected values
+        (uint expectedNetAmount, uint expectedProtocolFeeAmount,) =
+        helper_calculateNetAndSplitFees(totalAmount_, protocolFee_, projectFee_);
         address expectedTreasury =
             feeManager.getWorkflowTreasuries(address(_orchestrator));
 
+        // Test function call
         (uint feeAmount, uint netAmount, address treasury) = queue
-            .exposed_getProtocolFeeDetails(
-            totalAmount_,
+            .exposed_calculateProtocolFeeAmount(
+            expectedNetAmount + expectedProtocolFeeAmount,
             PROCESS_PAYMENTS_FUNCTION_SELECTOR,
-            collectProtocolFee_
+            collectProtocolFee_,
+            projectFee_
         );
 
-        assertEq(feeAmount, expectedFeeAmount, "Fee amount should be correct");
-        assertEq(
-            netAmount, totalAmount_ - feeAmount, "Net amount should be correct"
+        // Post-assertions
+        assertApproxEqAbs(
+            feeAmount,
+            expectedProtocolFeeAmount,
+            1,
+            "Fee amount should be correct"
+        );
+        assertApproxEqAbs(
+            netAmount, expectedNetAmount, 1, "Net amount should be correct"
+        );
+        assertEq(treasury, expectedTreasury, "Treasury should be correct");
+    }
+    /*  Test: Function _calculateProtocolFeeAmount()
+        └── Given collectProtocolFee flag is set to true
+            ├── And the protocol fee is > 0
+            └── And the project fee > 0
+                └── When the function _calculateProtocolFeeAmount() is called
+                    └── Then it should return the correct fee amount and treasury address
+    */
+
+    function testInternalCalculateProtocolFeeAmount_worksGivenCollectProtocolFeeFlagIsTrueAndProtocolFeeAndProjectFeeAreGreaterThanZero(
+        uint protocolFee_,
+        uint totalAmount_,
+        uint projectFee_
+    ) public {
+        // Setup
+        protocolFee_ = bound(protocolFee_, 10, 1000); // max 10%
+        totalAmount_ = bound(totalAmount_, 1e18, type(uint128).max);
+        projectFee_ = bound(projectFee_, 10, 1000); // max 10%
+        bool collectProtocolFee_ = true;
+        // Set protocol fee
+        feeManager.setCollateralWorkflowFee(
+            address(_orchestrator),
+            address(queue),
+            PROCESS_PAYMENTS_FUNCTION_SELECTOR,
+            true,
+            protocolFee_
+        );
+
+        // Calculate expected values
+        (uint expectedNetAmount, uint expectedProtocolFeeAmount,) =
+        helper_calculateNetAndSplitFees(totalAmount_, protocolFee_, projectFee_);
+        address expectedTreasury =
+            feeManager.getWorkflowTreasuries(address(_orchestrator));
+
+        // Test function call
+        (uint feeAmount, uint netAmount, address treasury) = queue
+            .exposed_calculateProtocolFeeAmount(
+            expectedNetAmount + expectedProtocolFeeAmount,
+            PROCESS_PAYMENTS_FUNCTION_SELECTOR,
+            collectProtocolFee_,
+            projectFee_
+        );
+
+        // Post-assertions
+        assertApproxEqAbs(
+            feeAmount,
+            expectedProtocolFeeAmount,
+            1,
+            "Fee amount should be correct"
+        );
+        assertApproxEqAbs(
+            netAmount, expectedNetAmount, 1, "Net amount should be correct"
         );
         assertEq(treasury, expectedTreasury, "Treasury should be correct");
     }
 
-    function testInternalGetProtocolFeeAmountAndTreasury_worksGivenNoFee(
-        uint totalAmount_
-    ) public {
-        totalAmount_ = bound(totalAmount_, 1e18, type(uint128).max);
-        bool collectProtocolFee_ = false;
+    /* Test: function _validateOrderFlags()
+        └── Given valid order flags
+            └── When the function _validateOrderFlags() is called
+                └── Then it should return true
+    */
 
-        (uint feeAmount, uint netAmount, address treasury) = queue
-            .exposed_getProtocolFeeDetails(
-            totalAmount_,
-            PROCESS_PAYMENTS_FUNCTION_SELECTOR,
-            collectProtocolFee_
-        );
+    function testInternalValidateOrderFlags_worksGivenValidFlags() public {
+        bytes32 flags = bytes32(uint(0));
+        flags |= bytes32((1 << FLAG_ORDER_ID));
+        flags |= bytes32((1 << FLAG_PROJECT_FEE));
 
-        assertEq(feeAmount, 0, "Fee amount should be 0");
-        assertEq(netAmount, totalAmount_, "Net amount should be correct");
-        assertEq(treasury, address(0), "Treasury should be 0 address");
+        assertTrue(queue.exposed_validateOrderFlags(flags));
+    }
+
+    /* Test: function _validateOrderFlags()
+        └── Given invalid order flags
+            └── When the function _validateOrderFlags() is called
+                └── Then it should return false
+    */
+
+    function testInternalValidateOrderFlags_worksGivenInvalidFlags() public {
+        bytes32 flags = bytes32(uint(0));
+        flags |= bytes32((1 << uint(200)));
+        flags |= bytes32((1 << uint(21)));
+
+        assertFalse(queue.exposed_validateOrderFlags(flags));
     }
 
     /* Test testValidChainId_GivenValidAndInvalidIds()
@@ -3739,60 +3850,106 @@ contract PP_Queue_v1_Test is ModuleTest {
         assertFalse(queue.exposed_validPaymentToken(address(0)));
     }
 
-    /* Test testValidateFlagsAndData_GivenValidFlagsAndData()
-        └── Given valid flags with ORDER_ID bit set
-            └── And data array with order ID
-                └── Then it should return true
+    /* Test: Function _getOrderDetailsFromFlagsAndData()
+        └── Given valid flags and data
+            └── When the function _getOrderDetailsFromFlagsAndData() is called
+                └── Then it should return the correct order details
     */
-    function testInternalValidateFlagsAndData_worksGivenValidFlagsAndData()
-        public
-    {
-        bytes32 flags = bytes32(uint(1)); // Set ORDER_ID bit
-        bytes32[] memory data = new bytes32[](1);
-        data[0] = bytes32(uint(123)); // Some order ID
-
-        assertTrue(queue.exposed_validateFlagsAndData(flags, data));
-    }
-
-    /* Test testValidateFlagsAndData_GivenValidFlagsWithoutData()
-        └── Given valid flags without ORDER_ID bit set
-            └── And empty data array
-                └── Then it should return true
-    */
-    function testInternalValidateFlagsAndData_worksGivenValidFlagsWithoutData()
-        public
-    {
-        bytes32 flags = bytes32(uint(0)); // No bits set
-        bytes32[] memory data = new bytes32[](0);
-
-        assertFalse(queue.exposed_validateFlagsAndData(flags, data));
-    }
-
-    /* Test testValidateFlagsAndData_GivenInvalidFlagsWithData()
-        └── Given flags with ORDER_ID bit set
-            └── And empty data array
-                └── Then it should return false
-    */
-    function testInternalValidateFlagsAndData_FailsGivenInvalidFlagsWithData()
-        public
-    {
-        bytes32 flags = bytes32(uint(1)); // Set ORDER_ID bit
-        bytes32[] memory data = new bytes32[](0); // Empty data array
-
-        assertFalse(queue.exposed_validateFlagsAndData(flags, data));
-    }
-
-    /* Test testValidateFlagsAndData_GivenInvalidFlagsWithoutData()
-        └── Given flags with invalid bits set
-            └── And empty data array
-                └── Then it should return false
-    */
-    function testInternalValidateFlagsAndData_FailsGivenInvalidFlagsWithoutData(
+    function testInternalGetOrderDetailsFromFlagsAndData_worksGivenValidFlagsAndData(
+        uint orderId_,
+        uint projectFee_
     ) public {
-        bytes32 flags = bytes32(uint(2)); // Set invalid bit
-        bytes32[] memory data = new bytes32[](0);
+        // Setup
+        bytes32 flags = bytes32(uint(0));
+        bytes32[] memory data = new bytes32[](2);
+        // Set flags
+        flags |= bytes32((1 << FLAG_ORDER_ID)); // ORDER_ID
+        flags |= bytes32((1 << FLAG_PROJECT_FEE)); // PROJECT_FEE
 
-        assertFalse(queue.exposed_validateFlagsAndData(flags, data));
+        // Fill data array in the order of set bits
+        data[0] = bytes32(uint(orderId_)); // Bit 0 data
+        data[1] = bytes32(uint(projectFee_)); // Bit 4 data
+
+        // Test function call
+        (uint orderId, uint projectFee) =
+            queue.exposed_getOrderDetailsFromFlagsAndData(flags, data);
+
+        // Post-assertions
+        assertEq(orderId, orderId_, "Order ID should be correct");
+        assertEq(projectFee, projectFee_, "Project fee should be correct");
+    }
+
+    function testInternalGetOrderDetailsFromFlagsAndData_worksGivenValidFlagsAndDataWithExtraData(
+        uint orderId_,
+        uint projectFee_
+    ) public {
+        // Setup
+        bytes32 flags = bytes32(uint(0));
+
+        // Order provides 5 data slots with corresponding flags set
+        bytes32[] memory data = new bytes32[](5);
+
+        // Set up the order with extra data:
+        // Bit 0: ORDER_ID (processor needs this)
+        // Bit 1: Some extra data (processor doesn't need)
+        // Bit 2: Some extra data (processor doesn't need)
+        // Bit 3: Some extra data (processor doesn't need)
+        // Bit 4: PROJECT_FEE (processor needs this)
+
+        flags |= bytes32((1 << FLAG_ORDER_ID)); // ORDER_ID
+        flags |= bytes32((1 << uint(1))); // Extra data 1
+        flags |= bytes32((1 << uint(2))); // Extra data 2
+        flags |= bytes32((1 << uint(3))); // Extra data 3
+        flags |= bytes32((1 << FLAG_PROJECT_FEE)); // PROJECT_FEE
+
+        // Fill data array in the order of set bits
+        data[0] = bytes32(uint(orderId_)); // Bit 0 data
+        data[1] = bytes32(uint(9999)); // Bit 1 data (extra)
+        data[2] = bytes32(uint(8888)); // Bit 2 data (extra)
+        data[3] = bytes32(uint(7777)); // Bit 3 data (extra)
+        data[4] = bytes32(uint(projectFee_)); // Bit 4 data
+
+        // The function should:
+        // 1. Read data[0] for bit 0 (processor needs it)
+        // 2. Skip data[1] for bit 1 (processor doesn't need it)
+        // 3. Skip data[2] for bit 2 (processor doesn't need it)
+        // 4. Skip data[3] for bit 3 (processor doesn't need it)
+        // 5. Read data[4] for bit 4 (processor needs it)
+
+        // Test function call
+        (uint orderId, uint projectFee) =
+            queue.exposed_getOrderDetailsFromFlagsAndData(flags, data);
+
+        // Post-assertions
+        assertEq(orderId, orderId_, "Order ID should be correct");
+        assertEq(projectFee, projectFee_, "Project fee should be correct");
+    }
+
+    /* Test: function _getOrderDetailsFromFlagsAndData()
+        └── Given flags are not valid
+            └── When the function _getOrderDetailsFromFlagsAndData() is called
+                └── Then it should return 0 for the order ID and project fee
+    */
+    function testInternalGetOrderDetailsFromFlagsAndData_worksGivenInvalidFlagsReturnsZero(
+    ) public {
+        // Setup
+        // Set invalid flags
+        bytes32 flags = bytes32(uint(0));
+        flags |= bytes32((1 << uint(11)));
+        flags |= bytes32((1 << uint(12)));
+
+        // Set data
+        bytes32[] memory data = new bytes32[](2);
+        data[0] = bytes32(uint(112));
+        data[1] = bytes32(uint(122));
+
+        // Test function call
+        (uint orderId, uint projectFee) =
+            queue.exposed_getOrderDetailsFromFlagsAndData(flags, data);
+
+        // Post-assertions
+        assertEq(orderId, 0, "Order ID should be 0");
+        assertEq(projectFee, 0, "Project fee should be 0");
     }
 
     /* Test testValidStateTransition_RevertGivenInvalidTransition()
@@ -3918,7 +4075,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
         (bytes32 flags, bytes32[] memory data) =
-            helper__encodePaymentOrderData(1);
+            helper__encodePaymentOrderData(1, 0);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory invalidOrder =
         IERC20PaymentClientBase_v2.PaymentOrder({
@@ -3955,6 +4112,32 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
     }
 
+    /*  Test: Function _validProjectFee()
+        └── Given the project fee is > BPS
+            └── When the function _validProjectFee() is called
+                └── Then it should return false
+    */
+
+    function testInternalValidProjectFee_failsGivenProjectFeeGreaterThanBPS(
+        uint projectFee_
+    ) public {
+        vm.assume(projectFee_ > BPS);
+        assertFalse(queue.exposed_validProjectFee(projectFee_));
+    }
+
+    /*  Test: Function _validProjectFee()
+        └── Given the project fee is < BPS
+            └── When the function _validProjectFee() is called
+                └── Then it should return true
+    */
+
+    function testInternalValidProjectFee_worksGivenProjectFeeLessThanBPS(
+        uint projectFee_
+    ) public {
+        vm.assume(projectFee_ < BPS);
+        assertTrue(queue.exposed_validProjectFee(projectFee_));
+    }
+
     // ================================================================================
     // Helper Functions
 
@@ -3972,6 +4155,29 @@ contract PP_Queue_v1_Test is ModuleTest {
         return recipient_;
     }
 
+    function helper_calculateNetAndSplitFees(
+        uint _totalAmount,
+        uint _protocolFee,
+        uint _projectFee
+    )
+        internal
+        pure
+        returns (uint netAmount, uint protocolFeeAmount, uint projectFeeAmount)
+    {
+        // Calculate protocol fee amount if applicable
+        if (_protocolFee > 0) {
+            protocolFeeAmount = _totalAmount * _protocolFee / BPS;
+            // Revert if calculated protocol fee amount rounded down to zero
+        }
+        // Calculate project fee amount if applicable
+        if (_projectFee > 0) {
+            projectFeeAmount = _totalAmount * _projectFee / BPS;
+            // Revert if calculated project fee amount rounded down to zero
+        }
+
+        netAmount = _totalAmount - protocolFeeAmount - projectFeeAmount;
+    }
+
     function helper_createTestPaymentOrder(
         address recipient_,
         uint96 amount_,
@@ -3979,7 +4185,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address token_
     ) internal view returns (IERC20PaymentClientBase_v2.PaymentOrder memory) {
         (bytes32 flags, bytes32[] memory data) =
-            helper__encodePaymentOrderData(orderNum_);
+            helper__encodePaymentOrderData(orderNum_, 0);
         return IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
             amount: amount_,
@@ -4029,7 +4235,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         assertEq(uint(queuedOrder.state_), uint(expectedState_), "Wrong state");
     }
 
-    function helper__encodePaymentOrderData(uint orderId_)
+    function helper__encodePaymentOrderData(uint orderId_, uint projectFee_)
         internal
         pure
         returns (bytes32 flags_, bytes32[] memory data_)
@@ -4037,13 +4243,16 @@ contract PP_Queue_v1_Test is ModuleTest {
         bytes32 _flags;
         _flags = 0;
 
-        uint8[] memory flags = new uint8[](1); // The Module will use 1 flag
-        flags[0] = 0;
+        uint8[] memory flags = new uint8[](2); // The Module will use 2 flag
+        flags[0] = 0; // ORDER_ID
+        flags[1] = 4; // PROJECT_FEE
 
         _flags |= bytes32((1 << flags[0]));
+        _flags |= bytes32((1 << flags[1]));
 
-        bytes32[] memory paymentParameters = new bytes32[](1);
+        bytes32[] memory paymentParameters = new bytes32[](2);
         paymentParameters[0] = bytes32(orderId_);
+        paymentParameters[1] = bytes32(projectFee_);
 
         return (_flags, paymentParameters);
     }

--- a/test/unit/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/unit/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -63,7 +63,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     bytes4 internal constant PROCESS_PAYMENTS_FUNCTION_SELECTOR =
         bytes4(keccak256(bytes("processPayments(address)")));
     uint internal constant BPS = 10_000;
-    uint internal constant DEFAULT_MAX_ORDERS_PER_EXECUTION = 30;
+    uint internal constant DEFAULT_MAX_ORDERS_PER_EXECUTION = 50;
     uint internal constant FLAG_ORDER_ID = 0;
     uint internal constant FLAG_PROJECT_FEE = 4;
 


### PR DESCRIPTION
## Why has this been done?
- The protocol collateral fee for selling is calculated in the Payment Client within a calculation using also the project fee percentage. However it is not collected in the Payment Client due to the collateral not being in the contract at time of calculation
- This created a situation whereby when re-calculating it in the Payment Processor, the total amount from which the fee is calculated differs from the first time the calculation is done, resulting in a different net and protocol fee amount
- To accommodated for this, the project fee is added to the payment order so the correct protocol fee amount can be correctly be re-calculated

## What has been done?
- Project Fee parameter has been added to the payment order.
- The functions to `get` and validate the data from the payment orders have been refactored and adapted for the new field in the payment order
- A E2E test has been added that tests the whole flow with collateral project fee enabled for buy and sell & protocol fee enabled for issuance/collateral for both buy and sell