### PR TITLE
Fix: update version in contracts inheriting from BondingCurveBase

### DIFF
--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -66,7 +66,7 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
  *                          to our Security Policy at security.inverter.network
  *                          or email us directly!
  *
- * @custom:version 1.1.2
+ * @custom:version 1.1.3
  *
  * @author  Inverter Network
  */

--- a/src/modules/fundingManager/bondingCurve/FM_BC_BondingSurface_Redeeming_Restricted_Repayer_Seizable_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_BondingSurface_Redeeming_Restricted_Repayer_Seizable_v1.sol
@@ -57,7 +57,7 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
  *                          our Security Policy at security.inverter.network or
  *                          email us directly!
  *
- * @custom:version  v1.0.0
+ * @custom:version  v1.0.1
  *
  * @custom:inverter-standard-version    v0.1.0
  *

--- a/src/modules/fundingManager/bondingCurve/FM_BC_BondingSurface_Redeeming_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_BondingSurface_Redeeming_v1.sol
@@ -51,7 +51,7 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
  *                          our Security Policy at security.inverter.network or
  *                          email us directly!
  *
- * @custom:version  v1.0.0
+ * @custom:version  v1.0.1
  *
  * @custom:inverter-standard-version    v0.1.0
  *

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -37,7 +37,7 @@ import {
  *                          to our Security Policy at security.inverter.network
  *                          or email us directly!
  *
- * @custom:version 1.1.2
+ * @custom:version 1.1.3
  *
  * @author  Inverter Network
  */

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -35,7 +35,7 @@ import {ERC165Upgradeable} from
  *                          to our Security Policy at security.inverter.network
  *                          or email us directly!
  *
- * @custom:version 1.1.2
+ * @custom:version 1.1.3
  *
  * @author  Inverter Network
  */

--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -35,7 +35,7 @@ import {ERC165Upgradeable} from
  *                          to our Security Policy at security.inverter.network
  *                          or email us directly!
  *
- * @custom:version 1.1.3
+ * @custom:version 1.1.4
  *
  * @author  Inverter Network
  */


### PR DESCRIPTION
The PR #456 patched the BondingCurve base. However the version was not updated. This PR resolves this issue