### PR TITLE
Feat: House Protocol Dynamic Fee Calculator Implementation

### DIFF
--- a/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
@@ -478,13 +478,16 @@ contract LM_PC_HouseProtocol_v1 is
         view
         returns (uint)
     {
-        if (dynamicFeeCalculator == address(0)) {
-            return 0; // No fee if no calculator is set
-        }
-
-        // Calculate fee based on floor liquidity rate
-        uint floorLiquidityRate = this.getFloorLiquidityRate();
-        return (requestedAmount_ * floorLiquidityRate) / 10_000; // Fee based on liquidity rate
+        // Calculate fee using the dynamic fee calculator library
+        uint utilizationRatio =
+            (currentlyBorrowedAmount * 1e18) / _calculateBorrowCapacity();
+        uint feeRate = DynamicFeeCalculatorLib_v1.calculateOriginationFee(
+            utilizationRatio,
+            _dynamicFeeParameters.Z_origination,
+            _dynamicFeeParameters.A_origination,
+            _dynamicFeeParameters.m_origination
+        );
+        return (requestedAmount_ * feeRate) / 1e18; // Fee based on calculated rate
     }
 
     /// @dev Calculate issuance tokens to unlock based on repayment amount

--- a/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
@@ -22,6 +22,12 @@ import {ERC165Upgradeable} from
 // System under Test (SuT)
 import {ILM_PC_HouseProtocol_v1} from
     "src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol";
+import {
+    IFM_BC_Discrete_Redeeming_VirtualSupply_v1
+} from "src/modules/fundingManager/bondingCurve/interfaces/IFM_BC_Discrete_Redeeming_VirtualSupply_v1.sol";
+import {
+    IVirtualCollateralSupplyBase_v1
+} from "src/modules/fundingManager/bondingCurve/interfaces/IVirtualCollateralSupplyBase_v1.sol";
 
 /**
  * @title   House Protocol Lending Facility Logic Module
@@ -168,23 +174,20 @@ contract LM_PC_HouseProtocol_v1 is
         uint userBorrowingPower = _calculateUserBorrowingPower(user);
 
         // Ensure user has sufficient borrowing power
-        require(
-            requestedLoanAmount_ <= userBorrowingPower,
-            "Insufficient borrowing power"
-        );
+        if (requestedLoanAmount_ > userBorrowingPower) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientBorrowingPower();
+        }
 
         // Check if borrowing would exceed borrowable quota
-        require(
-            currentlyBorrowedAmount + requestedLoanAmount_
-                <= _calculateBorrowCapacity() * borrowableQuota / 10_000,
-            "Borrowable quota exceeded"
-        );
+        if (currentlyBorrowedAmount + requestedLoanAmount_
+                > _calculateBorrowCapacity() * borrowableQuota / 10_000) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_BorrowableQuotaExceeded();
+        }
 
         // Check individual borrow limit
-        require(
-            requestedLoanAmount_ <= individualBorrowLimit,
-            "Individual borrow limit exceeded"
-        );
+        if (requestedLoanAmount_ > individualBorrowLimit) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_IndividualBorrowLimitExceeded();
+        }
 
         // Calculate dynamic borrowing fee
         uint dynamicBorrowingFee =
@@ -216,10 +219,9 @@ contract LM_PC_HouseProtocol_v1 is
     function repay(uint repaymentAmount_) external virtual {
         address user = _msgSender();
 
-        require(
-            _outstandingLoans[user] >= repaymentAmount_,
-            "Repayment amount exceeds outstanding loan"
-        );
+        if (_outstandingLoans[user] < repaymentAmount_) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_RepaymentAmountExceedsLoan();
+        }
 
         // Update state
         _outstandingLoans[user] -= repaymentAmount_;
@@ -245,13 +247,21 @@ contract LM_PC_HouseProtocol_v1 is
     function lockIssuanceTokens(uint amount_) external virtual {
         address user = _msgSender();
 
-        require(amount_ > 0, "Amount must be greater than zero");
+        if (amount_ == 0) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount();
+        }
 
         // Transfer issuance tokens from user to contract
         _issuanceToken.safeTransferFrom(user, address(this), amount_);
 
         // Update locked amount
         _lockedIssuanceTokens[user] += amount_;
+
+        // Calculate and transfer required collateral tokens
+        uint collateralAmount = _calculateCollateralAmount(amount_);
+        if (collateralAmount > 0) {
+            _collateralToken.safeTransferFrom(user, address(this), collateralAmount);
+        }
 
         // Emit event
         emit IssuanceTokensLocked(user, amount_);
@@ -261,15 +271,13 @@ contract LM_PC_HouseProtocol_v1 is
     function unlockIssuanceTokens(uint amount_) external virtual {
         address user = _msgSender();
 
-        require(
-            _lockedIssuanceTokens[user] >= amount_,
-            "Insufficient locked issuance tokens"
-        );
+        if (_lockedIssuanceTokens[user] < amount_) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientLockedTokens();
+        }
 
-        require(
-            _outstandingLoans[user] == 0,
-            "Cannot unlock tokens with outstanding loan"
-        );
+        if (_outstandingLoans[user] > 0) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_CannotUnlockWithOutstandingLoan();
+        }
 
         // Update locked amount
         _lockedIssuanceTokens[user] -= amount_;
@@ -300,10 +308,9 @@ contract LM_PC_HouseProtocol_v1 is
         external
         onlyLendingFacilityManager
     {
-        require(
-            newBorrowableQuota_ <= _MAX_BORROWABLE_QUOTA,
-            "Borrowable quota cannot exceed 100%"
-        );
+        if (newBorrowableQuota_ > _MAX_BORROWABLE_QUOTA) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_BorrowableQuotaTooHigh();
+        }
         borrowableQuota = newBorrowableQuota_;
         emit BorrowableQuotaUpdated(newBorrowableQuota_);
     }
@@ -314,9 +321,9 @@ contract LM_PC_HouseProtocol_v1 is
         external
         onlyLendingFacilityManager
     {
-        require(
-            newFeeCalculator_ != address(0), "Invalid fee calculator address"
-        );
+        if (newFeeCalculator_ == address(0)) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidFeeCalculatorAddress();
+        }
         dynamicFeeCalculator = newFeeCalculator_;
         emit DynamicFeeCalculatorUpdated(newFeeCalculator_);
     }
@@ -376,16 +383,19 @@ contract LM_PC_HouseProtocol_v1 is
     /// @dev Ensures the borrow amount is valid
     /// @param amount_ The amount to validate
     function _ensureValidBorrowAmount(uint amount_) internal pure {
-        require(amount_ > 0, "Borrow amount must be greater than zero");
+        if (amount_ == 0) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount();
+        }
     }
 
     /// @dev Calculate the system-wide Borrow Capacity
     /// @return The borrow capacity
     function _calculateBorrowCapacity() internal view returns (uint) {
-        // This would need to be implemented based on the actual DBC FM interface
-        // For now, returning a placeholder value
-        // In reality, this would be: virtualIssuanceSupply * P_floor
-        return 1_000_000 ether; // Placeholder
+        // Use the DBC FM to get the actual virtual collateral supply
+        // Borrow capacity = virtual collateral supply (this represents the total backing)
+        IVirtualCollateralSupplyBase_v1 dbcFm = 
+            IVirtualCollateralSupplyBase_v1(_dbcFmAddress);
+        return dbcFm.getVirtualCollateralSupply();
     }
 
     /// @dev Calculate user's borrowing power based on locked issuance tokens
@@ -396,10 +406,12 @@ contract LM_PC_HouseProtocol_v1 is
         view
         returns (uint)
     {
-        // This would need to be implemented based on the actual DBC FM interface
-        // For now, returning a placeholder calculation
-        // In reality, this would be: UserLockedIssuanceTokens * P_floor
-        return _lockedIssuanceTokens[user_] * 2; // Placeholder: 2x leverage
+        // Use the DBC FM to get the actual floor price
+        // User borrowing power = locked issuance tokens * floor price
+        IFM_BC_Discrete_Redeeming_VirtualSupply_v1 dbcFm = 
+            IFM_BC_Discrete_Redeeming_VirtualSupply_v1(_dbcFmAddress);
+        uint floorPrice = dbcFm.getStaticPriceForBuying();
+        return _lockedIssuanceTokens[user_] * floorPrice / 1e18; // Adjust for decimals
     }
 
     /// @dev Calculate dynamic borrowing fee using the fee calculator
@@ -414,10 +426,9 @@ contract LM_PC_HouseProtocol_v1 is
             return 0; // No fee if no calculator is set
         }
 
-        // This would need to be implemented based on the actual fee calculator interface
-        // For now, returning a placeholder calculation
+        // Calculate fee based on floor liquidity rate
         uint floorLiquidityRate = this.getFloorLiquidityRate();
-        return (requestedAmount_ * floorLiquidityRate) / 10_000; // Placeholder: 1% fee
+        return (requestedAmount_ * floorLiquidityRate) / 10_000; // Fee based on liquidity rate
     }
 
     /// @dev Calculate issuance tokens to unlock based on repayment amount
@@ -436,5 +447,21 @@ contract LM_PC_HouseProtocol_v1 is
 
         // Calculate the proportion of locked issuance tokens to unlock
         return (_lockedIssuanceTokens[user_] * repaymentProportion) / 10_000;
+    }
+
+    /// @dev Calculate the required collateral amount for a given issuance token amount
+    /// @param issuanceTokenAmount_ The amount of issuance tokens
+    /// @return The required collateral amount
+    function _calculateCollateralAmount(uint issuanceTokenAmount_)
+        internal
+        view
+        returns (uint)
+    {
+        // Use the DBC FM to get the actual floor price
+        // Required collateral = issuance tokens * floor price
+        IFM_BC_Discrete_Redeeming_VirtualSupply_v1 dbcFm = 
+            IFM_BC_Discrete_Redeeming_VirtualSupply_v1(_dbcFmAddress);
+        uint floorPrice = dbcFm.getStaticPriceForBuying();
+        return issuanceTokenAmount_ * floorPrice / 1e18; // Adjust for decimals
     }
 }

--- a/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
@@ -121,22 +121,22 @@ contract LM_PC_HouseProtocol_v1 is
     /// @notice DBC FM address for floor price calculations
     address internal _dbcFmAddress;
 
-    /// @notice Base fee component for issuance/redemption fees (as per formulas in 6.4.2).
+    /// @notice Base fee component for issuance/redemption fees.
     uint public Z_issueRedeem;
 
-    /// @notice premiumRate threshold for dynamic issuance/redemption fee adjustment (as per formulas in 6.4.2).
+    /// @notice premiumRate threshold for dynamic issuance/redemption fee adjustment.
     uint public A_issueRedeem;
 
-    /// @notice Multiplier for dynamic issuance/redemption fee component (as per formulas in 6.4.2).
+    /// @notice Multiplier for dynamic issuance/redemption fee component.
     uint public m_issueRedeem;
 
-    /// @notice Base fee component for origination fees (as per formula in 6.4.1).
+    /// @notice Base fee component for origination fees.
     uint public Z_origination;
 
-    /// @notice floorLiquidityRate threshold for dynamic origination fee adjustment (as per formula in 6.4.1).
+    /// @notice floorLiquidityRate threshold for dynamic origination fee adjustment.
     uint public A_origination;
 
-    /// @notice Multiplier for dynamic origination fee component (as per formula in 6.4.1).
+    /// @notice Multiplier for dynamic origination fee component.
     uint public m_origination;
 
     /// @notice Storage gap for future upgrades

--- a/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
@@ -22,12 +22,10 @@ import {ERC165Upgradeable} from
 // System under Test (SuT)
 import {ILM_PC_HouseProtocol_v1} from
     "src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol";
-import {
-    IFM_BC_Discrete_Redeeming_VirtualSupply_v1
-} from "src/modules/fundingManager/bondingCurve/interfaces/IFM_BC_Discrete_Redeeming_VirtualSupply_v1.sol";
-import {
-    IVirtualCollateralSupplyBase_v1
-} from "src/modules/fundingManager/bondingCurve/interfaces/IVirtualCollateralSupplyBase_v1.sol";
+import {IFM_BC_Discrete_Redeeming_VirtualSupply_v1} from
+    "src/modules/fundingManager/bondingCurve/interfaces/IFM_BC_Discrete_Redeeming_VirtualSupply_v1.sol";
+import {IVirtualCollateralSupplyBase_v1} from
+    "src/modules/fundingManager/bondingCurve/interfaces/IVirtualCollateralSupplyBase_v1.sol";
 import {DynamicFeeCalculatorLib_v1} from
     "src/modules/logicModule/libraries/DynamicFeeCalculator_v1.sol";
 
@@ -121,23 +119,8 @@ contract LM_PC_HouseProtocol_v1 is
     /// @notice DBC FM address for floor price calculations
     address internal _dbcFmAddress;
 
-    /// @notice Base fee component for issuance/redemption fees.
-    uint public Z_issueRedeem;
-
-    /// @notice premiumRate threshold for dynamic issuance/redemption fee adjustment.
-    uint public A_issueRedeem;
-
-    /// @notice Multiplier for dynamic issuance/redemption fee component.
-    uint public m_issueRedeem;
-
-    /// @notice Base fee component for origination fees.
-    uint public Z_origination;
-
-    /// @notice floorLiquidityRate threshold for dynamic origination fee adjustment.
-    uint public A_origination;
-
-    /// @notice Multiplier for dynamic origination fee component.
-    uint public m_origination;
+    /// @notice Parameters for the dynamic fee calculator
+    DynamicFeeParameters internal _dynamicFeeParameters;
 
     /// @notice Storage gap for future upgrades
     uint[50] private __gap;
@@ -205,30 +188,43 @@ contract LM_PC_HouseProtocol_v1 is
 
         // Ensure user has sufficient borrowing power
         if (requestedLoanAmount_ > userBorrowingPower) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientBorrowingPower();
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InsufficientBorrowingPower();
         }
 
         // Calculate how much issuance tokens need to be locked for this borrow amount
-        uint requiredIssuanceTokens = _calculateRequiredIssuanceTokens(requestedLoanAmount_);
-        
+        uint requiredIssuanceTokens =
+            _calculateRequiredIssuanceTokens(requestedLoanAmount_);
+
         // Ensure user has sufficient issuance tokens to lock
         if (userIssuanceTokens < requiredIssuanceTokens) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientIssuanceTokens();
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InsufficientIssuanceTokens();
         }
 
         // Check if borrowing would exceed borrowable quota
-        if (currentlyBorrowedAmount + requestedLoanAmount_
-                > _calculateBorrowCapacity() * borrowableQuota / 10_000) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_BorrowableQuotaExceeded();
+        if (
+            currentlyBorrowedAmount + requestedLoanAmount_
+                > _calculateBorrowCapacity() * borrowableQuota / 10_000
+        ) {
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_BorrowableQuotaExceeded();
         }
 
         // Check individual borrow limit
         if (requestedLoanAmount_ > individualBorrowLimit) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_IndividualBorrowLimitExceeded();
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_IndividualBorrowLimitExceeded();
         }
 
         // Lock the required issuance tokens automatically
-        _issuanceToken.safeTransferFrom(user, address(this), requiredIssuanceTokens);
+        _issuanceToken.safeTransferFrom(
+            user, address(this), requiredIssuanceTokens
+        );
         _lockedIssuanceTokens[user] += requiredIssuanceTokens;
 
         // Calculate dynamic borrowing fee
@@ -263,7 +259,9 @@ contract LM_PC_HouseProtocol_v1 is
         address user = _msgSender();
 
         if (_outstandingLoans[user] < repaymentAmount_) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_RepaymentAmountExceedsLoan();
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_RepaymentAmountExceedsLoan();
         }
 
         // Update state
@@ -291,11 +289,15 @@ contract LM_PC_HouseProtocol_v1 is
         address user = _msgSender();
 
         if (_lockedIssuanceTokens[user] < amount_) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientLockedTokens();
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InsufficientLockedTokens();
         }
 
         if (_outstandingLoans[user] > 0) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_CannotUnlockWithOutstandingLoan();
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_CannotUnlockWithOutstandingLoan();
         }
 
         // Update locked amount
@@ -328,7 +330,9 @@ contract LM_PC_HouseProtocol_v1 is
         onlyLendingFacilityManager
     {
         if (newBorrowableQuota_ > _MAX_BORROWABLE_QUOTA) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_BorrowableQuotaTooHigh();
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_BorrowableQuotaTooHigh();
         }
         borrowableQuota = newBorrowableQuota_;
         emit BorrowableQuotaUpdated(newBorrowableQuota_);
@@ -341,7 +345,9 @@ contract LM_PC_HouseProtocol_v1 is
         onlyLendingFacilityManager
     {
         if (newFeeCalculator_ == address(0)) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidFeeCalculatorAddress();
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InvalidFeeCalculatorAddress();
         }
         dynamicFeeCalculator = newFeeCalculator_;
         emit DynamicFeeCalculatorUpdated(newFeeCalculator_);
@@ -349,27 +355,10 @@ contract LM_PC_HouseProtocol_v1 is
 
     /// @inheritdoc ILM_PC_HouseProtocol_v1
     function setDynamicFeeCalculatorParams(
-        uint Z_issueRedeem_,
-        uint A_issueRedeem_,
-        uint m_issueRedeem_,
-        uint Z_origination_,
-        uint A_origination_,
-        uint m_origination_
+        DynamicFeeParameters memory dynamicFeeParameters_
     ) external onlyFeeCalculatorAdmin {
-        Z_issueRedeem = Z_issueRedeem_;
-        A_issueRedeem = A_issueRedeem_;
-        m_issueRedeem = m_issueRedeem_;
-        Z_origination = Z_origination_;
-        A_origination = A_origination_;
-        m_origination = m_origination_;
-        emit DynamicFeeCalculatorParamsUpdated(
-            Z_issueRedeem_,
-            A_issueRedeem_,
-            m_issueRedeem_,
-            Z_origination_,
-            A_origination_,
-            m_origination_
-        );
+        _dynamicFeeParameters = dynamicFeeParameters_;
+        emit DynamicFeeCalculatorParamsUpdated(dynamicFeeParameters_);
     }
 
     // =========================================================================
@@ -421,6 +410,15 @@ contract LM_PC_HouseProtocol_v1 is
         return _calculateUserBorrowingPower(user_);
     }
 
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function getDynamicFeeParameters()
+        external
+        view
+        returns (DynamicFeeParameters memory)
+    {
+        return _dynamicFeeParameters;
+    }
+
     //--------------------------------------------------------------------------
     // Internal
 
@@ -428,7 +426,9 @@ contract LM_PC_HouseProtocol_v1 is
     /// @param amount_ The amount to validate
     function _ensureValidBorrowAmount(uint amount_) internal pure {
         if (amount_ == 0) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount();
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InvalidBorrowAmount();
         }
     }
 
@@ -437,7 +437,7 @@ contract LM_PC_HouseProtocol_v1 is
     function _calculateBorrowCapacity() internal view returns (uint) {
         // Use the DBC FM to get the actual virtual collateral supply
         // Borrow capacity = virtual collateral supply (this represents the total backing)
-        IVirtualCollateralSupplyBase_v1 dbcFm = 
+        IVirtualCollateralSupplyBase_v1 dbcFm =
             IVirtualCollateralSupplyBase_v1(_dbcFmAddress);
         return dbcFm.getVirtualCollateralSupply();
     }
@@ -452,7 +452,7 @@ contract LM_PC_HouseProtocol_v1 is
     {
         // Use the DBC FM to get the actual floor price
         // User borrowing power = locked issuance tokens * floor price
-        IFM_BC_Discrete_Redeeming_VirtualSupply_v1 dbcFm = 
+        IFM_BC_Discrete_Redeeming_VirtualSupply_v1 dbcFm =
             IFM_BC_Discrete_Redeeming_VirtualSupply_v1(_dbcFmAddress);
         uint floorPrice = dbcFm.getStaticPriceForBuying();
         return _lockedIssuanceTokens[user_] * floorPrice / 1e18; // Adjust for decimals
@@ -503,7 +503,7 @@ contract LM_PC_HouseProtocol_v1 is
     {
         // Use the DBC FM to get the actual floor price
         // Required collateral = issuance tokens * floor price
-        IFM_BC_Discrete_Redeeming_VirtualSupply_v1 dbcFm = 
+        IFM_BC_Discrete_Redeeming_VirtualSupply_v1 dbcFm =
             IFM_BC_Discrete_Redeeming_VirtualSupply_v1(_dbcFmAddress);
         uint floorPrice = dbcFm.getStaticPriceForBuying();
         return issuanceTokenAmount_ * floorPrice / 1e18; // Adjust for decimals
@@ -524,12 +524,8 @@ contract LM_PC_HouseProtocol_v1 is
 
     /// @dev Get the current floor price from the DBC FM
     /// @return The current floor price
-    function _getFloorPrice()
-        internal
-        view
-        returns (uint)
-    {
-        IFM_BC_Discrete_Redeeming_VirtualSupply_v1 dbcFm = 
+    function _getFloorPrice() internal view returns (uint) {
+        IFM_BC_Discrete_Redeeming_VirtualSupply_v1 dbcFm =
             IFM_BC_Discrete_Redeeming_VirtualSupply_v1(_dbcFmAddress);
         return dbcFm.getStaticPriceForBuying();
     }

--- a/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
@@ -357,6 +357,18 @@ contract LM_PC_HouseProtocol_v1 is
     function setDynamicFeeCalculatorParams(
         DynamicFeeParameters memory dynamicFeeParameters_
     ) external onlyFeeCalculatorAdmin {
+        if (
+            dynamicFeeParameters_.Z_issueRedeem == 0
+                || dynamicFeeParameters_.A_issueRedeem == 0
+                || dynamicFeeParameters_.m_issueRedeem == 0
+                || dynamicFeeParameters_.Z_origination == 0
+                || dynamicFeeParameters_.A_origination == 0
+                || dynamicFeeParameters_.m_origination == 0
+        ) {
+            revert
+                ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InvalidDynamicFeeParameters();
+        }
         _dynamicFeeParameters = dynamicFeeParameters_;
         emit DynamicFeeCalculatorParamsUpdated(dynamicFeeParameters_);
     }

--- a/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
@@ -170,12 +170,21 @@ contract LM_PC_HouseProtocol_v1 is
     {
         address user = _msgSender();
 
-        // Calculate user's borrowing power based on locked issuance tokens
-        uint userBorrowingPower = _calculateUserBorrowingPower(user);
+        // Calculate user's borrowing power based on their available issuance tokens
+        uint userIssuanceTokens = _issuanceToken.balanceOf(user);
+        uint userBorrowingPower = userIssuanceTokens * _getFloorPrice() / 1e18;
 
         // Ensure user has sufficient borrowing power
         if (requestedLoanAmount_ > userBorrowingPower) {
             revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientBorrowingPower();
+        }
+
+        // Calculate how much issuance tokens need to be locked for this borrow amount
+        uint requiredIssuanceTokens = _calculateRequiredIssuanceTokens(requestedLoanAmount_);
+        
+        // Ensure user has sufficient issuance tokens to lock
+        if (userIssuanceTokens < requiredIssuanceTokens) {
+            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientIssuanceTokens();
         }
 
         // Check if borrowing would exceed borrowable quota
@@ -188,6 +197,10 @@ contract LM_PC_HouseProtocol_v1 is
         if (requestedLoanAmount_ > individualBorrowLimit) {
             revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_IndividualBorrowLimitExceeded();
         }
+
+        // Lock the required issuance tokens automatically
+        _issuanceToken.safeTransferFrom(user, address(this), requiredIssuanceTokens);
+        _lockedIssuanceTokens[user] += requiredIssuanceTokens;
 
         // Calculate dynamic borrowing fee
         uint dynamicBorrowingFee =
@@ -209,7 +222,8 @@ contract LM_PC_HouseProtocol_v1 is
         // Transfer net amount to user
         _collateralToken.safeTransfer(user, netAmountToUser);
 
-        // Emit event
+        // Emit events
+        emit IssuanceTokensLocked(user, requiredIssuanceTokens);
         emit Borrowed(
             user, requestedLoanAmount_, dynamicBorrowingFee, netAmountToUser
         );
@@ -241,30 +255,6 @@ contract LM_PC_HouseProtocol_v1 is
 
         // Emit event
         emit Repaid(user, repaymentAmount_, issuanceTokensToUnlock);
-    }
-
-    /// @inheritdoc ILM_PC_HouseProtocol_v1
-    function lockIssuanceTokens(uint amount_) external virtual {
-        address user = _msgSender();
-
-        if (amount_ == 0) {
-            revert ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount();
-        }
-
-        // Transfer issuance tokens from user to contract
-        _issuanceToken.safeTransferFrom(user, address(this), amount_);
-
-        // Update locked amount
-        _lockedIssuanceTokens[user] += amount_;
-
-        // Calculate and transfer required collateral tokens
-        uint collateralAmount = _calculateCollateralAmount(amount_);
-        if (collateralAmount > 0) {
-            _collateralToken.safeTransferFrom(user, address(this), collateralAmount);
-        }
-
-        // Emit event
-        emit IssuanceTokensLocked(user, amount_);
     }
 
     /// @inheritdoc ILM_PC_HouseProtocol_v1
@@ -463,5 +453,30 @@ contract LM_PC_HouseProtocol_v1 is
             IFM_BC_Discrete_Redeeming_VirtualSupply_v1(_dbcFmAddress);
         uint floorPrice = dbcFm.getStaticPriceForBuying();
         return issuanceTokenAmount_ * floorPrice / 1e18; // Adjust for decimals
+    }
+
+    /// @dev Calculate the required issuance tokens for a given borrow amount
+    /// @param borrowAmount_ The amount to borrow
+    /// @return The required issuance tokens to lock
+    function _calculateRequiredIssuanceTokens(uint borrowAmount_)
+        internal
+        view
+        returns (uint)
+    {
+        // Required issuance tokens = borrow amount / floor price
+        uint floorPrice = _getFloorPrice();
+        return borrowAmount_ * 1e18 / floorPrice; // Adjust for decimals
+    }
+
+    /// @dev Get the current floor price from the DBC FM
+    /// @return The current floor price
+    function _getFloorPrice()
+        internal
+        view
+        returns (uint)
+    {
+        IFM_BC_Discrete_Redeeming_VirtualSupply_v1 dbcFm = 
+            IFM_BC_Discrete_Redeeming_VirtualSupply_v1(_dbcFmAddress);
+        return dbcFm.getStaticPriceForBuying();
     }
 }

--- a/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.23;
+
+// Internal
+import {IOrchestrator_v1} from
+    "src/orchestrator/interfaces/IOrchestrator_v1.sol";
+import {
+    IERC20PaymentClientBase_v2,
+    IPaymentProcessor_v2
+} from "@lm/abstracts/ERC20PaymentClientBase_v2.sol";
+import {
+    ERC20PaymentClientBase_v2,
+    Module_v1
+} from "@lm/abstracts/ERC20PaymentClientBase_v2.sol";
+
+// External
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
+import {ERC165Upgradeable} from
+    "@oz-up/utils/introspection/ERC165Upgradeable.sol";
+
+// System under Test (SuT)
+import {ILM_PC_HouseProtocol_v1} from
+    "src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol";
+
+/**
+ * @title   House Protocol Lending Facility Logic Module
+ *
+ * @notice  A lending facility that allows users to borrow collateral tokens against issuance tokens.
+ *          The system uses dynamic fee calculation based on liquidity rates and enforces borrowing limits.
+ *
+ * @dev     This contract implements the following key functionality:
+ *          - Borrowing collateral tokens against locked issuance tokens
+ *          - Dynamic fee calculation based on floor liquidity rate
+ *          - Repayment functionality with issuance token unlocking
+ *          - Configurable borrowing limits and quotas
+ *          - Role-based access control for facility management
+ *
+ * @custom:security-contact security@inverter.network
+ *                          In case of any concerns or findings, please refer
+ *                          to our Security Policy at security.inverter.network
+ *                          or email us directly!
+ *
+ * @custom:version 1.0.0
+ *
+ * @author  Inverter Network
+ */
+contract LM_PC_HouseProtocol_v1 is
+    ILM_PC_HouseProtocol_v1,
+    ERC20PaymentClientBase_v2
+{
+    // =========================================================================
+    // Libraries
+
+    using SafeERC20 for IERC20;
+
+    // =========================================================================
+    // ERC165
+
+    /// @inheritdoc ERC165Upgradeable
+    function supportsInterface(bytes4 interfaceId_)
+        public
+        view
+        virtual
+        override(ERC20PaymentClientBase_v2)
+        returns (bool)
+    {
+        return interfaceId_ == type(ILM_PC_HouseProtocol_v1).interfaceId
+            || super.supportsInterface(interfaceId_);
+    }
+
+    //--------------------------------------------------------------------------
+    // Constants
+
+    /// @notice Maximum borrowable quota percentage (100%)
+    uint internal constant _MAX_BORROWABLE_QUOTA = 10_000; // 100% in basis points
+
+    //--------------------------------------------------------------------------
+    // State
+
+    /// @dev The role that allows managing the lending facility
+    bytes32 public constant LENDING_FACILITY_MANAGER_ROLE =
+        "LENDING_FACILITY_MANAGER";
+
+    /// @notice Address of the Dynamic Fee Calculator contract
+    address public dynamicFeeCalculator;
+
+    /// @notice Borrowable Quota as percentage of Borrow Capacity (in basis points)
+    uint public borrowableQuota;
+
+    /// @notice Individual borrow limit per user
+    uint public individualBorrowLimit;
+
+    /// @notice Currently borrowed amount across all users
+    uint public currentlyBorrowedAmount;
+
+    /// @notice Mapping of user addresses to their locked issuance token amounts
+    mapping(address user => uint amount) internal _lockedIssuanceTokens;
+
+    /// @notice Mapping of user addresses to their outstanding loan principals
+    mapping(address user => uint amount) internal _outstandingLoans;
+
+    /// @notice Collateral token (the token being borrowed)
+    IERC20 internal _collateralToken;
+
+    /// @notice Issuance token (the token being locked as collateral)
+    IERC20 internal _issuanceToken;
+
+    /// @notice DBC FM address for floor price calculations
+    address internal _dbcFmAddress;
+
+    /// @notice Storage gap for future upgrades
+    uint[50] private __gap;
+
+    // =========================================================================
+    // Modifiers
+
+    modifier onlyLendingFacilityManager() {
+        _checkRoleModifier(LENDING_FACILITY_MANAGER_ROLE, _msgSender());
+        _;
+    }
+
+    modifier onlyValidBorrowAmount(uint amount_) {
+        _ensureValidBorrowAmount(amount_);
+        _;
+    }
+
+    // =========================================================================
+    // Constructor & Init
+
+    /// @inheritdoc Module_v1
+    function init(
+        IOrchestrator_v1 orchestrator_,
+        Metadata memory metadata_,
+        bytes memory configData_
+    ) external override(Module_v1) initializer {
+        __Module_init(orchestrator_, metadata_);
+
+        // Decode module specific init data
+        (
+            address collateralToken,
+            address issuanceToken,
+            address dbcFmAddress,
+            uint borrowableQuota_,
+            uint individualBorrowLimit_
+        ) = abi.decode(configData_, (address, address, address, uint, uint));
+
+        // Set init state
+        _collateralToken = IERC20(collateralToken);
+        _issuanceToken = IERC20(issuanceToken);
+        _dbcFmAddress = dbcFmAddress;
+        borrowableQuota = borrowableQuota_;
+        individualBorrowLimit = individualBorrowLimit_;
+    }
+
+    // =========================================================================
+    // Public - Mutating
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function borrow(uint requestedLoanAmount_)
+        external
+        virtual
+        onlyValidBorrowAmount(requestedLoanAmount_)
+    {
+        address user = _msgSender();
+
+        // Calculate user's borrowing power based on locked issuance tokens
+        uint userBorrowingPower = _calculateUserBorrowingPower(user);
+
+        // Ensure user has sufficient borrowing power
+        require(
+            requestedLoanAmount_ <= userBorrowingPower,
+            "Insufficient borrowing power"
+        );
+
+        // Check if borrowing would exceed borrowable quota
+        require(
+            currentlyBorrowedAmount + requestedLoanAmount_
+                <= _calculateBorrowCapacity() * borrowableQuota / 10_000,
+            "Borrowable quota exceeded"
+        );
+
+        // Check individual borrow limit
+        require(
+            requestedLoanAmount_ <= individualBorrowLimit,
+            "Individual borrow limit exceeded"
+        );
+
+        // Calculate dynamic borrowing fee
+        uint dynamicBorrowingFee =
+            _calculateDynamicBorrowingFee(requestedLoanAmount_);
+        uint netAmountToUser = requestedLoanAmount_ - dynamicBorrowingFee;
+
+        // Update state
+        currentlyBorrowedAmount += requestedLoanAmount_;
+        _outstandingLoans[user] += requestedLoanAmount_;
+
+        // Transfer fee to fee manager
+        if (dynamicBorrowingFee > 0) {
+            _collateralToken.safeTransfer(
+                __Module_orchestrator.governor().getFeeManager(),
+                dynamicBorrowingFee
+            );
+        }
+
+        // Transfer net amount to user
+        _collateralToken.safeTransfer(user, netAmountToUser);
+
+        // Emit event
+        emit Borrowed(
+            user, requestedLoanAmount_, dynamicBorrowingFee, netAmountToUser
+        );
+    }
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function repay(uint repaymentAmount_) external virtual {
+        address user = _msgSender();
+
+        require(
+            _outstandingLoans[user] >= repaymentAmount_,
+            "Repayment amount exceeds outstanding loan"
+        );
+
+        // Update state
+        _outstandingLoans[user] -= repaymentAmount_;
+        currentlyBorrowedAmount -= repaymentAmount_;
+
+        // Transfer collateral back to lending facility
+        _collateralToken.safeTransferFrom(user, address(this), repaymentAmount_);
+
+        // Calculate and unlock issuance tokens
+        uint issuanceTokensToUnlock =
+            _calculateIssuanceTokensToUnlock(user, repaymentAmount_);
+
+        if (issuanceTokensToUnlock > 0) {
+            _lockedIssuanceTokens[user] -= issuanceTokensToUnlock;
+            _issuanceToken.safeTransfer(user, issuanceTokensToUnlock);
+        }
+
+        // Emit event
+        emit Repaid(user, repaymentAmount_, issuanceTokensToUnlock);
+    }
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function lockIssuanceTokens(uint amount_) external virtual {
+        address user = _msgSender();
+
+        require(amount_ > 0, "Amount must be greater than zero");
+
+        // Transfer issuance tokens from user to contract
+        _issuanceToken.safeTransferFrom(user, address(this), amount_);
+
+        // Update locked amount
+        _lockedIssuanceTokens[user] += amount_;
+
+        // Emit event
+        emit IssuanceTokensLocked(user, amount_);
+    }
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function unlockIssuanceTokens(uint amount_) external virtual {
+        address user = _msgSender();
+
+        require(
+            _lockedIssuanceTokens[user] >= amount_,
+            "Insufficient locked issuance tokens"
+        );
+
+        require(
+            _outstandingLoans[user] == 0,
+            "Cannot unlock tokens with outstanding loan"
+        );
+
+        // Update locked amount
+        _lockedIssuanceTokens[user] -= amount_;
+
+        // Transfer tokens back to user
+        _issuanceToken.safeTransfer(user, amount_);
+
+        // Emit event
+        emit IssuanceTokensUnlocked(user, amount_);
+    }
+
+    // =========================================================================
+    // Public - Configuration (Lending Facility Manager only)
+
+    /// @notice Set the individual borrow limit
+    /// @param newIndividualBorrowLimit_ The new individual borrow limit
+    function setIndividualBorrowLimit(uint newIndividualBorrowLimit_)
+        external
+        onlyLendingFacilityManager
+    {
+        individualBorrowLimit = newIndividualBorrowLimit_;
+        emit IndividualBorrowLimitUpdated(newIndividualBorrowLimit_);
+    }
+
+    /// @notice Set the borrowable quota
+    /// @param newBorrowableQuota_ The new borrowable quota (in basis points)
+    function setBorrowableQuota(uint newBorrowableQuota_)
+        external
+        onlyLendingFacilityManager
+    {
+        require(
+            newBorrowableQuota_ <= _MAX_BORROWABLE_QUOTA,
+            "Borrowable quota cannot exceed 100%"
+        );
+        borrowableQuota = newBorrowableQuota_;
+        emit BorrowableQuotaUpdated(newBorrowableQuota_);
+    }
+
+    /// @notice Set the Dynamic Fee Calculator address
+    /// @param newFeeCalculator_ The new fee calculator address
+    function setDynamicFeeCalculator(address newFeeCalculator_)
+        external
+        onlyLendingFacilityManager
+    {
+        require(
+            newFeeCalculator_ != address(0), "Invalid fee calculator address"
+        );
+        dynamicFeeCalculator = newFeeCalculator_;
+        emit DynamicFeeCalculatorUpdated(newFeeCalculator_);
+    }
+
+    // =========================================================================
+    // Public - Getters
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function getLockedIssuanceTokens(address user_)
+        external
+        view
+        returns (uint)
+    {
+        return _lockedIssuanceTokens[user_];
+    }
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function getOutstandingLoan(address user_) external view returns (uint) {
+        return _outstandingLoans[user_];
+    }
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function getBorrowCapacity() external view returns (uint) {
+        return _calculateBorrowCapacity();
+    }
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function getCurrentBorrowQuota() external view returns (uint) {
+        uint borrowCapacity = _calculateBorrowCapacity();
+        if (borrowCapacity == 0) return 0;
+        return (currentlyBorrowedAmount * 10_000) / borrowCapacity;
+    }
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function getFloorLiquidityRate() external view returns (uint) {
+        uint borrowCapacity = _calculateBorrowCapacity();
+        uint borrowableAmount = borrowCapacity * borrowableQuota / 10_000;
+
+        if (borrowableAmount == 0) return 0;
+
+        return ((borrowableAmount - currentlyBorrowedAmount) * 10_000)
+            / borrowableAmount;
+    }
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function getUserBorrowingPower(address user_)
+        external
+        view
+        returns (uint)
+    {
+        return _calculateUserBorrowingPower(user_);
+    }
+
+    //--------------------------------------------------------------------------
+    // Internal
+
+    /// @dev Ensures the borrow amount is valid
+    /// @param amount_ The amount to validate
+    function _ensureValidBorrowAmount(uint amount_) internal pure {
+        require(amount_ > 0, "Borrow amount must be greater than zero");
+    }
+
+    /// @dev Calculate the system-wide Borrow Capacity
+    /// @return The borrow capacity
+    function _calculateBorrowCapacity() internal view returns (uint) {
+        // This would need to be implemented based on the actual DBC FM interface
+        // For now, returning a placeholder value
+        // In reality, this would be: virtualIssuanceSupply * P_floor
+        return 1_000_000 ether; // Placeholder
+    }
+
+    /// @dev Calculate user's borrowing power based on locked issuance tokens
+    /// @param user_ The user address
+    /// @return The user's borrowing power
+    function _calculateUserBorrowingPower(address user_)
+        internal
+        view
+        returns (uint)
+    {
+        // This would need to be implemented based on the actual DBC FM interface
+        // For now, returning a placeholder calculation
+        // In reality, this would be: UserLockedIssuanceTokens * P_floor
+        return _lockedIssuanceTokens[user_] * 2; // Placeholder: 2x leverage
+    }
+
+    /// @dev Calculate dynamic borrowing fee using the fee calculator
+    /// @param requestedAmount_ The requested loan amount
+    /// @return The dynamic borrowing fee
+    function _calculateDynamicBorrowingFee(uint requestedAmount_)
+        internal
+        view
+        returns (uint)
+    {
+        if (dynamicFeeCalculator == address(0)) {
+            return 0; // No fee if no calculator is set
+        }
+
+        // This would need to be implemented based on the actual fee calculator interface
+        // For now, returning a placeholder calculation
+        uint floorLiquidityRate = this.getFloorLiquidityRate();
+        return (requestedAmount_ * floorLiquidityRate) / 10_000; // Placeholder: 1% fee
+    }
+
+    /// @dev Calculate issuance tokens to unlock based on repayment amount
+    /// @param user_ The user address
+    /// @param repaymentAmount_ The repayment amount
+    /// @return The amount of issuance tokens to unlock
+    function _calculateIssuanceTokensToUnlock(
+        address user_,
+        uint repaymentAmount_
+    ) internal view returns (uint) {
+        if (_outstandingLoans[user_] == 0) return 0;
+
+        // Calculate the proportion of the loan being repaid
+        uint repaymentProportion =
+            (repaymentAmount_ * 10_000) / _outstandingLoans[user_];
+
+        // Calculate the proportion of locked issuance tokens to unlock
+        return (_lockedIssuanceTokens[user_] * repaymentProportion) / 10_000;
+    }
+}

--- a/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/LM_PC_HouseProtocol_v1.sol
@@ -28,6 +28,8 @@ import {
 import {
     IVirtualCollateralSupplyBase_v1
 } from "src/modules/fundingManager/bondingCurve/interfaces/IVirtualCollateralSupplyBase_v1.sol";
+import {DynamicFeeCalculatorLib_v1} from
+    "src/modules/logicModule/libraries/DynamicFeeCalculator_v1.sol";
 
 /**
  * @title   House Protocol Lending Facility Logic Module
@@ -59,6 +61,7 @@ contract LM_PC_HouseProtocol_v1 is
     // Libraries
 
     using SafeERC20 for IERC20;
+    using DynamicFeeCalculatorLib_v1 for uint;
 
     // =========================================================================
     // ERC165
@@ -88,6 +91,9 @@ contract LM_PC_HouseProtocol_v1 is
     bytes32 public constant LENDING_FACILITY_MANAGER_ROLE =
         "LENDING_FACILITY_MANAGER";
 
+    /// @dev The role for managing the dynamic fee calculator
+    bytes32 public constant FEE_CALCULATOR_ADMIN_ROLE = "FEE_CALCULATOR_ADMIN";
+
     /// @notice Address of the Dynamic Fee Calculator contract
     address public dynamicFeeCalculator;
 
@@ -115,6 +121,24 @@ contract LM_PC_HouseProtocol_v1 is
     /// @notice DBC FM address for floor price calculations
     address internal _dbcFmAddress;
 
+    /// @notice Base fee component for issuance/redemption fees (as per formulas in 6.4.2).
+    uint public Z_issueRedeem;
+
+    /// @notice premiumRate threshold for dynamic issuance/redemption fee adjustment (as per formulas in 6.4.2).
+    uint public A_issueRedeem;
+
+    /// @notice Multiplier for dynamic issuance/redemption fee component (as per formulas in 6.4.2).
+    uint public m_issueRedeem;
+
+    /// @notice Base fee component for origination fees (as per formula in 6.4.1).
+    uint public Z_origination;
+
+    /// @notice floorLiquidityRate threshold for dynamic origination fee adjustment (as per formula in 6.4.1).
+    uint public A_origination;
+
+    /// @notice Multiplier for dynamic origination fee component (as per formula in 6.4.1).
+    uint public m_origination;
+
     /// @notice Storage gap for future upgrades
     uint[50] private __gap;
 
@@ -128,6 +152,11 @@ contract LM_PC_HouseProtocol_v1 is
 
     modifier onlyValidBorrowAmount(uint amount_) {
         _ensureValidBorrowAmount(amount_);
+        _;
+    }
+
+    modifier onlyFeeCalculatorAdmin() {
+        _checkRoleModifier(FEE_CALCULATOR_ADMIN_ROLE, _msgSender());
         _;
     }
 
@@ -316,6 +345,31 @@ contract LM_PC_HouseProtocol_v1 is
         }
         dynamicFeeCalculator = newFeeCalculator_;
         emit DynamicFeeCalculatorUpdated(newFeeCalculator_);
+    }
+
+    /// @inheritdoc ILM_PC_HouseProtocol_v1
+    function setDynamicFeeCalculatorParams(
+        uint Z_issueRedeem_,
+        uint A_issueRedeem_,
+        uint m_issueRedeem_,
+        uint Z_origination_,
+        uint A_origination_,
+        uint m_origination_
+    ) external onlyFeeCalculatorAdmin {
+        Z_issueRedeem = Z_issueRedeem_;
+        A_issueRedeem = A_issueRedeem_;
+        m_issueRedeem = m_issueRedeem_;
+        Z_origination = Z_origination_;
+        A_origination = A_origination_;
+        m_origination = m_origination_;
+        emit DynamicFeeCalculatorParamsUpdated(
+            Z_issueRedeem_,
+            A_issueRedeem_,
+            m_issueRedeem_,
+            Z_origination_,
+            A_origination_,
+            m_origination_
+        );
     }
 
     // =========================================================================

--- a/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
@@ -70,6 +70,22 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
     /// @param newCalculator The new fee calculator address
     event DynamicFeeCalculatorUpdated(address newCalculator);
 
+    /// @notice Emitted when the dynamic fee calculator parameters are updated
+    /// @param Z_issueRedeem_ The new base fee component for issuance/redemption fees.
+    /// @param A_issueRedeem_ The new premiumRate threshold for dynamic issuance/redemption fee adjustment.
+    /// @param m_issueRedeem_ The new multiplier for dynamic issuance/redemption fee component.
+    /// @param Z_origination_ The new base fee component for origination fees.
+    /// @param A_origination_ The new floorLiquidityRate threshold for dynamic origination fee adjustment.
+    /// @param m_origination_ The new multiplier for dynamic origination fee component.
+    event DynamicFeeCalculatorParamsUpdated(
+        uint Z_issueRedeem_,
+        uint A_issueRedeem_,
+        uint m_issueRedeem_,
+        uint Z_origination_,
+        uint A_origination_,
+        uint m_origination_
+    );
+
     // =========================================================================
     // Errors
 
@@ -175,4 +191,20 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Set the Dynamic Fee Calculator address
     /// @param newFeeCalculator_ The new fee calculator address
     function setDynamicFeeCalculator(address newFeeCalculator_) external;
+
+    /// @notice Set the Dynamic Fee Calculator parameters
+    /// @param Z_issueRedeem_ The new base fee component for issuance/redemption fees.
+    /// @param A_issueRedeem_ The new premiumRate threshold for dynamic issuance/redemption fee adjustment.
+    /// @param m_issueRedeem_ The new multiplier for dynamic issuance/redemption fee component.
+    /// @param Z_origination_ The new base fee component for origination fees.
+    /// @param A_origination_ The new floorLiquidityRate threshold for dynamic origination fee adjustment.
+    /// @param m_origination_ The new multiplier for dynamic origination fee component.
+    function setDynamicFeeCalculatorParams(
+        uint Z_issueRedeem_,
+        uint A_issueRedeem_,
+        uint m_issueRedeem_,
+        uint Z_origination_,
+        uint A_origination_,
+        uint m_origination_
+    ) external;
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
@@ -112,6 +112,9 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Insufficient issuance tokens to lock for borrowing
     error Module__LM_PC_HouseProtocol_InsufficientIssuanceTokens();
 
+    /// @notice Invalid dynamic fee parameters
+    error Module__LM_PC_HouseProtocol_InvalidDynamicFeeParameters();
+
     // =========================================================================
     // Structs
 

--- a/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
@@ -71,19 +71,9 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
     event DynamicFeeCalculatorUpdated(address newCalculator);
 
     /// @notice Emitted when the dynamic fee calculator parameters are updated
-    /// @param Z_issueRedeem_ The new base fee component for issuance/redemption fees.
-    /// @param A_issueRedeem_ The new premiumRate threshold for dynamic issuance/redemption fee adjustment.
-    /// @param m_issueRedeem_ The new multiplier for dynamic issuance/redemption fee component.
-    /// @param Z_origination_ The new base fee component for origination fees.
-    /// @param A_origination_ The new floorLiquidityRate threshold for dynamic origination fee adjustment.
-    /// @param m_origination_ The new multiplier for dynamic origination fee component.
+    /// @param dynamicFeeParameters_ The dynamic fee parameters
     event DynamicFeeCalculatorParamsUpdated(
-        uint Z_issueRedeem_,
-        uint A_issueRedeem_,
-        uint m_issueRedeem_,
-        uint Z_origination_,
-        uint A_origination_,
-        uint m_origination_
+        DynamicFeeParameters dynamicFeeParameters_
     );
 
     // =========================================================================
@@ -121,6 +111,27 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
 
     /// @notice Insufficient issuance tokens to lock for borrowing
     error Module__LM_PC_HouseProtocol_InsufficientIssuanceTokens();
+
+    // =========================================================================
+    // Structs
+
+    /// @notice Parameters for the dynamic fee calculator
+    /// @dev These parameters are used to calculate the dynamic fee for issuance/redemption and origination fees
+    ///      based on the floor liquidity rate.
+    ///      Z_issueRedeem: Base fee component for issuance/redemption fees.
+    ///      A_issueRedeem: PremiumRate threshold for dynamic issuance/redemption fee adjustment.
+    ///      m_issueRedeem: Multiplier for dynamic issuance/redemption fee component.
+    ///      Z_origination: Base fee component for origination fees.
+    ///      A_origination: FloorLiquidityRate threshold for dynamic origination fee adjustment.
+    ///      m_origination: Multiplier for dynamic origination fee component.
+    struct DynamicFeeParameters {
+        uint Z_issueRedeem;
+        uint A_issueRedeem;
+        uint m_issueRedeem;
+        uint Z_origination;
+        uint A_origination;
+        uint m_origination;
+    }
 
     // =========================================================================
     // Public - Getters
@@ -161,6 +172,13 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
         view
         returns (uint power_);
 
+    /// @notice Returns the dynamic fee parameters
+    /// @return dynamicFeeParameters_ The dynamic fee parameters
+    function getDynamicFeeParameters()
+        external
+        view
+        returns (DynamicFeeParameters memory dynamicFeeParameters_);
+
     // =========================================================================
     // Public - Mutating
 
@@ -193,18 +211,8 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
     function setDynamicFeeCalculator(address newFeeCalculator_) external;
 
     /// @notice Set the Dynamic Fee Calculator parameters
-    /// @param Z_issueRedeem_ The new base fee component for issuance/redemption fees.
-    /// @param A_issueRedeem_ The new premiumRate threshold for dynamic issuance/redemption fee adjustment.
-    /// @param m_issueRedeem_ The new multiplier for dynamic issuance/redemption fee component.
-    /// @param Z_origination_ The new base fee component for origination fees.
-    /// @param A_origination_ The new floorLiquidityRate threshold for dynamic origination fee adjustment.
-    /// @param m_origination_ The new multiplier for dynamic origination fee component.
+    /// @param dynamicFeeParameters_ The dynamic fee parameters
     function setDynamicFeeCalculatorParams(
-        uint Z_issueRedeem_,
-        uint A_issueRedeem_,
-        uint m_issueRedeem_,
-        uint Z_origination_,
-        uint A_origination_,
-        uint m_origination_
+        DynamicFeeParameters memory dynamicFeeParameters_
     ) external;
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+// Internal
+import {IERC20PaymentClientBase_v2} from
+    "@lm/interfaces/IERC20PaymentClientBase_v2.sol";
+
+/**
+ * @title   House Protocol Lending Facility Interface
+ *
+ * @notice  Interface for the House Protocol lending facility that allows users to borrow
+ *          collateral tokens against issuance tokens with dynamic fee calculation.
+ *
+ * @dev     This interface defines the following key functionality:
+ *          - Borrowing collateral tokens against locked issuance tokens
+ *          - Dynamic fee calculation based on floor liquidity rate
+ *          - Repayment functionality with issuance token unlocking
+ *          - Configurable borrowing limits and quotas
+ *          - Role-based access control for facility management
+ *
+ * @custom:security-contact security@inverter.network
+ *                          In case of any concerns or findings, please refer
+ *                          to our Security Policy at security.inverter.network
+ *                          or email us directly!
+ *
+ * @custom:version 1.0.0
+ *
+ * @author  Inverter Network
+ */
+interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
+    // =========================================================================
+    // Events
+
+    /// @notice Emitted when a user borrows collateral tokens
+    /// @param user The address of the borrower
+    /// @param requestedAmount The requested loan amount
+    /// @param fee The dynamic borrowing fee deducted
+    /// @param netAmount The net amount received by the user
+    event Borrowed(
+        address indexed user, uint requestedAmount, uint fee, uint netAmount
+    );
+
+    /// @notice Emitted when a user repays their loan
+    /// @param user The address of the borrower
+    /// @param repaymentAmount The amount repaid
+    /// @param issuanceTokensUnlocked The amount of issuance tokens unlocked
+    event Repaid(
+        address indexed user, uint repaymentAmount, uint issuanceTokensUnlocked
+    );
+
+    /// @notice Emitted when a user locks issuance tokens
+    /// @param user The address of the user
+    /// @param amount The amount of issuance tokens locked
+    event IssuanceTokensLocked(address indexed user, uint amount);
+
+    /// @notice Emitted when a user unlocks issuance tokens
+    /// @param user The address of the user
+    /// @param amount The amount of issuance tokens unlocked
+    event IssuanceTokensUnlocked(address indexed user, uint amount);
+
+    /// @notice Emitted when the individual borrow limit is updated
+    /// @param newLimit The new individual borrow limit
+    event IndividualBorrowLimitUpdated(uint newLimit);
+
+    /// @notice Emitted when the borrowable quota is updated
+    /// @param newQuota The new borrowable quota (in basis points)
+    event BorrowableQuotaUpdated(uint newQuota);
+
+    /// @notice Emitted when the dynamic fee calculator is updated
+    /// @param newCalculator The new fee calculator address
+    event DynamicFeeCalculatorUpdated(address newCalculator);
+
+    // =========================================================================
+    // Errors
+
+    /// @notice Amount cannot be zero
+    error Module__LM_PC_HouseProtocol_InvalidBorrowAmount();
+
+    /// @notice Insufficient borrowing power
+    error Module__LM_PC_HouseProtocol_InsufficientBorrowingPower();
+
+    /// @notice Borrowable quota exceeded
+    error Module__LM_PC_HouseProtocol_BorrowableQuotaExceeded();
+
+    /// @notice Individual borrow limit exceeded
+    error Module__LM_PC_HouseProtocol_IndividualBorrowLimitExceeded();
+
+    /// @notice Repayment amount exceeds outstanding loan
+    error Module__LM_PC_HouseProtocol_RepaymentAmountExceedsLoan();
+
+    /// @notice Insufficient locked issuance tokens
+    error Module__LM_PC_HouseProtocol_InsufficientLockedTokens();
+
+    /// @notice Cannot unlock tokens with outstanding loan
+    error Module__LM_PC_HouseProtocol_CannotUnlockWithOutstandingLoan();
+
+    /// @notice Caller not authorized
+    error Module__LM_PC_HouseProtocol_CallerNotAuthorized();
+
+    // =========================================================================
+    // Public - Getters
+
+    /// @notice Returns the amount of issuance tokens locked by a user
+    /// @param user_ The address of the user
+    /// @return amount_ The amount of locked issuance tokens
+    function getLockedIssuanceTokens(address user_)
+        external
+        view
+        returns (uint amount_);
+
+    /// @notice Returns the outstanding loan amount for a user
+    /// @param user_ The address of the user
+    /// @return amount_ The outstanding loan amount
+    function getOutstandingLoan(address user_)
+        external
+        view
+        returns (uint amount_);
+
+    /// @notice Returns the system-wide Borrow Capacity
+    /// @return capacity_ The borrow capacity
+    function getBorrowCapacity() external view returns (uint capacity_);
+
+    /// @notice Returns the current borrow quota as a percentage of borrow capacity
+    /// @return quota_ The current borrow quota (in basis points)
+    function getCurrentBorrowQuota() external view returns (uint quota_);
+
+    /// @notice Returns the floor liquidity rate
+    /// @return rate_ The floor liquidity rate (in basis points)
+    function getFloorLiquidityRate() external view returns (uint rate_);
+
+    /// @notice Returns the borrowing power for a specific user
+    /// @param user_ The address of the user
+    /// @return power_ The user's borrowing power
+    function getUserBorrowingPower(address user_)
+        external
+        view
+        returns (uint power_);
+
+    // =========================================================================
+    // Public - Mutating
+
+    /// @notice Borrow collateral tokens against locked issuance tokens
+    /// @param requestedLoanAmount_ The amount of collateral tokens to borrow
+    function borrow(uint requestedLoanAmount_) external;
+
+    /// @notice Repay a loan with collateral tokens
+    /// @param repaymentAmount_ The amount of collateral tokens to repay
+    function repay(uint repaymentAmount_) external;
+
+    /// @notice Lock issuance tokens to enable borrowing
+    /// @param amount_ The amount of issuance tokens to lock
+    function lockIssuanceTokens(uint amount_) external;
+
+    /// @notice Unlock issuance tokens (only if no outstanding loan)
+    /// @param amount_ The amount of issuance tokens to unlock
+    function unlockIssuanceTokens(uint amount_) external;
+
+    // =========================================================================
+    // Public - Configuration (Lending Facility Manager only)
+
+    /// @notice Set the individual borrow limit
+    /// @param newIndividualBorrowLimit_ The new individual borrow limit
+    function setIndividualBorrowLimit(uint newIndividualBorrowLimit_)
+        external;
+
+    /// @notice Set the borrowable quota
+    /// @param newBorrowableQuota_ The new borrowable quota (in basis points)
+    function setBorrowableQuota(uint newBorrowableQuota_) external;
+
+    /// @notice Set the Dynamic Fee Calculator address
+    /// @param newFeeCalculator_ The new fee calculator address
+    function setDynamicFeeCalculator(address newFeeCalculator_) external;
+}

--- a/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
@@ -103,6 +103,9 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Invalid fee calculator address (zero address)
     error Module__LM_PC_HouseProtocol_InvalidFeeCalculatorAddress();
 
+    /// @notice Insufficient issuance tokens to lock for borrowing
+    error Module__LM_PC_HouseProtocol_InsufficientIssuanceTokens();
+
     // =========================================================================
     // Public - Getters
 
@@ -152,10 +155,6 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Repay a loan with collateral tokens
     /// @param repaymentAmount_ The amount of collateral tokens to repay
     function repay(uint repaymentAmount_) external;
-
-    /// @notice Lock issuance tokens to enable borrowing
-    /// @param amount_ The amount of issuance tokens to lock
-    function lockIssuanceTokens(uint amount_) external;
 
     /// @notice Unlock issuance tokens (only if no outstanding loan)
     /// @param amount_ The amount of issuance tokens to unlock

--- a/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_HouseProtocol_v1.sol
@@ -97,6 +97,12 @@ interface ILM_PC_HouseProtocol_v1 is IERC20PaymentClientBase_v2 {
     /// @notice Caller not authorized
     error Module__LM_PC_HouseProtocol_CallerNotAuthorized();
 
+    /// @notice Borrowable quota cannot exceed 100%
+    error Module__LM_PC_HouseProtocol_BorrowableQuotaTooHigh();
+
+    /// @notice Invalid fee calculator address (zero address)
+    error Module__LM_PC_HouseProtocol_InvalidFeeCalculatorAddress();
+
     // =========================================================================
     // Public - Getters
 

--- a/src/modules/logicModule/libraries/DynamicFeeCalculator_v1.sol
+++ b/src/modules/logicModule/libraries/DynamicFeeCalculator_v1.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.23;
+
+library DynamicFeeCalculatorLib_v1 {
+    uint public constant SCALING_FACTOR = 1e18;
+
+    // --- Fee Calculation Functions ---
+
+    function calculateOriginationFee(
+        uint floorLiquidityRate,
+        uint Z_origination,
+        uint A_origination,
+        uint m_origination
+    ) internal pure returns (uint) {
+        if (floorLiquidityRate < A_origination) {
+            return Z_origination;
+        } else {
+            return Z_origination
+                + (floorLiquidityRate - A_origination) * m_origination
+                    / SCALING_FACTOR;
+        }
+    }
+
+    function calculateIssuanceFee(
+        uint premiumRate,
+        uint Z_issueRedeem,
+        uint A_issueRedeem,
+        uint m_issueRedeem
+    ) internal pure returns (uint) {
+        if (premiumRate < A_issueRedeem) {
+            return Z_issueRedeem;
+        } else {
+            return Z_issueRedeem
+                + (premiumRate - A_issueRedeem) * m_issueRedeem / SCALING_FACTOR;
+        }
+    }
+
+    function calculateRedemptionFee(
+        uint premiumRate,
+        uint Z_issueRedeem,
+        uint A_issueRedeem,
+        uint m_issueRedeem
+    ) internal pure returns (uint) {
+        if (premiumRate > A_issueRedeem) {
+            return Z_issueRedeem;
+        } else {
+            return Z_issueRedeem
+                + (A_issueRedeem - premiumRate) * m_issueRedeem / SCALING_FACTOR;
+        }
+    }
+}

--- a/src/modules/logicModule/libraries/DynamicFeeCalculator_v1.sol
+++ b/src/modules/logicModule/libraries/DynamicFeeCalculator_v1.sol
@@ -6,21 +6,36 @@ library DynamicFeeCalculatorLib_v1 {
 
     // --- Fee Calculation Functions ---
 
+    /// @notice Calculate origination fee based on utilization ratio
+    /// @param utilizationRatio_ Current utilization ratio
+    /// @param Z_origination Base fee component
+    /// @param A_origination Utilization threshold for dynamic fee adjustment
+    /// @param m_origination Multiplier for dynamic fee component
+    /// @return The calculated origination fee
     function calculateOriginationFee(
-        uint floorLiquidityRate,
+        uint utilizationRatio_,
         uint Z_origination,
         uint A_origination,
         uint m_origination
     ) internal pure returns (uint) {
-        if (floorLiquidityRate < A_origination) {
+        // If utilization is below threshold, return base fee only
+        if (utilizationRatio_ < A_origination) {
             return Z_origination;
         } else {
-            return Z_origination
-                + (floorLiquidityRate - A_origination) * m_origination
-                    / SCALING_FACTOR;
+            // Calculate the delta: utilization ratio - threshold
+            uint delta = utilizationRatio_ - A_origination;
+
+            // Fee = base fee + (delta * multiplier / scaling factor)
+            return Z_origination + (delta * m_origination) / SCALING_FACTOR;
         }
     }
 
+    /// @notice Calculate issuance fee based on premium rate
+    /// @param premiumRate The premium rate
+    /// @param Z_issueRedeem Base fee component
+    /// @param A_issueRedeem Utilization threshold for dynamic fee adjustment
+    /// @param m_issueRedeem Multiplier for dynamic fee component
+    /// @return The calculated issuance fee
     function calculateIssuanceFee(
         uint premiumRate,
         uint Z_issueRedeem,
@@ -35,6 +50,12 @@ library DynamicFeeCalculatorLib_v1 {
         }
     }
 
+    /// @notice Calculate redemption fee based on premium rate
+    /// @param premiumRate The premium rate
+    /// @param Z_issueRedeem Base fee component
+    /// @param A_issueRedeem Utilization threshold for dynamic fee adjustment
+    /// @param m_issueRedeem Multiplier for dynamic fee component
+    /// @return the calculated redemption fee
     function calculateRedemptionFee(
         uint premiumRate,
         uint Z_issueRedeem,

--- a/test/mocks/modules/logicModule/LM_PC_HouseProtocol_v1_Exposed.sol
+++ b/test/mocks/modules/logicModule/LM_PC_HouseProtocol_v1_Exposed.sol
@@ -40,4 +40,16 @@ contract LM_PC_HouseProtocol_v1_Exposed is LM_PC_HouseProtocol_v1 {
     ) external view returns (uint) {
         return _calculateIssuanceTokensToUnlock(user_, repaymentAmount_);
     }
+
+    function exposed_calculateRequiredIssuanceTokens(uint borrowAmount_)
+        external
+        view
+        returns (uint)
+    {
+        return _calculateRequiredIssuanceTokens(borrowAmount_);
+    }
+
+    function exposed_getFloorPrice() external view returns (uint) {
+        return _getFloorPrice();
+    }
 }

--- a/test/mocks/modules/logicModule/LM_PC_HouseProtocol_v1_Exposed.sol
+++ b/test/mocks/modules/logicModule/LM_PC_HouseProtocol_v1_Exposed.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+// Internal
+import {LM_PC_HouseProtocol_v1} from
+    "src/modules/logicModule/LM_PC_HouseProtocol_v1.sol";
+
+// Access Mock of the LM_PC_HouseProtocol_v1 contract for Testing.
+contract LM_PC_HouseProtocol_v1_Exposed is LM_PC_HouseProtocol_v1 {
+    // Use the `exposed_` prefix for functions to expose internal contract for
+    // testing.
+
+    function exposed_ensureValidBorrowAmount(uint amount_) external pure {
+        _ensureValidBorrowAmount(amount_);
+    }
+
+    function exposed_calculateBorrowCapacity() external view returns (uint) {
+        return _calculateBorrowCapacity();
+    }
+
+    function exposed_calculateUserBorrowingPower(address user_)
+        external
+        view
+        returns (uint)
+    {
+        return _calculateUserBorrowingPower(user_);
+    }
+
+    function exposed_calculateDynamicBorrowingFee(uint requestedAmount_)
+        external
+        view
+        returns (uint)
+    {
+        return _calculateDynamicBorrowingFee(requestedAmount_);
+    }
+
+    function exposed_calculateIssuanceTokensToUnlock(
+        address user_,
+        uint repaymentAmount_
+    ) external view returns (uint) {
+        return _calculateIssuanceTokensToUnlock(user_, repaymentAmount_);
+    }
+}

--- a/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
@@ -26,6 +26,8 @@ import {DiscreteCurveMathLib_v1} from
     "src/modules/fundingManager/bondingCurve/formulas/DiscreteCurveMathLib_v1.sol";
 import {PackedSegmentLib} from
     "src/modules/fundingManager/bondingCurve/libraries/PackedSegmentLib.sol";
+import {DynamicFeeCalculatorLib_v1} from
+    "src/modules/logicModule/libraries/DynamicFeeCalculator_v1.sol";
 
 // External
 import {Clones} from "@oz/proxy/Clones.sol";
@@ -64,7 +66,7 @@ import {FM_BC_Discrete_Redeeming_VirtualSupply_v1_Exposed} from
 contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
     using PackedSegmentLib for PackedSegment;
     using DiscreteCurveMathLib_v1 for PackedSegment[];
-
+    using DynamicFeeCalculatorLib_v1 for uint;
     // =========================================================================
     // State
 
@@ -199,6 +201,13 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         _authorizer.setIsAuthorized(address(this), true);
         _authorizer.grantRole(_authorizer.getAdminRole(), address(this));
+
+        //    // Grant role to this test contract
+        // bytes32 roleId = _authorizer.generateRoleId(
+        //     address(lendingFacility),
+        //     lendingFacility.FEE_CALCULATOR_ADMIN_ROLE()
+        // );
+        // _authorizer.grantRole(roleId, address(this));
 
         defaultCurve.description = "Flat segment followed by a sloped segment";
         uint[] memory initialPrices = new uint[](2);
@@ -755,6 +764,157 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
     }
 
     // =========================================================================
+    // Test: Dynamic Fee Calculator
+
+    /* Test external setDynamicFeeCalculatorParams function
+        ├── Given caller has FEE_CALCULATOR_ADMIN_ROLE
+        │   └── When setting new fee calculator parameters
+        │       ├── Then the parameters should be updated
+        │       └── Then an event should be emitted
+        └── Given caller doesn't have role
+            └── When trying to set parameters
+    */
+
+    function test_setDynamicFeeCalculatorParams_unauthorized() public {
+        address unauthorizedUser = makeAddr("unauthorized");
+
+        vm.startPrank(unauthorizedUser);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IModule_v1.Module__CallerNotAuthorized.selector,
+                lendingFacility.FEE_CALCULATOR_ADMIN_ROLE(),
+                unauthorizedUser
+            )
+        );
+        lendingFacility.setDynamicFeeCalculatorParams(
+            1e16, 2e16, 3e16, 4e16, 5e16, 6e16
+        );
+        vm.stopPrank();
+    }
+
+    function test_setDynamicFeeCalculatorParams() public {
+        helper_setDynamicFeeCalculatorParams();
+
+        // assertEq(lendingFacility.Z_issueRedeem(), Z_issueRedeem);
+        // assertEq(lendingFacility.A_issueRedeem(), A_issueRedeem);
+        // assertEq(lendingFacility.m_issueRedeem(), m_issueRedeem);
+        // assertEq(lendingFacility.Z_origination(), Z_origination);
+        // assertEq(lendingFacility.A_origination(), A_origination);
+        // assertEq(lendingFacility.m_origination(), m_origination);
+    }
+
+    // Test: Dynamic Fee Calculator Library
+
+    /* Test calculateOriginationFee function
+        ├── Given floorLiquidityRate is below A_origination
+        │   └── Then the fee should be Z_origination
+        └── Given floorLiquidityRate is above A_origination
+            └── Then the fee should be Z_origination + (floorLiquidityRate - A_origination) * m_origination / 1e18
+    */
+    function test_calculateOriginationFee_BelowThreshold() public {
+        helper_setDynamicFeeCalculatorParams();
+
+        uint floorLiquidityRate = 1e16; // 1%
+        uint fee = DynamicFeeCalculatorLib_v1.calculateOriginationFee(
+            floorLiquidityRate,
+            lendingFacility.Z_origination(),
+            lendingFacility.A_origination(),
+            lendingFacility.m_origination()
+        );
+        assertEq(fee, lendingFacility.Z_origination());
+    }
+
+    function test_calculateOriginationFee_AboveThreshold() public {
+        uint floorLiquidityRate = 9e16; // 9%
+        uint fee = DynamicFeeCalculatorLib_v1.calculateOriginationFee(
+            floorLiquidityRate,
+            lendingFacility.Z_origination(),
+            lendingFacility.A_origination(),
+            lendingFacility.m_origination()
+        );
+        assertEq(
+            fee,
+            lendingFacility.Z_origination()
+                + (floorLiquidityRate - lendingFacility.A_origination())
+                    * lendingFacility.m_origination() / 1e18
+        );
+    }
+
+    /* Test calculateIssuanceFee function
+        ├── Given premiumRate is below A_issueRedeem
+        │   └── Then the fee should be Z_issueRedeem
+        └── Given premiumRate is above A_issueRedeem
+            └── Then the fee should be Z_issueRedeem + (premiumRate - A_issueRedeem) * m_issueRedeem / 1e18
+    */
+    function test_calculateIssuanceFee_BelowThreshold() public {
+        helper_setDynamicFeeCalculatorParams();
+
+        uint premiumRate = 1e16; // 1%
+        uint fee = DynamicFeeCalculatorLib_v1.calculateIssuanceFee(
+            premiumRate,
+            lendingFacility.Z_issueRedeem(),
+            lendingFacility.A_issueRedeem(),
+            lendingFacility.m_issueRedeem()
+        );
+        assertEq(fee, lendingFacility.Z_issueRedeem());
+    }
+
+    function test_calculateIssuanceFee_AboveThreshold() public {
+        helper_setDynamicFeeCalculatorParams();
+
+        uint premiumRate = 9e16; // 9%
+        uint fee = DynamicFeeCalculatorLib_v1.calculateIssuanceFee(
+            premiumRate,
+            lendingFacility.Z_issueRedeem(),
+            lendingFacility.A_issueRedeem(),
+            lendingFacility.m_issueRedeem()
+        );
+        assertEq(
+            fee,
+            lendingFacility.Z_issueRedeem()
+                + (premiumRate - lendingFacility.A_issueRedeem())
+                    * lendingFacility.m_issueRedeem() / 1e18
+        );
+    }
+
+    /* Test calculateRedemptionFee function
+        ├── Given premiumRate is below A_issueRedeem
+        │   └── Then the fee should be Z_issueRedeem
+        └── Given premiumRate is above A_issueRedeem
+            └── Then the fee should be Z_issueRedeem + (A_issueRedeem - premiumRate) * m_issueRedeem / 1e18
+    */
+    function test_calculateRedemptionFee_BelowThreshold() public {
+        helper_setDynamicFeeCalculatorParams();
+
+        uint premiumRate = 1e16; // 1%
+        uint fee = DynamicFeeCalculatorLib_v1.calculateRedemptionFee(
+            premiumRate,
+            lendingFacility.Z_issueRedeem(),
+            lendingFacility.A_issueRedeem(),
+            lendingFacility.m_issueRedeem()
+        );
+        assertEq(
+            fee,
+            lendingFacility.Z_issueRedeem()
+                + (lendingFacility.A_issueRedeem() - premiumRate)
+                    * lendingFacility.m_issueRedeem() / 1e18
+        );
+    }
+
+    function test_calculateRedemptionFee_AboveThreshold() public {
+        helper_setDynamicFeeCalculatorParams();
+
+        uint premiumRate = 9e16; // 9%
+        uint fee = DynamicFeeCalculatorLib_v1.calculateRedemptionFee(
+            premiumRate,
+            lendingFacility.Z_issueRedeem(),
+            lendingFacility.A_issueRedeem(),
+            lendingFacility.m_issueRedeem()
+        );
+        assertEq(fee, lendingFacility.Z_issueRedeem());
+    }
+
+    // =========================================================================
     // Test: Getters
 
     function testGetBorrowCapacity() public {
@@ -1019,5 +1179,23 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
             );
         }
         return segments;
+    }
+
+    function helper_setDynamicFeeCalculatorParams() internal {
+        uint Z_issueRedeem = 1e16; // 1%
+        uint A_issueRedeem = 7.5e16; // 7.5%
+        uint m_issueRedeem = 2e15; // 0.2%
+        uint Z_origination = 1e16; // 1%
+        uint A_origination = 2e16; // 2%
+        uint m_origination = 2e15; // 0.2%
+
+        lendingFacility.setDynamicFeeCalculatorParams(
+            Z_issueRedeem,
+            A_issueRedeem,
+            m_issueRedeem,
+            Z_origination,
+            A_origination,
+            m_origination
+        );
     }
 }

--- a/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
@@ -1,0 +1,536 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+// Internal
+import {
+    ModuleTest,
+    IModule_v1,
+    IOrchestrator_v1
+} from "@unitTest/modules/ModuleTest.sol";
+import {OZErrors} from "@testUtilities/OZErrors.sol";
+import {ERC20Mock} from "@mocks/external/token/ERC20Mock.sol";
+
+// External
+import {Clones} from "@oz/proxy/Clones.sol";
+
+// Tests and Mocks
+import {LM_PC_HouseProtocol_v1_Exposed} from
+    "@mocks/modules/logicModule/LM_PC_HouseProtocol_v1_Exposed.sol";
+import {
+    IERC20PaymentClientBase_v2,
+    ERC20PaymentClientBaseV2Mock,
+    ERC20Mock
+} from "@mocks/modules/paymentClient/ERC20PaymentClientBaseV2Mock.sol";
+
+// System under Test (SuT)
+import {ILM_PC_HouseProtocol_v1} from
+    "@lm/interfaces/ILM_PC_HouseProtocol_v1.sol";
+
+/**
+ * @title   House Protocol Lending Facility Tests
+ *
+ * @notice  Tests for the House Protocol lending facility logic module
+ *
+ * @dev     This test contract follows the standard testing pattern showing:
+ *          - Initialization tests
+ *          - External function tests
+ *          - Internal function tests through exposed functions
+ *          - Use of Gherkin for test documentation
+ *
+ * @author  Inverter Network
+ */
+contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
+    // =========================================================================
+    // State
+
+    // SuT
+    LM_PC_HouseProtocol_v1_Exposed lendingFacility;
+
+    // Mocks
+    ERC20Mock collateralToken;
+    ERC20Mock issuanceToken;
+    address dbcFmAddress;
+
+    // Test constants
+    uint constant BORROWABLE_QUOTA = 8000; // 80% in basis points
+    uint constant INDIVIDUAL_BORROW_LIMIT = 1000 ether;
+    uint constant LOCKED_ISSUANCE_TOKENS = 1000 ether;
+
+    // =========================================================================
+    // Setup
+
+    function setUp() public {
+        // Setup the tokens
+        collateralToken = new ERC20Mock("Collateral Token", "CT", 18);
+        issuanceToken = new ERC20Mock("Issuance Token", "IT", 18);
+        dbcFmAddress = makeAddr("dbcFm");
+
+        // Deploy the SuT
+        address impl = address(new LM_PC_HouseProtocol_v1_Exposed());
+        lendingFacility = LM_PC_HouseProtocol_v1_Exposed(Clones.clone(impl));
+
+        // Setup the module to test
+        _setUpOrchestrator(lendingFacility);
+
+        // Initiate the Logic Module with the metadata and config data
+        lendingFacility.init(
+            _orchestrator,
+            _METADATA,
+            abi.encode(
+                address(collateralToken),
+                address(issuanceToken),
+                dbcFmAddress,
+                BORROWABLE_QUOTA,
+                INDIVIDUAL_BORROW_LIMIT
+            )
+        );
+
+        // Mint tokens to the lending facility
+        collateralToken.mint(address(lendingFacility), 10_000 ether);
+        issuanceToken.mint(address(lendingFacility), 10_000 ether);
+    }
+
+    // =========================================================================
+    // Test: Initialization
+
+    // Test if the orchestrator is correctly set
+    function testInit() public override(ModuleTest) {
+        assertEq(
+            address(lendingFacility.orchestrator()), address(_orchestrator)
+        );
+    }
+
+    // Test the interface support
+    function testSupportsInterface() public {
+        assertTrue(
+            lendingFacility.supportsInterface(
+                type(IERC20PaymentClientBase_v2).interfaceId
+            )
+        );
+        assertTrue(
+            lendingFacility.supportsInterface(
+                type(ILM_PC_HouseProtocol_v1).interfaceId
+            )
+        );
+    }
+
+    // Test the reinit function
+    function testReinitFails() public override(ModuleTest) {
+        vm.expectRevert(OZErrors.Initializable__InvalidInitialization);
+        lendingFacility.init(_orchestrator, _METADATA, abi.encode(""));
+    }
+
+    // =========================================================================
+    // Test: Issuance Token Management
+
+    /* Test external lockIssuanceTokens function
+        ├── Given valid amount
+        │   └── When user locks issuance tokens
+        │       ├── Then their locked amount should increase
+        │       └── Then tokens should be transferred to contract
+        └── Given invalid amount
+            └── When user tries to lock zero tokens
+                └── Then it should revert with InvalidBorrowAmount
+    */
+    function testLockIssuanceTokens() public {
+        address user = makeAddr("user");
+        uint lockAmount = 100 ether;
+
+        issuanceToken.mint(user, lockAmount);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), lockAmount);
+
+        vm.prank(user);
+        lendingFacility.lockIssuanceTokens(lockAmount);
+
+        assertEq(lendingFacility.getLockedIssuanceTokens(user), lockAmount);
+    }
+
+    function testLockIssuanceTokens_zeroAmount() public {
+        address user = makeAddr("user");
+
+        vm.prank(user);
+        vm.expectRevert("Amount must be greater than zero");
+        lendingFacility.lockIssuanceTokens(0);
+    }
+
+    /* Test external unlockIssuanceTokens function
+        ├── Given user has locked tokens and no outstanding loan
+        │   └── When user unlocks tokens
+        │       ├── Then their locked amount should decrease
+        │       └── Then tokens should be transferred back to user
+        └── Given user has outstanding loan
+            └── When user tries to unlock tokens
+                └── Then it should revert with CannotUnlockWithOutstandingLoan
+    */
+    function testUnlockIssuanceTokens() public {
+        address user = makeAddr("user");
+        uint lockAmount = 100 ether;
+        uint unlockAmount = 50 ether;
+
+        // Setup: lock tokens
+        issuanceToken.mint(user, lockAmount);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        lendingFacility.lockIssuanceTokens(lockAmount);
+
+        // Test: unlock tokens
+        vm.prank(user);
+        lendingFacility.unlockIssuanceTokens(unlockAmount);
+
+        assertEq(
+            lendingFacility.getLockedIssuanceTokens(user),
+            lockAmount - unlockAmount
+        );
+    }
+
+    function testUnlockIssuanceTokens_withOutstandingLoan() public {
+        address user = makeAddr("user");
+        uint lockAmount = 100 ether;
+
+        // Setup: lock tokens and borrow
+        issuanceToken.mint(user, lockAmount);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        lendingFacility.lockIssuanceTokens(lockAmount);
+
+        // Borrow some tokens (this creates an outstanding loan)
+        uint borrowAmount = 50 ether;
+        vm.prank(user);
+        lendingFacility.borrow(borrowAmount);
+
+        // Try to unlock tokens
+        vm.prank(user);
+        vm.expectRevert("Cannot unlock tokens with outstanding loan");
+        lendingFacility.unlockIssuanceTokens(50 ether);
+    }
+
+    // =========================================================================
+    // Test: Borrowing
+
+    /* Test external borrow function
+        ├── Given valid borrow request
+        │   └── When user borrows collateral tokens
+        │       ├── Then their outstanding loan should increase
+        │       ├── Then dynamic fee should be calculated and deducted
+        │       └── Then net amount should be transferred to user
+        └── Given invalid borrow request
+            └── When user tries to borrow more than limit
+                └── Then it should revert with appropriate error
+    */
+    function testBorrow() public {
+        address user = makeAddr("user");
+        uint lockAmount = 1000 ether;
+        uint borrowAmount = 500 ether;
+
+        // Setup: lock issuance tokens
+        issuanceToken.mint(user, lockAmount);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        lendingFacility.lockIssuanceTokens(lockAmount);
+
+        // Test: borrow collateral tokens
+        vm.prank(user);
+        lendingFacility.borrow(borrowAmount);
+
+        assertEq(lendingFacility.getOutstandingLoan(user), borrowAmount);
+        assertEq(lendingFacility.currentlyBorrowedAmount(), borrowAmount);
+    }
+
+    function testBorrow_exceedsIndividualLimit() public {
+        address user = makeAddr("user");
+        uint lockAmount = 1000 ether;
+        uint borrowAmount = INDIVIDUAL_BORROW_LIMIT + 1 ether;
+
+        // Setup: lock issuance tokens
+        issuanceToken.mint(user, lockAmount);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        lendingFacility.lockIssuanceTokens(lockAmount);
+
+        // Test: try to borrow more than individual limit
+        vm.prank(user);
+        vm.expectRevert("Individual borrow limit exceeded");
+        lendingFacility.borrow(borrowAmount);
+    }
+
+    function testBorrow_zeroAmount() public {
+        address user = makeAddr("user");
+
+        vm.prank(user);
+        vm.expectRevert("Borrow amount must be greater than zero");
+        lendingFacility.borrow(0);
+    }
+
+    // =========================================================================
+    // Test: Repaying
+
+    /* Test external repay function
+        ├── Given user has outstanding loan
+        │   └── When user repays loan
+        │       ├── Then their outstanding loan should decrease
+        │       ├── Then collateral should be transferred back to facility
+        │       └── Then issuance tokens should be unlocked proportionally
+        └── Given user has no outstanding loan
+            └── When user tries to repay
+                └── Then it should revert with appropriate error
+    */
+    function testRepay() public {
+        address user = makeAddr("user");
+        uint lockAmount = 1000 ether;
+        uint borrowAmount = 500 ether;
+        uint repayAmount = 200 ether;
+
+        // Setup: lock tokens and borrow
+        issuanceToken.mint(user, lockAmount);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        lendingFacility.lockIssuanceTokens(lockAmount);
+
+        vm.prank(user);
+        lendingFacility.borrow(borrowAmount);
+
+        // Test: repay loan
+        collateralToken.mint(user, repayAmount);
+        vm.prank(user);
+        collateralToken.approve(address(lendingFacility), repayAmount);
+
+        vm.prank(user);
+        lendingFacility.repay(repayAmount);
+
+        assertEq(
+            lendingFacility.getOutstandingLoan(user), borrowAmount - repayAmount
+        );
+        assertEq(
+            lendingFacility.currentlyBorrowedAmount(),
+            borrowAmount - repayAmount
+        );
+    }
+
+    function testRepay_exceedsOutstandingLoan() public {
+        address user = makeAddr("user");
+        uint lockAmount = 1000 ether;
+        uint borrowAmount = 500 ether;
+        uint repayAmount = 600 ether;
+
+        // Setup: lock tokens and borrow
+        issuanceToken.mint(user, lockAmount);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        lendingFacility.lockIssuanceTokens(lockAmount);
+
+        vm.prank(user);
+        lendingFacility.borrow(borrowAmount);
+
+        // Test: try to repay more than outstanding loan
+        collateralToken.mint(user, repayAmount);
+        vm.prank(user);
+        collateralToken.approve(address(lendingFacility), repayAmount);
+
+        vm.prank(user);
+        vm.expectRevert("Repayment amount exceeds outstanding loan");
+        lendingFacility.repay(repayAmount);
+    }
+
+    // =========================================================================
+    // Test: Configuration Functions
+
+    /* Test external setIndividualBorrowLimit function
+        ├── Given caller has LENDING_FACILITY_MANAGER_ROLE
+        │   └── When setting new individual borrow limit
+        │       ├── Then the limit should be updated
+        │       └── Then an event should be emitted
+        └── Given caller doesn't have role
+            └── When trying to set limit
+                └── Then it should revert with CallerNotAuthorized
+    */
+    function testSetIndividualBorrowLimit() public {
+        // Grant role to this test contract
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(lendingFacility),
+            lendingFacility.LENDING_FACILITY_MANAGER_ROLE()
+        );
+        _authorizer.grantRole(roleId, address(this));
+
+        uint newLimit = 2000 ether;
+        lendingFacility.setIndividualBorrowLimit(newLimit);
+
+        assertEq(lendingFacility.individualBorrowLimit(), newLimit);
+    }
+
+    function testSetIndividualBorrowLimit_unauthorized() public {
+        address unauthorizedUser = makeAddr("unauthorized");
+
+        vm.startPrank(unauthorizedUser);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IModule_v1.Module__CallerNotAuthorized.selector,
+                lendingFacility.LENDING_FACILITY_MANAGER_ROLE(),
+                unauthorizedUser
+            )
+        );
+        lendingFacility.setIndividualBorrowLimit(2000 ether);
+        vm.stopPrank();
+    }
+
+    /* Test external setBorrowableQuota function
+        ├── Given caller has LENDING_FACILITY_MANAGER_ROLE
+        │   └── When setting new borrowable quota
+        │       ├── Then the quota should be updated
+        │       └── Then an event should be emitted
+        └── Given quota exceeds 100%
+            └── When trying to set quota
+                └── Then it should revert with appropriate error
+    */
+    function testSetBorrowableQuota() public {
+        // Grant role to this test contract
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(lendingFacility),
+            lendingFacility.LENDING_FACILITY_MANAGER_ROLE()
+        );
+        _authorizer.grantRole(roleId, address(this));
+
+        uint newQuota = 9000; // 90% in basis points
+        lendingFacility.setBorrowableQuota(newQuota);
+
+        assertEq(lendingFacility.borrowableQuota(), newQuota);
+    }
+
+    function testSetBorrowableQuota_exceedsMax() public {
+        // Grant role to this test contract
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(lendingFacility),
+            lendingFacility.LENDING_FACILITY_MANAGER_ROLE()
+        );
+        _authorizer.grantRole(roleId, address(this));
+
+        uint invalidQuota = 10_001; // Exceeds 100%
+        vm.expectRevert("Borrowable quota cannot exceed 100%");
+        lendingFacility.setBorrowableQuota(invalidQuota);
+    }
+
+    /* Test external setDynamicFeeCalculator function
+        ├── Given caller has LENDING_FACILITY_MANAGER_ROLE
+        │   └── When setting new fee calculator address
+        │       ├── Then the address should be updated
+        │       └── Then an event should be emitted
+        └── Given invalid address (zero address)
+            └── When trying to set address
+                └── Then it should revert with appropriate error
+    */
+    function testSetDynamicFeeCalculator() public {
+        // Grant role to this test contract
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(lendingFacility),
+            lendingFacility.LENDING_FACILITY_MANAGER_ROLE()
+        );
+        _authorizer.grantRole(roleId, address(this));
+
+        address newCalculator = makeAddr("newCalculator");
+        lendingFacility.setDynamicFeeCalculator(newCalculator);
+
+        assertEq(lendingFacility.dynamicFeeCalculator(), newCalculator);
+    }
+
+    function testSetDynamicFeeCalculator_zeroAddress() public {
+        // Grant role to this test contract
+        bytes32 roleId = _authorizer.generateRoleId(
+            address(lendingFacility),
+            lendingFacility.LENDING_FACILITY_MANAGER_ROLE()
+        );
+        _authorizer.grantRole(roleId, address(this));
+
+        vm.expectRevert("Invalid fee calculator address");
+        lendingFacility.setDynamicFeeCalculator(address(0));
+    }
+
+    // =========================================================================
+    // Test: Getters
+
+    function testGetBorrowCapacity() public {
+        uint capacity = lendingFacility.getBorrowCapacity();
+        assertGt(capacity, 0);
+    }
+
+    function testGetCurrentBorrowQuota() public {
+        uint quota = lendingFacility.getCurrentBorrowQuota();
+        assertEq(quota, 0); // Initially no borrowed amount
+    }
+
+    function testGetFloorLiquidityRate() public {
+        uint rate = lendingFacility.getFloorLiquidityRate();
+        assertGt(rate, 0);
+    }
+
+    function testGetUserBorrowingPower() public {
+        address user = makeAddr("user");
+        uint power = lendingFacility.getUserBorrowingPower(user);
+        assertEq(power, 0); // Initially no locked tokens
+
+        // Lock some tokens and check power
+        uint lockAmount = 1000 ether;
+        issuanceToken.mint(user, lockAmount);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        lendingFacility.lockIssuanceTokens(lockAmount);
+
+        power = lendingFacility.getUserBorrowingPower(user);
+        assertGt(power, 0);
+    }
+
+    // =========================================================================
+    // Test: Internal (tested through exposed_ functions)
+
+    function testEnsureValidBorrowAmount() public {
+        // Should not revert for valid amount
+        lendingFacility.exposed_ensureValidBorrowAmount(100 ether);
+
+        // Should revert for zero amount
+        vm.expectRevert("Borrow amount must be greater than zero");
+        lendingFacility.exposed_ensureValidBorrowAmount(0);
+    }
+
+    function testCalculateBorrowCapacity() public {
+        uint capacity = lendingFacility.exposed_calculateBorrowCapacity();
+        assertGt(capacity, 0);
+    }
+
+    function testCalculateUserBorrowingPower() public {
+        address user = makeAddr("user");
+        uint power = lendingFacility.exposed_calculateUserBorrowingPower(user);
+        assertEq(power, 0); // No locked tokens initially
+
+        // Lock tokens and check power
+        uint lockAmount = 1000 ether;
+        issuanceToken.mint(user, lockAmount);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        lendingFacility.lockIssuanceTokens(lockAmount);
+
+        power = lendingFacility.exposed_calculateUserBorrowingPower(user);
+        assertGt(power, 0);
+    }
+
+    function testCalculateDynamicBorrowingFee() public {
+        uint fee =
+            lendingFacility.exposed_calculateDynamicBorrowingFee(1000 ether);
+        // Fee calculation depends on floor liquidity rate
+        assertGe(fee, 0);
+    }
+
+    function testCalculateIssuanceTokensToUnlock() public {
+        address user = makeAddr("user");
+        uint repaymentAmount = 500 ether;
+        uint tokensToUnlock = lendingFacility
+            .exposed_calculateIssuanceTokensToUnlock(user, repaymentAmount);
+        assertEq(tokensToUnlock, 0); // No outstanding loan initially
+    }
+}

--- a/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
@@ -78,7 +78,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
     // Test constants
     uint constant BORROWABLE_QUOTA = 8000; // 80% in basis points
-    uint constant INDIVIDUAL_BORROW_LIMIT = 1000 ether;
+    uint constant INDIVIDUAL_BORROW_LIMIT = 500 ether;
     uint constant LOCKED_ISSUANCE_TOKENS = 1000 ether;
 
     // Structs for organizing test data
@@ -105,12 +105,12 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
     // Default Curve Parameters
     uint public constant DEFAULT_SEG0_INITIAL_PRICE = 0.5 ether;
     uint public constant DEFAULT_SEG0_PRICE_INCREASE = 0;
-    uint public constant DEFAULT_SEG0_SUPPLY_PER_STEP = 50 ether;
+    uint public constant DEFAULT_SEG0_SUPPLY_PER_STEP = 500 ether;
     uint public constant DEFAULT_SEG0_NUMBER_OF_STEPS = 1;
 
     uint public constant DEFAULT_SEG1_INITIAL_PRICE = 0.8 ether;
     uint public constant DEFAULT_SEG1_PRICE_INCREASE = 0.02 ether;
-    uint public constant DEFAULT_SEG1_SUPPLY_PER_STEP = 25 ether;
+    uint public constant DEFAULT_SEG1_SUPPLY_PER_STEP = 500 ether;
     uint public constant DEFAULT_SEG1_NUMBER_OF_STEPS = 2;
 
     // Issuance Token Parameters
@@ -250,6 +250,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Grant minting rights for issuance token to the bonding curve
         issuanceToken.setMinter(address(fmBcDiscrete), true);
+
+        // Set virtual collateral supply to simulate pre-sale funds
+        // This represents the backing for the first step of the bonding curve
+        uint initialVirtualSupply = 1000 ether; // Simulate 1000 ETH worth of pre-sale
+        fmBcDiscrete.setVirtualCollateralSupply(initialVirtualSupply);
 
         // Initiate the Logic Module with the metadata and config data
         lendingFacility.init(
@@ -392,8 +397,12 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint lockAmount = 100 ether;
 
         issuanceToken.mint(user, lockAmount);
+        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        
         vm.prank(user);
         issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
 
         vm.prank(user);
         lendingFacility.lockIssuanceTokens(lockAmount);
@@ -405,7 +414,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         address user = makeAddr("user");
 
         vm.prank(user);
-        vm.expectRevert("Amount must be greater than zero");
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount.selector);
         lendingFacility.lockIssuanceTokens(0);
     }
 
@@ -425,8 +434,13 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Setup: lock tokens
         issuanceToken.mint(user, lockAmount);
+        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        
         vm.prank(user);
         issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        
         vm.prank(user);
         lendingFacility.lockIssuanceTokens(lockAmount);
 
@@ -446,8 +460,13 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Setup: lock tokens and borrow
         issuanceToken.mint(user, lockAmount);
+        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        
         vm.prank(user);
         issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        
         vm.prank(user);
         lendingFacility.lockIssuanceTokens(lockAmount);
 
@@ -458,7 +477,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Try to unlock tokens
         vm.prank(user);
-        vm.expectRevert("Cannot unlock tokens with outstanding loan");
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_CannotUnlockWithOutstandingLoan.selector);
         lendingFacility.unlockIssuanceTokens(50 ether);
     }
 
@@ -482,8 +501,13 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Setup: lock issuance tokens
         issuanceToken.mint(user, lockAmount);
+        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        
         vm.prank(user);
         issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        
         vm.prank(user);
         lendingFacility.lockIssuanceTokens(lockAmount);
 
@@ -497,19 +521,24 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
     function testBorrow_exceedsIndividualLimit() public {
         address user = makeAddr("user");
-        uint lockAmount = 1000 ether;
-        uint borrowAmount = INDIVIDUAL_BORROW_LIMIT + 1 ether;
+        uint lockAmount = 3000 ether; // Lock more tokens to have sufficient borrowing power
+        uint borrowAmount = 600 ether; // More than individual limit (500 ether) but within borrowable quota (800 ether)
 
         // Setup: lock issuance tokens
         issuanceToken.mint(user, lockAmount);
+        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        
         vm.prank(user);
         issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        
         vm.prank(user);
         lendingFacility.lockIssuanceTokens(lockAmount);
 
         // Test: try to borrow more than individual limit
         vm.prank(user);
-        vm.expectRevert("Individual borrow limit exceeded");
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_IndividualBorrowLimitExceeded.selector);
         lendingFacility.borrow(borrowAmount);
     }
 
@@ -517,7 +546,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         address user = makeAddr("user");
 
         vm.prank(user);
-        vm.expectRevert("Borrow amount must be greater than zero");
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount.selector);
         lendingFacility.borrow(0);
     }
 
@@ -542,8 +571,13 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Setup: lock tokens and borrow
         issuanceToken.mint(user, lockAmount);
+        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        
         vm.prank(user);
         issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        
         vm.prank(user);
         lendingFacility.lockIssuanceTokens(lockAmount);
 
@@ -575,8 +609,13 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Setup: lock tokens and borrow
         issuanceToken.mint(user, lockAmount);
+        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        
         vm.prank(user);
         issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        
         vm.prank(user);
         lendingFacility.lockIssuanceTokens(lockAmount);
 
@@ -589,7 +628,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         orchestratorToken.approve(address(lendingFacility), repayAmount);
 
         vm.prank(user);
-        vm.expectRevert("Repayment amount exceeds outstanding loan");
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_RepaymentAmountExceedsLoan.selector);
         lendingFacility.repay(repayAmount);
     }
 
@@ -666,7 +705,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         _authorizer.grantRole(roleId, address(this));
 
         uint invalidQuota = 10_001; // Exceeds 100%
-        vm.expectRevert("Borrowable quota cannot exceed 100%");
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_BorrowableQuotaTooHigh.selector);
         lendingFacility.setBorrowableQuota(invalidQuota);
     }
 
@@ -701,7 +740,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         );
         _authorizer.grantRole(roleId, address(this));
 
-        vm.expectRevert("Invalid fee calculator address");
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidFeeCalculatorAddress.selector);
         lendingFacility.setDynamicFeeCalculator(address(0));
     }
 
@@ -731,8 +770,13 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         // Lock some tokens and check power
         uint lockAmount = 1000 ether;
         issuanceToken.mint(user, lockAmount);
+        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        
         vm.prank(user);
         issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        
         vm.prank(user);
         lendingFacility.lockIssuanceTokens(lockAmount);
 
@@ -748,7 +792,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         lendingFacility.exposed_ensureValidBorrowAmount(100 ether);
 
         // Should revert for zero amount
-        vm.expectRevert("Borrow amount must be greater than zero");
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount.selector);
         lendingFacility.exposed_ensureValidBorrowAmount(0);
     }
 
@@ -765,8 +809,13 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         // Lock tokens and check power
         uint lockAmount = 1000 ether;
         issuanceToken.mint(user, lockAmount);
+        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        
         vm.prank(user);
         issuanceToken.approve(address(lendingFacility), lockAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        
         vm.prank(user);
         lendingFacility.lockIssuanceTokens(lockAmount);
 

--- a/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
@@ -942,8 +942,10 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         assertEq(
             fee,
             feeParams.Z_origination
-                + (floorLiquidityRate - feeParams.A_origination)
-                    * feeParams.m_origination / 1e18
+                + (
+                    (floorLiquidityRate - feeParams.A_origination)
+                        * feeParams.m_origination
+                ) / 1e18
         );
     }
 
@@ -990,7 +992,9 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         ├── Given premiumRate is below A_issueRedeem
         │   └── Then the fee should be Z_issueRedeem
         └── Given premiumRate is above A_issueRedeem
-            └── Then the fee should be Z_issueRedeem + (A_issueRedeem - premiumRate) * m_issueRedeem / SCALING_FACTOR
+            └── Then the fee should be feeParams.Z_issueRedeem
+                + (feeParams.A_issueRedeem - premiumRate) * feeParams.m_issueRedeem
+                    / SCALING_FACTOR
     */
     function test_calculateRedemptionFee_BelowThreshold() public {
         ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =

--- a/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
@@ -9,6 +9,23 @@ import {
 } from "@unitTest/modules/ModuleTest.sol";
 import {OZErrors} from "@testUtilities/OZErrors.sol";
 import {ERC20Mock} from "@mocks/external/token/ERC20Mock.sol";
+import {IFundingManager_v1} from "@fm/IFundingManager_v1.sol";
+import {IBondingCurveBase_v1} from
+    "@fm/bondingCurve/interfaces/IBondingCurveBase_v1.sol";
+import {IRedeemingBondingCurveBase_v1} from
+    "@fm/bondingCurve/interfaces/IRedeemingBondingCurveBase_v1.sol";
+import {IVirtualCollateralSupplyBase_v1} from
+    "@fm/bondingCurve/interfaces/IVirtualCollateralSupplyBase_v1.sol";
+import {IVirtualIssuanceSupplyBase_v1} from
+    "@fm/bondingCurve/interfaces/IVirtualIssuanceSupplyBase_v1.sol";
+import {PackedSegment} from
+    "src/modules/fundingManager/bondingCurve/types/PackedSegment_v1.sol";
+import {IDiscreteCurveMathLib_v1} from
+    "src/modules/fundingManager/bondingCurve/interfaces/IDiscreteCurveMathLib_v1.sol";
+import {DiscreteCurveMathLib_v1} from
+    "src/modules/fundingManager/bondingCurve/formulas/DiscreteCurveMathLib_v1.sol";
+import {PackedSegmentLib} from
+    "src/modules/fundingManager/bondingCurve/libraries/PackedSegmentLib.sol";
 
 // External
 import {Clones} from "@oz/proxy/Clones.sol";
@@ -21,10 +38,15 @@ import {
     ERC20PaymentClientBaseV2Mock,
     ERC20Mock
 } from "@mocks/modules/paymentClient/ERC20PaymentClientBaseV2Mock.sol";
+import {ERC20Issuance_v1} from "@ex/token/ERC20Issuance_v1.sol"; // Added import
 
 // System under Test (SuT)
 import {ILM_PC_HouseProtocol_v1} from
     "@lm/interfaces/ILM_PC_HouseProtocol_v1.sol";
+import {IFM_BC_Discrete_Redeeming_VirtualSupply_v1} from
+    "src/modules/fundingManager/bondingCurve/interfaces/IFM_BC_Discrete_Redeeming_VirtualSupply_v1.sol";
+import {FM_BC_Discrete_Redeeming_VirtualSupply_v1_Exposed} from
+    "test/mocks/modules/fundingManager/bondingCurve/FM_BC_Discrete_Redeeming_VirtualSupply_v1_Exposed.sol";
 
 /**
  * @title   House Protocol Lending Facility Tests
@@ -40,6 +62,9 @@ import {ILM_PC_HouseProtocol_v1} from
  * @author  Inverter Network
  */
 contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
+    using PackedSegmentLib for PackedSegment;
+    using DiscreteCurveMathLib_v1 for PackedSegment[];
+
     // =========================================================================
     // State
 
@@ -47,46 +72,200 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
     LM_PC_HouseProtocol_v1_Exposed lendingFacility;
 
     // Mocks
-    ERC20Mock collateralToken;
-    ERC20Mock issuanceToken;
-    address dbcFmAddress;
+    // ERC20Mock collateralToken;
+    // ERC20Mock issuanceToken;
+    // address dbcFmAddress;
 
     // Test constants
     uint constant BORROWABLE_QUOTA = 8000; // 80% in basis points
     uint constant INDIVIDUAL_BORROW_LIMIT = 1000 ether;
     uint constant LOCKED_ISSUANCE_TOKENS = 1000 ether;
 
+    // Structs for organizing test data
+    struct CurveTestData {
+        PackedSegment[] packedSegmentsArray; // Array of PackedSegments for the library
+        uint totalCapacity; // Calculated: sum of segment capacities
+        uint totalReserve; // Calculated: sum of segment reserves
+        string description; // Optional: for logging or comments
+    }
+
+    // Protocol Fee Test Parameters
+    uint internal constant TEST_PROTOCOL_COLLATERAL_BUY_FEE_BPS = 50; // 0.5%
+    uint internal constant TEST_PROTOCOL_ISSUANCE_BUY_FEE_BPS = 20; // 0.2%
+    uint internal constant TEST_PROTOCOL_COLLATERAL_SELL_FEE_BPS = 40; // 0.4%
+    uint internal constant TEST_PROTOCOL_ISSUANCE_SELL_FEE_BPS = 30; // 0.3%
+    address internal constant TEST_PROTOCOL_TREASURY = address(0xFEE5); // Define a test treasury address
+
+    // Project Fee Constants (mirroring those in the contract for assertion)
+    uint internal constant TEST_PROJECT_BUY_FEE_BPS = 100;
+    uint internal constant TEST_PROJECT_SELL_FEE_BPS = 100;
+
+    address internal non_admin_address = address(0xB0B);
+
+    // Default Curve Parameters
+    uint public constant DEFAULT_SEG0_INITIAL_PRICE = 0.5 ether;
+    uint public constant DEFAULT_SEG0_PRICE_INCREASE = 0;
+    uint public constant DEFAULT_SEG0_SUPPLY_PER_STEP = 50 ether;
+    uint public constant DEFAULT_SEG0_NUMBER_OF_STEPS = 1;
+
+    uint public constant DEFAULT_SEG1_INITIAL_PRICE = 0.8 ether;
+    uint public constant DEFAULT_SEG1_PRICE_INCREASE = 0.02 ether;
+    uint public constant DEFAULT_SEG1_SUPPLY_PER_STEP = 25 ether;
+    uint public constant DEFAULT_SEG1_NUMBER_OF_STEPS = 2;
+
+    // Issuance Token Parameters
+    string internal constant ISSUANCE_TOKEN_NAME = "House Token";
+    string internal constant ISSUANCE_TOKEN_SYMBOL = "HOUSE";
+    uint8 internal constant ISSUANCE_TOKEN_DECIMALS = 18;
+    uint internal constant ISSUANCE_TOKEN_MAX_SUPPLY = type(uint).max;
+
+    FM_BC_Discrete_Redeeming_VirtualSupply_v1_Exposed public fmBcDiscrete;
+    ERC20Mock public orchestratorToken; // This is the collateral token
+    ERC20Issuance_v1 public issuanceToken; // This is the token to be issued
+    ERC20PaymentClientBaseV2Mock public paymentClient;
+    PackedSegment[] public initialTestSegments;
+    CurveTestData internal defaultCurve; // Declare defaultCurve variable
+
     // =========================================================================
     // Setup
 
     function setUp() public {
-        // Setup the tokens
-        collateralToken = new ERC20Mock("Collateral Token", "CT", 18);
-        issuanceToken = new ERC20Mock("Issuance Token", "IT", 18);
-        dbcFmAddress = makeAddr("dbcFm");
+        address impl_fmBcDiscrete =
+            address(new FM_BC_Discrete_Redeeming_VirtualSupply_v1_Exposed());
+        fmBcDiscrete = FM_BC_Discrete_Redeeming_VirtualSupply_v1_Exposed(
+            Clones.clone(impl_fmBcDiscrete)
+        );
+
+        orchestratorToken = new ERC20Mock("Orchestrator Token", "OTK", 18);
+        issuanceToken = new ERC20Issuance_v1(
+            ISSUANCE_TOKEN_NAME,
+            ISSUANCE_TOKEN_SYMBOL,
+            ISSUANCE_TOKEN_DECIMALS,
+            ISSUANCE_TOKEN_MAX_SUPPLY
+        );
+        // Grant minting rights for issuance token to the test contract for setup if needed,
+        // and later to the bonding curve itself.
+        issuanceToken.setMinter(address(this), true);
 
         // Deploy the SuT
-        address impl = address(new LM_PC_HouseProtocol_v1_Exposed());
-        lendingFacility = LM_PC_HouseProtocol_v1_Exposed(Clones.clone(impl));
+        address impl_lendingFacility =
+            address(new LM_PC_HouseProtocol_v1_Exposed());
+        lendingFacility =
+            LM_PC_HouseProtocol_v1_Exposed(Clones.clone(impl_lendingFacility));
 
         // Setup the module to test
+        _setUpOrchestrator(fmBcDiscrete); // This also sets up feeManager via _createFeeManager in ModuleTest
         _setUpOrchestrator(lendingFacility);
+
+        // Configure FeeManager *before* fmBcDiscrete.init() is called later in this setUp.
+        // ModuleTest's _setUpOrchestrator should make `this` (the test contract) the owner of feeManager.
+        feeManager.setWorkflowTreasury(
+            address(_orchestrator), TEST_PROTOCOL_TREASURY
+        );
+
+        bytes4 buyOrderSelector =
+            bytes4(keccak256(bytes("_buyOrder(address,uint,uint)")));
+        feeManager.setCollateralWorkflowFee(
+            address(_orchestrator),
+            address(fmBcDiscrete),
+            buyOrderSelector,
+            true,
+            TEST_PROTOCOL_COLLATERAL_BUY_FEE_BPS
+        );
+        feeManager.setIssuanceWorkflowFee(
+            address(_orchestrator),
+            address(fmBcDiscrete),
+            buyOrderSelector,
+            true,
+            TEST_PROTOCOL_ISSUANCE_BUY_FEE_BPS
+        );
+
+        bytes4 sellOrderSelector =
+            bytes4(keccak256(bytes("_sellOrder(address,uint,uint)")));
+        feeManager.setCollateralWorkflowFee(
+            address(_orchestrator),
+            address(fmBcDiscrete),
+            sellOrderSelector,
+            true,
+            TEST_PROTOCOL_COLLATERAL_SELL_FEE_BPS
+        );
+        feeManager.setIssuanceWorkflowFee(
+            address(_orchestrator),
+            address(fmBcDiscrete),
+            sellOrderSelector,
+            true,
+            TEST_PROTOCOL_ISSUANCE_SELL_FEE_BPS
+        );
+
+        _authorizer.setIsAuthorized(address(this), true);
+        _authorizer.grantRole(_authorizer.getAdminRole(), address(this));
+
+        defaultCurve.description = "Flat segment followed by a sloped segment";
+        uint[] memory initialPrices = new uint[](2);
+        initialPrices[0] = DEFAULT_SEG0_INITIAL_PRICE;
+        initialPrices[1] = DEFAULT_SEG1_INITIAL_PRICE;
+        uint[] memory priceIncreases = new uint[](2);
+        priceIncreases[0] = DEFAULT_SEG0_PRICE_INCREASE;
+        priceIncreases[1] = DEFAULT_SEG1_PRICE_INCREASE;
+        uint[] memory suppliesPerStep = new uint[](2);
+        suppliesPerStep[0] = DEFAULT_SEG0_SUPPLY_PER_STEP;
+        suppliesPerStep[1] = DEFAULT_SEG1_SUPPLY_PER_STEP;
+        uint[] memory numbersOfSteps = new uint[](2);
+        numbersOfSteps[0] = DEFAULT_SEG0_NUMBER_OF_STEPS;
+        numbersOfSteps[1] = DEFAULT_SEG1_NUMBER_OF_STEPS;
+
+        defaultCurve.packedSegmentsArray = helper_createSegments(
+            initialPrices, priceIncreases, suppliesPerStep, numbersOfSteps
+        );
+        defaultCurve.totalCapacity = (
+            DEFAULT_SEG0_SUPPLY_PER_STEP * DEFAULT_SEG0_NUMBER_OF_STEPS
+        ) + (DEFAULT_SEG1_SUPPLY_PER_STEP * DEFAULT_SEG1_NUMBER_OF_STEPS);
+        initialTestSegments = defaultCurve.packedSegmentsArray;
+
+        vm.expectEmit(true, true, true, true, address(fmBcDiscrete));
+        emit IBondingCurveBase_v1.IssuanceTokenSet(
+            address(issuanceToken), issuanceToken.decimals()
+        );
+        vm.expectEmit(true, true, true, true, address(fmBcDiscrete));
+        emit IFM_BC_Discrete_Redeeming_VirtualSupply_v1.SegmentsSet(
+            initialTestSegments
+        );
+        vm.expectEmit(true, true, true, true, address(fmBcDiscrete));
+        emit IFundingManager_v1.OrchestratorTokenSet(
+            address(orchestratorToken), orchestratorToken.decimals()
+        );
+
+        fmBcDiscrete.init(
+            _orchestrator,
+            _METADATA,
+            abi.encode(
+                address(issuanceToken),
+                address(orchestratorToken),
+                initialTestSegments
+            )
+        );
+
+        // Update protocol fee cache for buy and sell operations
+        fmBcDiscrete.updateProtocolFeeCache();
+
+        // Grant minting rights for issuance token to the bonding curve
+        issuanceToken.setMinter(address(fmBcDiscrete), true);
 
         // Initiate the Logic Module with the metadata and config data
         lendingFacility.init(
             _orchestrator,
             _METADATA,
             abi.encode(
-                address(collateralToken),
+                address(orchestratorToken),
                 address(issuanceToken),
-                dbcFmAddress,
+                address(fmBcDiscrete),
                 BORROWABLE_QUOTA,
                 INDIVIDUAL_BORROW_LIMIT
             )
         );
 
         // Mint tokens to the lending facility
-        collateralToken.mint(address(lendingFacility), 10_000 ether);
+        orchestratorToken.mint(address(lendingFacility), 10_000 ether);
         issuanceToken.mint(address(lendingFacility), 10_000 ether);
     }
 
@@ -97,6 +276,82 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
     function testInit() public override(ModuleTest) {
         assertEq(
             address(lendingFacility.orchestrator()), address(_orchestrator)
+        );
+        assertEq(address(fmBcDiscrete.orchestrator()), address(_orchestrator));
+        assertEq(
+            address(fmBcDiscrete.token()),
+            address(orchestratorToken),
+            "Collateral token mismatch"
+        );
+        assertEq(
+            fmBcDiscrete.getIssuanceToken(),
+            address(issuanceToken),
+            "Issuance token mismatch"
+        );
+
+        PackedSegment[] memory segmentsAfterInit = fmBcDiscrete.getSegments();
+        assertEq(
+            segmentsAfterInit.length,
+            initialTestSegments.length,
+            "Segments length mismatch"
+        );
+        for (uint i = 0; i < segmentsAfterInit.length; i++) {
+            assertEq(
+                PackedSegment.unwrap(segmentsAfterInit[i]),
+                PackedSegment.unwrap(initialTestSegments[i]),
+                string(
+                    abi.encodePacked(
+                        "Segment content mismatch at index ", vm.toString(i)
+                    )
+                )
+            );
+        }
+
+        // --- Assertions for fee setup during init ---
+        assertEq(
+            fmBcDiscrete.buyFee(),
+            TEST_PROJECT_BUY_FEE_BPS,
+            "Project buy fee mismatch after init"
+        );
+        assertEq(
+            fmBcDiscrete.sellFee(),
+            TEST_PROJECT_SELL_FEE_BPS,
+            "Project sell fee mismatch after init"
+        );
+
+        IFM_BC_Discrete_Redeeming_VirtualSupply_v1.ProtocolFeeCache memory cache =
+            fmBcDiscrete.exposed_getProtocolFeeCache();
+
+        assertEq(
+            cache.collateralTreasury,
+            TEST_PROTOCOL_TREASURY,
+            "Cached collateral treasury mismatch"
+        );
+        assertEq(
+            cache.issuanceTreasury,
+            TEST_PROTOCOL_TREASURY,
+            "Cached issuance treasury mismatch"
+        ); // FeeManager uses one workflow treasury for both
+
+        assertEq(
+            cache.collateralFeeBuyBps,
+            TEST_PROTOCOL_COLLATERAL_BUY_FEE_BPS,
+            "Cached collateralFeeBuyBps mismatch"
+        );
+        assertEq(
+            cache.issuanceFeeBuyBps,
+            TEST_PROTOCOL_ISSUANCE_BUY_FEE_BPS,
+            "Cached issuanceFeeBuyBps mismatch"
+        );
+        assertEq(
+            cache.collateralFeeSellBps,
+            TEST_PROTOCOL_COLLATERAL_SELL_FEE_BPS,
+            "Cached collateralFeeSellBps mismatch"
+        );
+        assertEq(
+            cache.issuanceFeeSellBps,
+            TEST_PROTOCOL_ISSUANCE_SELL_FEE_BPS,
+            "Cached issuanceFeeSellBps mismatch"
         );
     }
 
@@ -296,9 +551,9 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         lendingFacility.borrow(borrowAmount);
 
         // Test: repay loan
-        collateralToken.mint(user, repayAmount);
+        orchestratorToken.mint(user, repayAmount);
         vm.prank(user);
-        collateralToken.approve(address(lendingFacility), repayAmount);
+        orchestratorToken.approve(address(lendingFacility), repayAmount);
 
         vm.prank(user);
         lendingFacility.repay(repayAmount);
@@ -329,9 +584,9 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         lendingFacility.borrow(borrowAmount);
 
         // Test: try to repay more than outstanding loan
-        collateralToken.mint(user, repayAmount);
+        orchestratorToken.mint(user, repayAmount);
         vm.prank(user);
-        collateralToken.approve(address(lendingFacility), repayAmount);
+        orchestratorToken.approve(address(lendingFacility), repayAmount);
 
         vm.prank(user);
         vm.expectRevert("Repayment amount exceeds outstanding loan");
@@ -532,5 +787,45 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint tokensToUnlock = lendingFacility
             .exposed_calculateIssuanceTokensToUnlock(user, repaymentAmount);
         assertEq(tokensToUnlock, 0); // No outstanding loan initially
+    }
+
+    // =========================================================================
+    // Helper Functions
+
+    function helper_createSegment(
+        uint _initialPrice,
+        uint _priceIncrease,
+        uint _supplyPerStep,
+        uint _numberOfSteps
+    ) internal pure returns (PackedSegment) {
+        return PackedSegmentLib._create(
+            _initialPrice, _priceIncrease, _supplyPerStep, _numberOfSteps
+        );
+    }
+
+    function helper_createSegments( // TODO: move to a library
+        uint[] memory _initialPrices,
+        uint[] memory _priceIncreases,
+        uint[] memory _suppliesPerStep,
+        uint[] memory _numbersOfSteps
+    ) internal pure returns (PackedSegment[] memory) {
+        require(
+            _initialPrices.length == _priceIncreases.length
+                && _initialPrices.length == _suppliesPerStep.length
+                && _initialPrices.length == _numbersOfSteps.length,
+            "Input arrays must have same length"
+        );
+
+        PackedSegment[] memory segments =
+            new PackedSegment[](_initialPrices.length);
+        for (uint i = 0; i < _initialPrices.length; i++) {
+            segments[i] = helper_createSegment(
+                _initialPrices[i],
+                _priceIncreases[i],
+                _suppliesPerStep[i],
+                _numbersOfSteps[i]
+            );
+        }
+        return segments;
     }
 }

--- a/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
@@ -381,255 +381,265 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
     }
 
     // =========================================================================
-    // Test: Issuance Token Management
+    // Test: Repaying
 
-    /* Test external lockIssuanceTokens function
-        ├── Given valid amount
-        │   └── When user locks issuance tokens
-        │       ├── Then their locked amount should increase
-        │       └── Then tokens should be transferred to contract
-        └── Given invalid amount
-            └── When user tries to lock zero tokens
-                └── Then it should revert with InvalidBorrowAmount
+    /* Test: Function repay()
+        ├── Given a user has an outstanding loan
+        └── And the user has sufficient collateral tokens to repay
+            └── When the user repays part of their loan
+                ├── Then their outstanding loan should decrease
+                ├── And the system's currently borrowed amount should decrease
+                ├── And collateral tokens should be transferred back to facility
+                └── And issuance tokens should be unlocked proportionally
     */
-    function testLockIssuanceTokens() public {
+    function testRepay() public {
+        // Given: a user has an outstanding loan
         address user = makeAddr("user");
-        uint lockAmount = 100 ether;
+        uint borrowAmount = 500 ether;
+        uint repayAmount = 200 ether;
 
-        issuanceToken.mint(user, lockAmount);
-        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
-        
+        // Setup: user borrows tokens (which automatically locks issuance tokens)
+        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        // Add a larger buffer to account for rounding precision
+        uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
+        issuanceToken.mint(user, issuanceTokensWithBuffer);
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), lockAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
-
-        vm.prank(user);
-        lendingFacility.lockIssuanceTokens(lockAmount);
-
-        assertEq(lendingFacility.getLockedIssuanceTokens(user), lockAmount);
-    }
-
-    function testLockIssuanceTokens_zeroAmount() public {
-        address user = makeAddr("user");
-
-        vm.prank(user);
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount.selector);
-        lendingFacility.lockIssuanceTokens(0);
-    }
-
-    /* Test external unlockIssuanceTokens function
-        ├── Given user has locked tokens and no outstanding loan
-        │   └── When user unlocks tokens
-        │       ├── Then their locked amount should decrease
-        │       └── Then tokens should be transferred back to user
-        └── Given user has outstanding loan
-            └── When user tries to unlock tokens
-                └── Then it should revert with CannotUnlockWithOutstandingLoan
-    */
-    function testUnlockIssuanceTokens() public {
-        address user = makeAddr("user");
-        uint lockAmount = 100 ether;
-        uint unlockAmount = 50 ether;
-
-        // Setup: lock tokens
-        issuanceToken.mint(user, lockAmount);
-        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
-        
-        vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), lockAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
-        
-        vm.prank(user);
-        lendingFacility.lockIssuanceTokens(lockAmount);
-
-        // Test: unlock tokens
-        vm.prank(user);
-        lendingFacility.unlockIssuanceTokens(unlockAmount);
-
-        assertEq(
-            lendingFacility.getLockedIssuanceTokens(user),
-            lockAmount - unlockAmount
-        );
-    }
-
-    function testUnlockIssuanceTokens_withOutstandingLoan() public {
-        address user = makeAddr("user");
-        uint lockAmount = 100 ether;
-
-        // Setup: lock tokens and borrow
-        issuanceToken.mint(user, lockAmount);
-        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
-        
-        vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), lockAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
-        
-        vm.prank(user);
-        lendingFacility.lockIssuanceTokens(lockAmount);
-
-        // Borrow some tokens (this creates an outstanding loan)
-        uint borrowAmount = 50 ether;
+        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
-        // Try to unlock tokens
+        // Given: the user has sufficient collateral tokens to repay
+        orchestratorToken.mint(user, repayAmount);
         vm.prank(user);
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_CannotUnlockWithOutstandingLoan.selector);
-        lendingFacility.unlockIssuanceTokens(50 ether);
+        orchestratorToken.approve(address(lendingFacility), repayAmount);
+
+        // When: the user repays part of their loan
+        uint outstandingLoanBefore = lendingFacility.getOutstandingLoan(user);
+        uint currentlyBorrowedBefore = lendingFacility.currentlyBorrowedAmount();
+        uint lockedTokensBefore = lendingFacility.getLockedIssuanceTokens(user);
+        uint facilityCollateralBefore = orchestratorToken.balanceOf(address(lendingFacility));
+
+        vm.prank(user);
+        lendingFacility.repay(repayAmount);
+
+        // Then: their outstanding loan should decrease
+        assertEq(
+            lendingFacility.getOutstandingLoan(user), 
+            outstandingLoanBefore - repayAmount,
+            "Outstanding loan should decrease by repayment amount"
+        );
+
+        // And: the system's currently borrowed amount should decrease
+        assertEq(
+            lendingFacility.currentlyBorrowedAmount(),
+            currentlyBorrowedBefore - repayAmount,
+            "System borrowed amount should decrease by repayment amount"
+        );
+
+        // And: collateral tokens should be transferred back to facility
+        uint facilityCollateralAfter = orchestratorToken.balanceOf(address(lendingFacility));
+        assertEq(
+            facilityCollateralAfter,
+            facilityCollateralBefore + repayAmount,
+            "Facility should receive repayment amount"
+        );
+
+        // And: issuance tokens should be unlocked proportionally
+        uint lockedTokensAfter = lendingFacility.getLockedIssuanceTokens(user);
+        assertLt(lockedTokensAfter, lockedTokensBefore, "Some issuance tokens should be unlocked");
+    }
+
+    /* Test: Function repay()
+        ├── Given a user has an outstanding loan
+        └── And the user tries to repay more than the outstanding amount
+            └── When the user attempts to repay
+                └── Then the transaction should revert with RepaymentAmountExceedsLoan error
+    */
+    function testRepay_exceedsOutstandingLoan() public {
+        // Given: a user has an outstanding loan
+        address user = makeAddr("user");
+        uint borrowAmount = 500 ether;
+        uint repayAmount = 600 ether; // More than outstanding loan
+
+        // Setup: user borrows tokens (which automatically locks issuance tokens)
+        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        // Add a larger buffer to account for rounding precision
+        uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
+        issuanceToken.mint(user, issuanceTokensWithBuffer);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        vm.prank(user);
+        lendingFacility.borrow(borrowAmount);
+
+        // Given: the user tries to repay more than the outstanding amount
+        assertGt(repayAmount, lendingFacility.getOutstandingLoan(user), "Repay amount should exceed outstanding loan");
+
+        orchestratorToken.mint(user, repayAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), repayAmount);
+
+        // When: the user attempts to repay
+        vm.prank(user);
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_RepaymentAmountExceedsLoan.selector);
+        lendingFacility.repay(repayAmount);
+
+        // Then: the transaction should revert with RepaymentAmountExceedsLoan error
     }
 
     // =========================================================================
     // Test: Borrowing
 
-    /* Test external borrow function
-        ├── Given valid borrow request
-        │   └── When user borrows collateral tokens
-        │       ├── Then their outstanding loan should increase
-        │       ├── Then dynamic fee should be calculated and deducted
-        │       └── Then net amount should be transferred to user
-        └── Given invalid borrow request
-            └── When user tries to borrow more than limit
-                └── Then it should revert with appropriate error
+    /* Test: Function borrow()
+        ├── Given a user has issuance tokens
+        ├── And the user has sufficient borrowing power
+        └── And the borrow amount is within individual and system limits
+            └── When the user borrows collateral tokens
+                ├── Then their outstanding loan should increase
+                ├── And issuance tokens should be locked automatically
+                ├── And dynamic fee should be calculated and deducted
+                ├── And net amount should be transferred to user
+                └── And the system's currently borrowed amount should increase
     */
     function testBorrow() public {
+        // Given: a user has issuance tokens
         address user = makeAddr("user");
-        uint lockAmount = 1000 ether;
         uint borrowAmount = 500 ether;
 
-        // Setup: lock issuance tokens
-        issuanceToken.mint(user, lockAmount);
-        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        // Calculate how much issuance tokens will be needed
+        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        // Add a larger buffer to account for rounding precision
+        uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
+        issuanceToken.mint(user, issuanceTokensWithBuffer);
         
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), lockAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
-        
-        vm.prank(user);
-        lendingFacility.lockIssuanceTokens(lockAmount);
+        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
 
-        // Test: borrow collateral tokens
+        // Given: the user has sufficient borrowing power
+        uint userBorrowingPower = issuanceTokensWithBuffer * lendingFacility.exposed_getFloorPrice() / 1e18;
+        assertGe(userBorrowingPower, borrowAmount, "User should have sufficient borrowing power");
+
+        // Given: the borrow amount is within individual and system limits
+        assertLe(borrowAmount, lendingFacility.individualBorrowLimit(), "Borrow amount should be within individual limit");
+        
+        uint borrowCapacity = lendingFacility.getBorrowCapacity();
+        uint borrowableQuota = borrowCapacity * lendingFacility.borrowableQuota() / 10_000;
+        assertLe(borrowAmount, borrowableQuota, "Borrow amount should be within system quota");
+
+        // When: the user borrows collateral tokens
+        uint userBalanceBefore = orchestratorToken.balanceOf(user);
+        uint outstandingLoanBefore = lendingFacility.getOutstandingLoan(user);
+        uint currentlyBorrowedBefore = lendingFacility.currentlyBorrowedAmount();
+        uint lockedTokensBefore = lendingFacility.getLockedIssuanceTokens(user);
+        
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
-        assertEq(lendingFacility.getOutstandingLoan(user), borrowAmount);
-        assertEq(lendingFacility.currentlyBorrowedAmount(), borrowAmount);
+        // Then: their outstanding loan should increase
+        assertEq(
+            lendingFacility.getOutstandingLoan(user), 
+            outstandingLoanBefore + borrowAmount,
+            "Outstanding loan should increase by borrow amount"
+        );
+
+        // And: issuance tokens should be locked automatically
+        assertEq(
+            lendingFacility.getLockedIssuanceTokens(user),
+            lockedTokensBefore + requiredIssuanceTokens,
+            "Issuance tokens should be locked automatically"
+        );
+
+        // And: the system's currently borrowed amount should increase
+        assertEq(
+            lendingFacility.currentlyBorrowedAmount(), 
+            currentlyBorrowedBefore + borrowAmount,
+            "System borrowed amount should increase by borrow amount"
+        );
+
+        // And: net amount should be transferred to user (after fees)
+        uint userBalanceAfter = orchestratorToken.balanceOf(user);
+        uint actualReceived = userBalanceAfter - userBalanceBefore;
+        assertGt(actualReceived, 0, "User should receive collateral tokens");
+        assertLe(actualReceived, borrowAmount, "User should receive amount less than or equal to requested");
     }
 
-    function testBorrow_exceedsIndividualLimit() public {
+    /* Test: Function borrow()
+        ├── Given a user has insufficient issuance tokens
+        └── When the user tries to borrow collateral tokens
+            └── Then the transaction should revert with InsufficientBorrowingPower error
+    */
+    function testBorrow_insufficientIssuanceTokens() public {
+        // Given: a user has insufficient issuance tokens
         address user = makeAddr("user");
-        uint lockAmount = 3000 ether; // Lock more tokens to have sufficient borrowing power
-        uint borrowAmount = 600 ether; // More than individual limit (500 ether) but within borrowable quota (800 ether)
+        uint borrowAmount = 500 ether;
+        uint insufficientTokens = 100 ether; // Less than required
 
-        // Setup: lock issuance tokens
-        issuanceToken.mint(user, lockAmount);
-        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        issuanceToken.mint(user, insufficientTokens);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), insufficientTokens);
+
+        // When: the user tries to borrow collateral tokens
+        vm.prank(user);
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientBorrowingPower.selector);
+        lendingFacility.borrow(borrowAmount);
+
+        // Then: the transaction should revert with InsufficientBorrowingPower error
+    }
+
+    /* Test: Function borrow()
+        ├── Given a user has issuance tokens
+        ├── And the user has sufficient borrowing power
+        └── And the borrow amount exceeds individual limit
+            └── When the user tries to borrow collateral tokens
+                └── Then the transaction should revert with IndividualBorrowLimitExceeded error
+    */
+    function testBorrow_exceedsIndividualLimit() public {
+        // Given: a user has issuance tokens
+        address user = makeAddr("user");
+        uint borrowAmount = 600 ether; // More than individual limit (500 ether)
+
+        // Calculate how much issuance tokens will be needed
+        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        // Add a larger buffer to account for rounding precision
+        uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
+        issuanceToken.mint(user, issuanceTokensWithBuffer);
         
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), lockAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
-        
-        vm.prank(user);
-        lendingFacility.lockIssuanceTokens(lockAmount);
+        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
 
-        // Test: try to borrow more than individual limit
+        // Given: the user has sufficient borrowing power
+        uint userBorrowingPower = issuanceTokensWithBuffer * lendingFacility.exposed_getFloorPrice() / 1e18;
+        assertGe(userBorrowingPower, borrowAmount, "User should have sufficient borrowing power");
+
+        // Given: the borrow amount exceeds individual limit
+        assertGt(borrowAmount, lendingFacility.individualBorrowLimit(), "Borrow amount should exceed individual limit");
+
+        // When: the user tries to borrow collateral tokens
         vm.prank(user);
         vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_IndividualBorrowLimitExceeded.selector);
         lendingFacility.borrow(borrowAmount);
+
+        // Then: the transaction should revert with IndividualBorrowLimitExceeded error
     }
 
+    /* Test: Function borrow()
+        ├── Given a user wants to borrow tokens
+        └── And the borrow amount is zero
+            └── When the user tries to borrow collateral tokens
+                └── Then the transaction should revert with InvalidBorrowAmount error
+    */
     function testBorrow_zeroAmount() public {
+        // Given: a user wants to borrow tokens
         address user = makeAddr("user");
 
+        // Given: the borrow amount is zero
+        uint borrowAmount = 0;
+
+        // When: the user tries to borrow collateral tokens
         vm.prank(user);
         vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount.selector);
-        lendingFacility.borrow(0);
-    }
-
-    // =========================================================================
-    // Test: Repaying
-
-    /* Test external repay function
-        ├── Given user has outstanding loan
-        │   └── When user repays loan
-        │       ├── Then their outstanding loan should decrease
-        │       ├── Then collateral should be transferred back to facility
-        │       └── Then issuance tokens should be unlocked proportionally
-        └── Given user has no outstanding loan
-            └── When user tries to repay
-                └── Then it should revert with appropriate error
-    */
-    function testRepay() public {
-        address user = makeAddr("user");
-        uint lockAmount = 1000 ether;
-        uint borrowAmount = 500 ether;
-        uint repayAmount = 200 ether;
-
-        // Setup: lock tokens and borrow
-        issuanceToken.mint(user, lockAmount);
-        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
-        
-        vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), lockAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
-        
-        vm.prank(user);
-        lendingFacility.lockIssuanceTokens(lockAmount);
-
-        vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
-        // Test: repay loan
-        orchestratorToken.mint(user, repayAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), repayAmount);
-
-        vm.prank(user);
-        lendingFacility.repay(repayAmount);
-
-        assertEq(
-            lendingFacility.getOutstandingLoan(user), borrowAmount - repayAmount
-        );
-        assertEq(
-            lendingFacility.currentlyBorrowedAmount(),
-            borrowAmount - repayAmount
-        );
-    }
-
-    function testRepay_exceedsOutstandingLoan() public {
-        address user = makeAddr("user");
-        uint lockAmount = 1000 ether;
-        uint borrowAmount = 500 ether;
-        uint repayAmount = 600 ether;
-
-        // Setup: lock tokens and borrow
-        issuanceToken.mint(user, lockAmount);
-        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
-        
-        vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), lockAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
-        
-        vm.prank(user);
-        lendingFacility.lockIssuanceTokens(lockAmount);
-
-        vm.prank(user);
-        lendingFacility.borrow(borrowAmount);
-
-        // Test: try to repay more than outstanding loan
-        orchestratorToken.mint(user, repayAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), repayAmount);
-
-        vm.prank(user);
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_RepaymentAmountExceedsLoan.selector);
-        lendingFacility.repay(repayAmount);
+        // Then: the transaction should revert with InvalidBorrowAmount error
     }
 
     // =========================================================================
@@ -767,18 +777,18 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint power = lendingFacility.getUserBorrowingPower(user);
         assertEq(power, 0); // Initially no locked tokens
 
-        // Lock some tokens and check power
-        uint lockAmount = 1000 ether;
-        issuanceToken.mint(user, lockAmount);
-        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        // Borrow some tokens (which automatically locks issuance tokens)
+        uint borrowAmount = 500 ether;
+        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        // Add a larger buffer to account for rounding precision
+        uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
+        issuanceToken.mint(user, issuanceTokensWithBuffer);
         
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), lockAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
         
         vm.prank(user);
-        lendingFacility.lockIssuanceTokens(lockAmount);
+        lendingFacility.borrow(borrowAmount);
 
         power = lendingFacility.getUserBorrowingPower(user);
         assertGt(power, 0);
@@ -806,18 +816,18 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint power = lendingFacility.exposed_calculateUserBorrowingPower(user);
         assertEq(power, 0); // No locked tokens initially
 
-        // Lock tokens and check power
-        uint lockAmount = 1000 ether;
-        issuanceToken.mint(user, lockAmount);
-        orchestratorToken.mint(user, lockAmount); // Mint collateral tokens for the user
+        // Borrow some tokens (which automatically locks issuance tokens)
+        uint borrowAmount = 500 ether;
+        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        // Add a larger buffer to account for rounding precision
+        uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
+        issuanceToken.mint(user, issuanceTokensWithBuffer);
         
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), lockAmount);
-        vm.prank(user);
-        orchestratorToken.approve(address(lendingFacility), lockAmount); // Approve collateral tokens
+        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
         
         vm.prank(user);
-        lendingFacility.lockIssuanceTokens(lockAmount);
+        lendingFacility.borrow(borrowAmount);
 
         power = lendingFacility.exposed_calculateUserBorrowingPower(user);
         assertGt(power, 0);
@@ -836,6 +846,139 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint tokensToUnlock = lendingFacility
             .exposed_calculateIssuanceTokensToUnlock(user, repaymentAmount);
         assertEq(tokensToUnlock, 0); // No outstanding loan initially
+    }
+
+    // =========================================================================
+    // Test: Unlocking Issuance Tokens
+
+    /* Test: Function unlockIssuanceTokens()
+        ├── Given a user has locked issuance tokens
+        ├── And the user has no outstanding loan
+        └── When the user unlocks issuance tokens
+            ├── Then their locked issuance tokens should decrease
+            ├── And issuance tokens should be transferred back to user
+            └── And an event should be emitted
+    */
+    function testUnlockIssuanceTokens() public {
+        // Given: a user has locked issuance tokens
+        address user = makeAddr("user");
+        uint borrowAmount = 500 ether;
+        uint unlockAmount = 200 ether;
+
+        // Setup: user borrows tokens (which automatically locks issuance tokens)
+        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        // Add a larger buffer to account for rounding precision
+        uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
+        issuanceToken.mint(user, issuanceTokensWithBuffer);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        vm.prank(user);
+        lendingFacility.borrow(borrowAmount);
+
+        // Given: the user has no outstanding loan (repay the full amount)
+        orchestratorToken.mint(user, borrowAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), borrowAmount);
+        vm.prank(user);
+        lendingFacility.repay(borrowAmount);
+
+        // Verify user has no outstanding loan
+        assertEq(lendingFacility.getOutstandingLoan(user), 0, "User should have no outstanding loan");
+
+        // When: the user unlocks issuance tokens
+        uint lockedTokensBefore = lendingFacility.getLockedIssuanceTokens(user);
+        uint userBalanceBefore = issuanceToken.balanceOf(user);
+
+        vm.prank(user);
+        lendingFacility.unlockIssuanceTokens(unlockAmount);
+
+        // Then: their locked issuance tokens should decrease
+        assertEq(
+            lendingFacility.getLockedIssuanceTokens(user),
+            lockedTokensBefore - unlockAmount,
+            "Locked issuance tokens should decrease"
+        );
+
+        // And: issuance tokens should be transferred back to user
+        assertEq(
+            issuanceToken.balanceOf(user),
+            userBalanceBefore + unlockAmount,
+            "User should receive unlocked issuance tokens"
+        );
+    }
+
+    /* Test: Function unlockIssuanceTokens()
+        ├── Given a user has locked issuance tokens
+        ├── And the user has an outstanding loan
+        └── When the user tries to unlock issuance tokens
+            └── Then the transaction should revert with CannotUnlockWithOutstandingLoan error
+    */
+    function testUnlockIssuanceTokens_withOutstandingLoan() public {
+        // Given: a user has locked issuance tokens
+        address user = makeAddr("user");
+        uint borrowAmount = 500 ether;
+        uint unlockAmount = 200 ether;
+
+        // Setup: user borrows tokens (which automatically locks issuance tokens)
+        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        // Add a larger buffer to account for rounding precision
+        uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
+        issuanceToken.mint(user, issuanceTokensWithBuffer);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        vm.prank(user);
+        lendingFacility.borrow(borrowAmount);
+
+        // Given: the user has an outstanding loan (don't repay)
+        assertGt(lendingFacility.getOutstandingLoan(user), 0, "User should have outstanding loan");
+
+        // When: the user tries to unlock issuance tokens
+        vm.prank(user);
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_CannotUnlockWithOutstandingLoan.selector);
+        lendingFacility.unlockIssuanceTokens(unlockAmount);
+
+        // Then: the transaction should revert with CannotUnlockWithOutstandingLoan error
+    }
+
+    /* Test: Function unlockIssuanceTokens()
+        ├── Given a user has locked issuance tokens
+        └── And the user tries to unlock more than locked amount
+            └── When the user tries to unlock issuance tokens
+                └── Then the transaction should revert with InsufficientLockedTokens error
+    */
+    function testUnlockIssuanceTokens_insufficientLockedTokens() public {
+        // Given: a user has locked issuance tokens
+        address user = makeAddr("user");
+        uint borrowAmount = 500 ether;
+        uint unlockAmount = 1000 ether; // More than locked amount
+
+        // Setup: user borrows tokens (which automatically locks issuance tokens)
+        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        // Add a larger buffer to account for rounding precision
+        uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
+        issuanceToken.mint(user, issuanceTokensWithBuffer);
+        vm.prank(user);
+        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        vm.prank(user);
+        lendingFacility.borrow(borrowAmount);
+
+        // Given: the user has no outstanding loan (repay the full amount)
+        orchestratorToken.mint(user, borrowAmount);
+        vm.prank(user);
+        orchestratorToken.approve(address(lendingFacility), borrowAmount);
+        vm.prank(user);
+        lendingFacility.repay(borrowAmount);
+
+        // Given: the user tries to unlock more than locked amount
+        uint lockedTokens = lendingFacility.getLockedIssuanceTokens(user);
+        assertLt(lockedTokens, unlockAmount, "Unlock amount should exceed locked tokens");
+
+        // When: the user tries to unlock issuance tokens
+        vm.prank(user);
+        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientLockedTokens.selector);
+        lendingFacility.unlockIssuanceTokens(unlockAmount);
+
+        // Then: the transaction should revert with InsufficientLockedTokens error
     }
 
     // =========================================================================

--- a/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
@@ -396,12 +396,15 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint repayAmount = 200 ether;
 
         // Setup: user borrows tokens (which automatically locks issuance tokens)
-        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        uint requiredIssuanceTokens = lendingFacility
+            .exposed_calculateRequiredIssuanceTokens(borrowAmount);
         // Add a larger buffer to account for rounding precision
         uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
         issuanceToken.mint(user, issuanceTokensWithBuffer);
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        issuanceToken.approve(
+            address(lendingFacility), issuanceTokensWithBuffer
+        );
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
@@ -414,14 +417,15 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint outstandingLoanBefore = lendingFacility.getOutstandingLoan(user);
         uint currentlyBorrowedBefore = lendingFacility.currentlyBorrowedAmount();
         uint lockedTokensBefore = lendingFacility.getLockedIssuanceTokens(user);
-        uint facilityCollateralBefore = orchestratorToken.balanceOf(address(lendingFacility));
+        uint facilityCollateralBefore =
+            orchestratorToken.balanceOf(address(lendingFacility));
 
         vm.prank(user);
         lendingFacility.repay(repayAmount);
 
         // Then: their outstanding loan should decrease
         assertEq(
-            lendingFacility.getOutstandingLoan(user), 
+            lendingFacility.getOutstandingLoan(user),
             outstandingLoanBefore - repayAmount,
             "Outstanding loan should decrease by repayment amount"
         );
@@ -434,7 +438,8 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         );
 
         // And: collateral tokens should be transferred back to facility
-        uint facilityCollateralAfter = orchestratorToken.balanceOf(address(lendingFacility));
+        uint facilityCollateralAfter =
+            orchestratorToken.balanceOf(address(lendingFacility));
         assertEq(
             facilityCollateralAfter,
             facilityCollateralBefore + repayAmount,
@@ -443,7 +448,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // And: issuance tokens should be unlocked proportionally
         uint lockedTokensAfter = lendingFacility.getLockedIssuanceTokens(user);
-        assertLt(lockedTokensAfter, lockedTokensBefore, "Some issuance tokens should be unlocked");
+        assertLt(
+            lockedTokensAfter,
+            lockedTokensBefore,
+            "Some issuance tokens should be unlocked"
+        );
     }
 
     /* Test: Function repay()
@@ -459,17 +468,24 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint repayAmount = 600 ether; // More than outstanding loan
 
         // Setup: user borrows tokens (which automatically locks issuance tokens)
-        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        uint requiredIssuanceTokens = lendingFacility
+            .exposed_calculateRequiredIssuanceTokens(borrowAmount);
         // Add a larger buffer to account for rounding precision
         uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
         issuanceToken.mint(user, issuanceTokensWithBuffer);
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        issuanceToken.approve(
+            address(lendingFacility), issuanceTokensWithBuffer
+        );
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
         // Given: the user tries to repay more than the outstanding amount
-        assertGt(repayAmount, lendingFacility.getOutstandingLoan(user), "Repay amount should exceed outstanding loan");
+        assertGt(
+            repayAmount,
+            lendingFacility.getOutstandingLoan(user),
+            "Repay amount should exceed outstanding loan"
+        );
 
         orchestratorToken.mint(user, repayAmount);
         vm.prank(user);
@@ -477,7 +493,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // When: the user attempts to repay
         vm.prank(user);
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_RepaymentAmountExceedsLoan.selector);
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_RepaymentAmountExceedsLoan
+                .selector
+        );
         lendingFacility.repay(repayAmount);
 
         // Then: the transaction should revert with RepaymentAmountExceedsLoan error
@@ -503,37 +523,54 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint borrowAmount = 500 ether;
 
         // Calculate how much issuance tokens will be needed
-        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        uint requiredIssuanceTokens = lendingFacility
+            .exposed_calculateRequiredIssuanceTokens(borrowAmount);
         // Add a larger buffer to account for rounding precision
         uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
         issuanceToken.mint(user, issuanceTokensWithBuffer);
-        
+
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        issuanceToken.approve(
+            address(lendingFacility), issuanceTokensWithBuffer
+        );
 
         // Given: the user has sufficient borrowing power
-        uint userBorrowingPower = issuanceTokensWithBuffer * lendingFacility.exposed_getFloorPrice() / 1e18;
-        assertGe(userBorrowingPower, borrowAmount, "User should have sufficient borrowing power");
+        uint userBorrowingPower = issuanceTokensWithBuffer
+            * lendingFacility.exposed_getFloorPrice() / 1e18;
+        assertGe(
+            userBorrowingPower,
+            borrowAmount,
+            "User should have sufficient borrowing power"
+        );
 
         // Given: the borrow amount is within individual and system limits
-        assertLe(borrowAmount, lendingFacility.individualBorrowLimit(), "Borrow amount should be within individual limit");
-        
+        assertLe(
+            borrowAmount,
+            lendingFacility.individualBorrowLimit(),
+            "Borrow amount should be within individual limit"
+        );
+
         uint borrowCapacity = lendingFacility.getBorrowCapacity();
-        uint borrowableQuota = borrowCapacity * lendingFacility.borrowableQuota() / 10_000;
-        assertLe(borrowAmount, borrowableQuota, "Borrow amount should be within system quota");
+        uint borrowableQuota =
+            borrowCapacity * lendingFacility.borrowableQuota() / 10_000;
+        assertLe(
+            borrowAmount,
+            borrowableQuota,
+            "Borrow amount should be within system quota"
+        );
 
         // When: the user borrows collateral tokens
         uint userBalanceBefore = orchestratorToken.balanceOf(user);
         uint outstandingLoanBefore = lendingFacility.getOutstandingLoan(user);
         uint currentlyBorrowedBefore = lendingFacility.currentlyBorrowedAmount();
         uint lockedTokensBefore = lendingFacility.getLockedIssuanceTokens(user);
-        
+
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
         // Then: their outstanding loan should increase
         assertEq(
-            lendingFacility.getOutstandingLoan(user), 
+            lendingFacility.getOutstandingLoan(user),
             outstandingLoanBefore + borrowAmount,
             "Outstanding loan should increase by borrow amount"
         );
@@ -547,7 +584,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // And: the system's currently borrowed amount should increase
         assertEq(
-            lendingFacility.currentlyBorrowedAmount(), 
+            lendingFacility.currentlyBorrowedAmount(),
             currentlyBorrowedBefore + borrowAmount,
             "System borrowed amount should increase by borrow amount"
         );
@@ -556,7 +593,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint userBalanceAfter = orchestratorToken.balanceOf(user);
         uint actualReceived = userBalanceAfter - userBalanceBefore;
         assertGt(actualReceived, 0, "User should receive collateral tokens");
-        assertLe(actualReceived, borrowAmount, "User should receive amount less than or equal to requested");
+        assertLe(
+            actualReceived,
+            borrowAmount,
+            "User should receive amount less than or equal to requested"
+        );
     }
 
     /* Test: Function borrow()
@@ -576,7 +617,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // When: the user tries to borrow collateral tokens
         vm.prank(user);
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientBorrowingPower.selector);
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InsufficientBorrowingPower
+                .selector
+        );
         lendingFacility.borrow(borrowAmount);
 
         // Then: the transaction should revert with InsufficientBorrowingPower error
@@ -595,24 +640,40 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint borrowAmount = 600 ether; // More than individual limit (500 ether)
 
         // Calculate how much issuance tokens will be needed
-        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        uint requiredIssuanceTokens = lendingFacility
+            .exposed_calculateRequiredIssuanceTokens(borrowAmount);
         // Add a larger buffer to account for rounding precision
         uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
         issuanceToken.mint(user, issuanceTokensWithBuffer);
-        
+
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        issuanceToken.approve(
+            address(lendingFacility), issuanceTokensWithBuffer
+        );
 
         // Given: the user has sufficient borrowing power
-        uint userBorrowingPower = issuanceTokensWithBuffer * lendingFacility.exposed_getFloorPrice() / 1e18;
-        assertGe(userBorrowingPower, borrowAmount, "User should have sufficient borrowing power");
+        uint userBorrowingPower = issuanceTokensWithBuffer
+            * lendingFacility.exposed_getFloorPrice() / 1e18;
+        assertGe(
+            userBorrowingPower,
+            borrowAmount,
+            "User should have sufficient borrowing power"
+        );
 
         // Given: the borrow amount exceeds individual limit
-        assertGt(borrowAmount, lendingFacility.individualBorrowLimit(), "Borrow amount should exceed individual limit");
+        assertGt(
+            borrowAmount,
+            lendingFacility.individualBorrowLimit(),
+            "Borrow amount should exceed individual limit"
+        );
 
         // When: the user tries to borrow collateral tokens
         vm.prank(user);
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_IndividualBorrowLimitExceeded.selector);
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_IndividualBorrowLimitExceeded
+                .selector
+        );
         lendingFacility.borrow(borrowAmount);
 
         // Then: the transaction should revert with IndividualBorrowLimitExceeded error
@@ -633,7 +694,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // When: the user tries to borrow collateral tokens
         vm.prank(user);
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount.selector);
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InvalidBorrowAmount
+                .selector
+        );
         lendingFacility.borrow(borrowAmount);
 
         // Then: the transaction should revert with InvalidBorrowAmount error
@@ -712,7 +777,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         _authorizer.grantRole(roleId, address(this));
 
         uint invalidQuota = 10_001; // Exceeds 100%
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_BorrowableQuotaTooHigh.selector);
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_BorrowableQuotaTooHigh
+                .selector
+        );
         lendingFacility.setBorrowableQuota(invalidQuota);
     }
 
@@ -747,7 +816,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         );
         _authorizer.grantRole(roleId, address(this));
 
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidFeeCalculatorAddress.selector);
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InvalidFeeCalculatorAddress
+                .selector
+        );
         lendingFacility.setDynamicFeeCalculator(address(0));
     }
 
@@ -774,36 +847,26 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
                 unauthorizedUser
             )
         );
-        (
-            uint Z_issueRedeem,
-            uint A_issueRedeem,
-            uint m_issueRedeem,
-            uint Z_origination,
-            uint A_origination,
-            uint m_origination
-        ) = helper_getDynamicFeeCalculatorParams();
-        lendingFacility.setDynamicFeeCalculatorParams(Z_issueRedeem, A_issueRedeem, m_issueRedeem, Z_origination, A_origination, m_origination);
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =
+            helper_getDynamicFeeCalculatorParams();
+        lendingFacility.setDynamicFeeCalculatorParams(feeParams);
         vm.stopPrank();
     }
 
     function test_setDynamicFeeCalculatorParams() public {
-        helper_setDynamicFeeCalculatorParams();
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =
+            helper_getDynamicFeeCalculatorParams();
+        lendingFacility.setDynamicFeeCalculatorParams(feeParams);
 
-        (
-            uint Z_issueRedeem,
-            uint A_issueRedeem,
-            uint m_issueRedeem,
-            uint Z_origination,
-            uint A_origination,
-            uint m_origination
-        ) = helper_getDynamicFeeCalculatorParams();
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory LF_feeParams =
+            lendingFacility.getDynamicFeeParameters();
 
-        assertEq(lendingFacility.Z_issueRedeem(), Z_issueRedeem);
-        assertEq(lendingFacility.A_issueRedeem(), A_issueRedeem);
-        assertEq(lendingFacility.m_issueRedeem(), m_issueRedeem);
-        assertEq(lendingFacility.Z_origination(), Z_origination);
-        assertEq(lendingFacility.A_origination(), A_origination);
-        assertEq(lendingFacility.m_origination(), m_origination);
+        assertEq(LF_feeParams.Z_issueRedeem, feeParams.Z_issueRedeem);
+        assertEq(LF_feeParams.A_issueRedeem, feeParams.A_issueRedeem);
+        assertEq(LF_feeParams.m_issueRedeem, feeParams.m_issueRedeem);
+        assertEq(LF_feeParams.Z_origination, feeParams.Z_origination);
+        assertEq(LF_feeParams.A_origination, feeParams.A_origination);
+        assertEq(LF_feeParams.m_origination, feeParams.m_origination);
     }
 
     // Test: Dynamic Fee Calculator Library
@@ -815,31 +878,35 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
             └── Then the fee should be Z_origination + (floorLiquidityRate - A_origination) * m_origination / Sc
     */
     function test_calculateOriginationFee_BelowThreshold() public {
-        helper_setDynamicFeeCalculatorParams();
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =
+            helper_setDynamicFeeCalculatorParams();
 
         uint floorLiquidityRate = 1e16; // 1%
         uint fee = DynamicFeeCalculatorLib_v1.calculateOriginationFee(
             floorLiquidityRate,
-            lendingFacility.Z_origination(),
-            lendingFacility.A_origination(),
-            lendingFacility.m_origination()
+            feeParams.Z_origination,
+            feeParams.A_origination,
+            feeParams.m_origination
         );
-        assertEq(fee, lendingFacility.Z_origination());
+        assertEq(fee, feeParams.Z_origination);
     }
 
     function test_calculateOriginationFee_AboveThreshold() public {
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =
+            helper_setDynamicFeeCalculatorParams();
+
         uint floorLiquidityRate = 9e16; // 9%
         uint fee = DynamicFeeCalculatorLib_v1.calculateOriginationFee(
             floorLiquidityRate,
-            lendingFacility.Z_origination(),
-            lendingFacility.A_origination(),
-            lendingFacility.m_origination()
+            feeParams.Z_origination,
+            feeParams.A_origination,
+            feeParams.m_origination
         );
         assertEq(
             fee,
-            lendingFacility.Z_origination()
-                + (floorLiquidityRate - lendingFacility.A_origination())
-                    * lendingFacility.m_origination() / 1e18
+            feeParams.Z_origination
+                + (floorLiquidityRate - feeParams.A_origination)
+                    * feeParams.m_origination / 1e18
         );
     }
 
@@ -850,33 +917,35 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
             └── Then the fee should be Z_issueRedeem + (premiumRate - A_issueRedeem) * m_issueRedeem / SCALING_FACTOR
     */
     function test_calculateIssuanceFee_BelowThreshold() public {
-        helper_setDynamicFeeCalculatorParams();
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =
+            helper_setDynamicFeeCalculatorParams();
 
         uint premiumRate = 1e16; // 1%
         uint fee = DynamicFeeCalculatorLib_v1.calculateIssuanceFee(
             premiumRate,
-            lendingFacility.Z_issueRedeem(),
-            lendingFacility.A_issueRedeem(),
-            lendingFacility.m_issueRedeem()
+            feeParams.Z_issueRedeem,
+            feeParams.A_issueRedeem,
+            feeParams.m_issueRedeem
         );
-        assertEq(fee, lendingFacility.Z_issueRedeem());
+        assertEq(fee, feeParams.Z_issueRedeem);
     }
 
     function test_calculateIssuanceFee_AboveThreshold() public {
-        helper_setDynamicFeeCalculatorParams();
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =
+            helper_setDynamicFeeCalculatorParams();
 
         uint premiumRate = 9e16; // 9%
         uint fee = DynamicFeeCalculatorLib_v1.calculateIssuanceFee(
             premiumRate,
-            lendingFacility.Z_issueRedeem(),
-            lendingFacility.A_issueRedeem(),
-            lendingFacility.m_issueRedeem()
+            feeParams.Z_issueRedeem,
+            feeParams.A_issueRedeem,
+            feeParams.m_issueRedeem
         );
         assertEq(
             fee,
-            lendingFacility.Z_issueRedeem()
-                + (premiumRate - lendingFacility.A_issueRedeem())
-                    * lendingFacility.m_issueRedeem() / 1e18
+            feeParams.Z_issueRedeem
+                + (premiumRate - feeParams.A_issueRedeem) * feeParams.m_issueRedeem
+                    / 1e18
         );
     }
 
@@ -887,34 +956,36 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
             └── Then the fee should be Z_issueRedeem + (A_issueRedeem - premiumRate) * m_issueRedeem / SCALING_FACTOR
     */
     function test_calculateRedemptionFee_BelowThreshold() public {
-        helper_setDynamicFeeCalculatorParams();
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =
+            helper_setDynamicFeeCalculatorParams();
 
         uint premiumRate = 1e16; // 1%
         uint fee = DynamicFeeCalculatorLib_v1.calculateRedemptionFee(
             premiumRate,
-            lendingFacility.Z_issueRedeem(),
-            lendingFacility.A_issueRedeem(),
-            lendingFacility.m_issueRedeem()
+            feeParams.Z_issueRedeem,
+            feeParams.A_issueRedeem,
+            feeParams.m_issueRedeem
         );
         assertEq(
             fee,
-            lendingFacility.Z_issueRedeem()
-                + (lendingFacility.A_issueRedeem() - premiumRate)
-                    * lendingFacility.m_issueRedeem() / 1e18
+            feeParams.Z_issueRedeem
+                + (feeParams.A_issueRedeem - premiumRate) * feeParams.m_issueRedeem
+                    / 1e18
         );
     }
 
     function test_calculateRedemptionFee_AboveThreshold() public {
-        helper_setDynamicFeeCalculatorParams();
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =
+            helper_setDynamicFeeCalculatorParams();
 
         uint premiumRate = 9e16; // 9%
         uint fee = DynamicFeeCalculatorLib_v1.calculateRedemptionFee(
             premiumRate,
-            lendingFacility.Z_issueRedeem(),
-            lendingFacility.A_issueRedeem(),
-            lendingFacility.m_issueRedeem()
+            feeParams.Z_issueRedeem,
+            feeParams.A_issueRedeem,
+            feeParams.m_issueRedeem
         );
-        assertEq(fee, lendingFacility.Z_issueRedeem());
+        assertEq(fee, feeParams.Z_issueRedeem);
     }
 
     // =========================================================================
@@ -942,14 +1013,17 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Borrow some tokens (which automatically locks issuance tokens)
         uint borrowAmount = 500 ether;
-        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        uint requiredIssuanceTokens = lendingFacility
+            .exposed_calculateRequiredIssuanceTokens(borrowAmount);
         // Add a larger buffer to account for rounding precision
         uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
         issuanceToken.mint(user, issuanceTokensWithBuffer);
-        
+
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
-        
+        issuanceToken.approve(
+            address(lendingFacility), issuanceTokensWithBuffer
+        );
+
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
@@ -965,7 +1039,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         lendingFacility.exposed_ensureValidBorrowAmount(100 ether);
 
         // Should revert for zero amount
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InvalidBorrowAmount.selector);
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InvalidBorrowAmount
+                .selector
+        );
         lendingFacility.exposed_ensureValidBorrowAmount(0);
     }
 
@@ -981,14 +1059,17 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Borrow some tokens (which automatically locks issuance tokens)
         uint borrowAmount = 500 ether;
-        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        uint requiredIssuanceTokens = lendingFacility
+            .exposed_calculateRequiredIssuanceTokens(borrowAmount);
         // Add a larger buffer to account for rounding precision
         uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
         issuanceToken.mint(user, issuanceTokensWithBuffer);
-        
+
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
-        
+        issuanceToken.approve(
+            address(lendingFacility), issuanceTokensWithBuffer
+        );
+
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
@@ -1029,12 +1110,15 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint unlockAmount = 200 ether;
 
         // Setup: user borrows tokens (which automatically locks issuance tokens)
-        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        uint requiredIssuanceTokens = lendingFacility
+            .exposed_calculateRequiredIssuanceTokens(borrowAmount);
         // Add a larger buffer to account for rounding precision
         uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
         issuanceToken.mint(user, issuanceTokensWithBuffer);
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        issuanceToken.approve(
+            address(lendingFacility), issuanceTokensWithBuffer
+        );
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
@@ -1046,7 +1130,11 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         lendingFacility.repay(borrowAmount);
 
         // Verify user has no outstanding loan
-        assertEq(lendingFacility.getOutstandingLoan(user), 0, "User should have no outstanding loan");
+        assertEq(
+            lendingFacility.getOutstandingLoan(user),
+            0,
+            "User should have no outstanding loan"
+        );
 
         // When: the user unlocks issuance tokens
         uint lockedTokensBefore = lendingFacility.getLockedIssuanceTokens(user);
@@ -1083,21 +1171,32 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint unlockAmount = 200 ether;
 
         // Setup: user borrows tokens (which automatically locks issuance tokens)
-        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        uint requiredIssuanceTokens = lendingFacility
+            .exposed_calculateRequiredIssuanceTokens(borrowAmount);
         // Add a larger buffer to account for rounding precision
         uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
         issuanceToken.mint(user, issuanceTokensWithBuffer);
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        issuanceToken.approve(
+            address(lendingFacility), issuanceTokensWithBuffer
+        );
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
         // Given: the user has an outstanding loan (don't repay)
-        assertGt(lendingFacility.getOutstandingLoan(user), 0, "User should have outstanding loan");
+        assertGt(
+            lendingFacility.getOutstandingLoan(user),
+            0,
+            "User should have outstanding loan"
+        );
 
         // When: the user tries to unlock issuance tokens
         vm.prank(user);
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_CannotUnlockWithOutstandingLoan.selector);
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_CannotUnlockWithOutstandingLoan
+                .selector
+        );
         lendingFacility.unlockIssuanceTokens(unlockAmount);
 
         // Then: the transaction should revert with CannotUnlockWithOutstandingLoan error
@@ -1116,12 +1215,15 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         uint unlockAmount = 1000 ether; // More than locked amount
 
         // Setup: user borrows tokens (which automatically locks issuance tokens)
-        uint requiredIssuanceTokens = lendingFacility.exposed_calculateRequiredIssuanceTokens(borrowAmount);
+        uint requiredIssuanceTokens = lendingFacility
+            .exposed_calculateRequiredIssuanceTokens(borrowAmount);
         // Add a larger buffer to account for rounding precision
         uint issuanceTokensWithBuffer = requiredIssuanceTokens + 10 ether;
         issuanceToken.mint(user, issuanceTokensWithBuffer);
         vm.prank(user);
-        issuanceToken.approve(address(lendingFacility), issuanceTokensWithBuffer);
+        issuanceToken.approve(
+            address(lendingFacility), issuanceTokensWithBuffer
+        );
         vm.prank(user);
         lendingFacility.borrow(borrowAmount);
 
@@ -1134,11 +1236,19 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         // Given: the user tries to unlock more than locked amount
         uint lockedTokens = lendingFacility.getLockedIssuanceTokens(user);
-        assertLt(lockedTokens, unlockAmount, "Unlock amount should exceed locked tokens");
+        assertLt(
+            lockedTokens,
+            unlockAmount,
+            "Unlock amount should exceed locked tokens"
+        );
 
         // When: the user tries to unlock issuance tokens
         vm.prank(user);
-        vm.expectRevert(ILM_PC_HouseProtocol_v1.Module__LM_PC_HouseProtocol_InsufficientLockedTokens.selector);
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InsufficientLockedTokens
+                .selector
+        );
         lendingFacility.unlockIssuanceTokens(unlockAmount);
 
         // Then: the transaction should revert with InsufficientLockedTokens error
@@ -1184,40 +1294,34 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         return segments;
     }
 
-    function helper_getDynamicFeeCalculatorParams() internal pure returns (
-        uint Z_issueRedeem,
-        uint A_issueRedeem,
-        uint m_issueRedeem,
-        uint Z_origination,
-        uint A_origination,
-        uint m_origination
-    ) {
-        Z_issueRedeem = 1e16; // 1%
-        A_issueRedeem = 7.5e16; // 7.5%
-        m_issueRedeem = 2e15; // 0.2%
-        Z_origination = 1e16; // 1%
-        A_origination = 2e16; // 2%
-        m_origination = 2e15; // 0.2%
+    function helper_getDynamicFeeCalculatorParams()
+        internal
+        pure
+        returns (
+            ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory dynamicFeeParameters
+        )
+    {
+        dynamicFeeParameters = ILM_PC_HouseProtocol_v1.DynamicFeeParameters({
+            Z_issueRedeem: 1e16, // 1%
+            A_issueRedeem: 7.5e16, // 7.5%
+            m_issueRedeem: 2e15, // 0.2%
+            Z_origination: 1e16, // 1%
+            A_origination: 2e16, // 2%
+            m_origination: 2e15 // 0.2%
+        });
+        return dynamicFeeParameters;
     }
 
-    function helper_setDynamicFeeCalculatorParams() internal {
-        (
-            uint Z_issueRedeem,
-            uint A_issueRedeem,
-            uint m_issueRedeem,
-            uint Z_origination,
-            uint A_origination,
-            uint m_origination
-        ) = helper_getDynamicFeeCalculatorParams();
+    function helper_setDynamicFeeCalculatorParams()
+        internal
+        returns (
+            ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory dynamicFeeParameters
+        )
+    {
+        dynamicFeeParameters = helper_getDynamicFeeCalculatorParams();
 
-        lendingFacility.setDynamicFeeCalculatorParams(
-            Z_issueRedeem,
-            A_issueRedeem,
-            m_issueRedeem,
-            Z_origination,
-            A_origination,
-            m_origination
-        );
+        lendingFacility.setDynamicFeeCalculatorParams(dynamicFeeParameters);
+
+        return dynamicFeeParameters;
     }
 }
-    

--- a/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
@@ -832,12 +832,19 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         │   └── When setting new fee calculator parameters
         │       ├── Then the parameters should be updated
         │       └── Then an event should be emitted
+        └── Given invalid parameters (zero values)
+            └── When trying to set parameters
+                └── Then it should revert with InvalidDynamicFeeParameters error
         └── Given caller doesn't have role
             └── When trying to set parameters
     */
 
-    function test_setDynamicFeeCalculatorParams_unauthorized() public {
-        address unauthorizedUser = makeAddr("unauthorized");
+    function testFuzz_setDynamicFeeCalculatorParams_unauthorized(
+        address unauthorizedUser
+    ) public {
+        vm.assume(
+            unauthorizedUser != address(0) && unauthorizedUser != address(this)
+        );
 
         vm.startPrank(unauthorizedUser);
         vm.expectRevert(
@@ -853,9 +860,39 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         vm.stopPrank();
     }
 
-    function test_setDynamicFeeCalculatorParams() public {
-        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams =
-            helper_getDynamicFeeCalculatorParams();
+    function testFuzz_setDynamicFeeCalculatorParams_invalidParams(
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams
+    ) public {
+        vm.assume(
+            feeParams.Z_issueRedeem == 0 || feeParams.A_issueRedeem == 0
+                || feeParams.m_issueRedeem == 0 || feeParams.Z_origination == 0
+                || feeParams.A_origination == 0 || feeParams.m_origination == 0
+        );
+        vm.expectRevert(
+            ILM_PC_HouseProtocol_v1
+                .Module__LM_PC_HouseProtocol_InvalidDynamicFeeParameters
+                .selector
+        );
+        lendingFacility.setDynamicFeeCalculatorParams(feeParams);
+    }
+
+    function testFuzz_setDynamicFeeCalculatorParams(
+        ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory feeParams
+    ) public {
+        vm.assume(
+            feeParams.Z_issueRedeem != 0 && feeParams.A_issueRedeem != 0
+                && feeParams.m_issueRedeem != 0 && feeParams.Z_origination != 0
+                && feeParams.A_origination != 0 && feeParams.m_origination != 0
+        );
+        vm.assume(
+            feeParams.Z_issueRedeem < type(uint64).max
+                && feeParams.A_issueRedeem < type(uint64).max
+                && feeParams.m_issueRedeem < type(uint64).max
+                && feeParams.Z_origination < type(uint64).max
+                && feeParams.A_origination < type(uint64).max
+                && feeParams.m_origination < type(uint64).max
+        );
+
         lendingFacility.setDynamicFeeCalculatorParams(feeParams);
 
         ILM_PC_HouseProtocol_v1.DynamicFeeParameters memory LF_feeParams =

--- a/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
+++ b/test/unit/modules/logicModule/LM_PC_HouseProtocol_v1_Test.t.sol
@@ -73,11 +73,6 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
     // SuT
     LM_PC_HouseProtocol_v1_Exposed lendingFacility;
 
-    // Mocks
-    // ERC20Mock collateralToken;
-    // ERC20Mock issuanceToken;
-    // address dbcFmAddress;
-
     // Test constants
     uint constant BORROWABLE_QUOTA = 8000; // 80% in basis points
     uint constant INDIVIDUAL_BORROW_LIMIT = 500 ether;
@@ -201,13 +196,6 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
 
         _authorizer.setIsAuthorized(address(this), true);
         _authorizer.grantRole(_authorizer.getAdminRole(), address(this));
-
-        //    // Grant role to this test contract
-        // bytes32 roleId = _authorizer.generateRoleId(
-        //     address(lendingFacility),
-        //     lendingFacility.FEE_CALCULATOR_ADMIN_ROLE()
-        // );
-        // _authorizer.grantRole(roleId, address(this));
 
         defaultCurve.description = "Flat segment followed by a sloped segment";
         uint[] memory initialPrices = new uint[](2);
@@ -786,21 +774,36 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
                 unauthorizedUser
             )
         );
-        lendingFacility.setDynamicFeeCalculatorParams(
-            1e16, 2e16, 3e16, 4e16, 5e16, 6e16
-        );
+        (
+            uint Z_issueRedeem,
+            uint A_issueRedeem,
+            uint m_issueRedeem,
+            uint Z_origination,
+            uint A_origination,
+            uint m_origination
+        ) = helper_getDynamicFeeCalculatorParams();
+        lendingFacility.setDynamicFeeCalculatorParams(Z_issueRedeem, A_issueRedeem, m_issueRedeem, Z_origination, A_origination, m_origination);
         vm.stopPrank();
     }
 
     function test_setDynamicFeeCalculatorParams() public {
         helper_setDynamicFeeCalculatorParams();
 
-        // assertEq(lendingFacility.Z_issueRedeem(), Z_issueRedeem);
-        // assertEq(lendingFacility.A_issueRedeem(), A_issueRedeem);
-        // assertEq(lendingFacility.m_issueRedeem(), m_issueRedeem);
-        // assertEq(lendingFacility.Z_origination(), Z_origination);
-        // assertEq(lendingFacility.A_origination(), A_origination);
-        // assertEq(lendingFacility.m_origination(), m_origination);
+        (
+            uint Z_issueRedeem,
+            uint A_issueRedeem,
+            uint m_issueRedeem,
+            uint Z_origination,
+            uint A_origination,
+            uint m_origination
+        ) = helper_getDynamicFeeCalculatorParams();
+
+        assertEq(lendingFacility.Z_issueRedeem(), Z_issueRedeem);
+        assertEq(lendingFacility.A_issueRedeem(), A_issueRedeem);
+        assertEq(lendingFacility.m_issueRedeem(), m_issueRedeem);
+        assertEq(lendingFacility.Z_origination(), Z_origination);
+        assertEq(lendingFacility.A_origination(), A_origination);
+        assertEq(lendingFacility.m_origination(), m_origination);
     }
 
     // Test: Dynamic Fee Calculator Library
@@ -809,7 +812,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         ├── Given floorLiquidityRate is below A_origination
         │   └── Then the fee should be Z_origination
         └── Given floorLiquidityRate is above A_origination
-            └── Then the fee should be Z_origination + (floorLiquidityRate - A_origination) * m_origination / 1e18
+            └── Then the fee should be Z_origination + (floorLiquidityRate - A_origination) * m_origination / Sc
     */
     function test_calculateOriginationFee_BelowThreshold() public {
         helper_setDynamicFeeCalculatorParams();
@@ -844,7 +847,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         ├── Given premiumRate is below A_issueRedeem
         │   └── Then the fee should be Z_issueRedeem
         └── Given premiumRate is above A_issueRedeem
-            └── Then the fee should be Z_issueRedeem + (premiumRate - A_issueRedeem) * m_issueRedeem / 1e18
+            └── Then the fee should be Z_issueRedeem + (premiumRate - A_issueRedeem) * m_issueRedeem / SCALING_FACTOR
     */
     function test_calculateIssuanceFee_BelowThreshold() public {
         helper_setDynamicFeeCalculatorParams();
@@ -881,7 +884,7 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         ├── Given premiumRate is below A_issueRedeem
         │   └── Then the fee should be Z_issueRedeem
         └── Given premiumRate is above A_issueRedeem
-            └── Then the fee should be Z_issueRedeem + (A_issueRedeem - premiumRate) * m_issueRedeem / 1e18
+            └── Then the fee should be Z_issueRedeem + (A_issueRedeem - premiumRate) * m_issueRedeem / SCALING_FACTOR
     */
     function test_calculateRedemptionFee_BelowThreshold() public {
         helper_setDynamicFeeCalculatorParams();
@@ -1181,13 +1184,31 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         return segments;
     }
 
+    function helper_getDynamicFeeCalculatorParams() internal pure returns (
+        uint Z_issueRedeem,
+        uint A_issueRedeem,
+        uint m_issueRedeem,
+        uint Z_origination,
+        uint A_origination,
+        uint m_origination
+    ) {
+        Z_issueRedeem = 1e16; // 1%
+        A_issueRedeem = 7.5e16; // 7.5%
+        m_issueRedeem = 2e15; // 0.2%
+        Z_origination = 1e16; // 1%
+        A_origination = 2e16; // 2%
+        m_origination = 2e15; // 0.2%
+    }
+
     function helper_setDynamicFeeCalculatorParams() internal {
-        uint Z_issueRedeem = 1e16; // 1%
-        uint A_issueRedeem = 7.5e16; // 7.5%
-        uint m_issueRedeem = 2e15; // 0.2%
-        uint Z_origination = 1e16; // 1%
-        uint A_origination = 2e16; // 2%
-        uint m_origination = 2e15; // 0.2%
+        (
+            uint Z_issueRedeem,
+            uint A_issueRedeem,
+            uint m_issueRedeem,
+            uint Z_origination,
+            uint A_origination,
+            uint m_origination
+        ) = helper_getDynamicFeeCalculatorParams();
 
         lendingFacility.setDynamicFeeCalculatorParams(
             Z_issueRedeem,
@@ -1199,3 +1220,4 @@ contract LM_PC_HouseProtocol_v1_Test is ModuleTest {
         );
     }
 }
+    


### PR DESCRIPTION
## Dynamic Fee Calculator (DFC) Library

### Overview
Introduces a reusable fee-calculation library for utilization- and premium-based fees with deterministic, gas‑efficient pure functions and 1e18 fixed‑point precision.

### Files to be Reviewed
- `src/modules/logicModule/libraries/DynamicFeeCalculator_v1.sol`
*** Please ignore the LF files(LM_PC_HouseProtcol_v1.sol) and related tests*

### Core functions
- `calculateOriginationFee(utilizationRatio, Z_origination, A_origination, m_origination) -> uint`
  - Returns fee rate based on utilization proxy `utilizationRatio` with threshold `A_origination`, base `Z_origination`, slope `m_origination`.
- `calculateIssuanceFee(premiumRate, Z_issueRedeem, A_issueRedeem, m_issueRedeem) -> uint`
- `calculateRedemptionFee(premiumRate, Z_issueRedeem, A_issueRedeem, m_issueRedeem) -> uint`
- Constant: `SCALING_FACTOR = 1e18`

All rates and parameters are scaled by 1e18. Resulting fee rate is also 1e18‑scaled; convert to amount via `fee = amount * rate / 1e18`.

### Parameters
- Origination: `Z_origination` (base), `A_origination` (threshold), `m_origination` (slope)
- Issuance/Redemption: `Z_issueRedeem`, `A_issueRedeem`, `m_issueRedeem`

### Math Summary
- If signal < threshold: fee = base (`Z`)
- Else: fee = base + (signal − threshold) × slope / 1e18
- For redemption, the delta is inverted around the threshold.

### Safety and Constraints
- Pure functions; no state or external calls.
- 1e18 fixed‑point; callers must scale inputs/outputs consistently.
- Callers should validate parameter domains as needed (e.g., non‑zero or caps) and guard against overflows in upstream calculations.

### Integration Guide
- Utilization example (1e18‑scaled):
  - `util = currentlyBorrowedAmount * 1e18 / borrowCapacity`
  - `rate = calculateOriginationFee(util, Z, A, m)`
  - `feeAmount = principal * rate / 1e18`
- Premium‑based flows use `premiumRate` similarly.

### Testing
- Edge tests at/around thresholds `A` for all functions.
- Fuzz tests for domain: 0…1e18 signals and reasonable `Z/A/m` ranges.

### Documentation
- NatSpec on each function with scaling notes

Out of scope
- Lending facility logic is included in this PR however it is out of date and not up to specs. Please disregard the lending facility code which is located in LM_PC_HouseProtocol.