### PR TITLE
Fix: Repair unclaimable-payment recovery in PP_Queue_v1

### DIFF
--- a/src/modules/paymentProcessor/PP_Queue_v1.sol
+++ b/src/modules/paymentProcessor/PP_Queue_v1.sol
@@ -458,11 +458,10 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
         // Delete the field.
         delete _unclaimableAmountsForRecipient[client_][token_][receiver_];
 
-        // Transfer amount to treasury. Call has to succeed otherwise no state
-        // change.
-        IERC20(token_).safeTransferFrom(
-            address(this), _failedOrdersTreasury, amount
-        );
+        // Transfer amount to treasury. The module already holds these tokens
+        // (escrowed in `_tryPaymentTransfer`), so release them with
+        // `safeTransfer`. Call has to succeed otherwise no state change.
+        IERC20(token_).safeTransfer(_failedOrdersTreasury, amount);
 
         emit TokensReleased(receiver_, address(token_), amount);
         emit UnclaimableAmountClaimedToTreasury(
@@ -824,14 +823,20 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
         address token_,
         address paymentReceiver_
     ) internal virtual {
-        // Copy value over.
-        uint amount =
-            _unclaimableAmountsForRecipient[client_][token_][paymentReceiver_];
-        // Delete the field.
-        delete _unclaimableAmountsForRecipient[client_][token_][paymentReceiver_];
+        // Balance is keyed on the caller; `paymentReceiver_` is only the
+        // destination the funds are sent to.
+        address sender = _msgSender();
 
+        // Copy value over.
+        uint amount = _unclaimableAmountsForRecipient[client_][token_][sender];
+        // Delete the field.
+        delete _unclaimableAmountsForRecipient[client_][token_][sender];
+
+        // The module already holds these tokens (escrowed in
+        // `_tryPaymentTransfer`), so release them with `safeTransfer`.
+        // `amountPaid` is not called here: it was already called on escrow.
         // Call has to succeed otherwise no state change.
-        IERC20(token_).safeTransferFrom(address(this), paymentReceiver_, amount);
+        IERC20(token_).safeTransfer(paymentReceiver_, amount);
 
         emit TokensReleased(paymentReceiver_, address(token_), amount);
     }

--- a/test/unit/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/unit/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -2442,6 +2442,130 @@ contract PP_Queue_v1_Test is ModuleTest {
         }
     }
 
+    /* Test testClaimPreviouslyUnclaimable_ReleasesEscrowedFundsWithoutSelfApproval()
+        └── Given an escrowed unclaimable balance held by the module
+            └── When the recipient claims (module given NO self-allowance)
+                ├── Then the claim should succeed using safeTransfer.
+                └── Then the recipient should receive the full amount.
+    */
+    function testClaimPreviouslyUnclaimable_ReleasesEscrowedFundsWithoutSelfApproval(
+    ) public {
+        address recipient_ = makeAddr("recipient");
+        uint96 amount_ = 100;
+
+        // Escrow the funds in the module and record the unclaimable balance,
+        // keyed on the recipient. Deliberately NO `queue -> queue` approval is
+        // granted: a correct implementation uses safeTransfer and needs none.
+        _token.mint(address(queue), amount_);
+        queue.exposed_addUnclaimableOrder(
+            helper_createTestPaymentOrder(
+                recipient_, amount_, 1, address(_token)
+            ),
+            address(paymentClient)
+        );
+
+        vm.prank(recipient_);
+        queue.claimPreviouslyUnclaimable(
+            address(paymentClient), address(_token), recipient_
+        );
+
+        assertEq(
+            _token.balanceOf(recipient_),
+            amount_,
+            "Recipient should receive the escrowed tokens."
+        );
+        assertEq(
+            queue.unclaimable(
+                address(paymentClient), address(_token), recipient_
+            ),
+            0,
+            "Unclaimable balance should be cleared."
+        );
+    }
+
+    /* Test testClaimPreviouslyUnclaimable_PaysOutToReplacementReceiver()
+        └── Given a caller with an escrowed unclaimable balance
+            └── When the caller claims to a different receiver address
+                ├── Then the balance is keyed on the caller, not the receiver.
+                ├── Then the replacement receiver gets the funds.
+                └── Then the caller's unclaimable balance is cleared.
+    */
+    function testClaimPreviouslyUnclaimable_PaysOutToReplacementReceiver()
+        public
+    {
+        address caller_ = makeAddr("originalRecipient");
+        address replacement_ = makeAddr("replacementReceiver");
+        uint96 amount_ = 100;
+
+        // Escrow funds and record the unclaimable balance keyed on the caller.
+        _token.mint(address(queue), amount_);
+        queue.exposed_addUnclaimableOrder(
+            helper_createTestPaymentOrder(caller_, amount_, 1, address(_token)),
+            address(paymentClient)
+        );
+
+        // Caller claims, but routes the payout to a different address.
+        vm.prank(caller_);
+        queue.claimPreviouslyUnclaimable(
+            address(paymentClient), address(_token), replacement_
+        );
+
+        assertEq(
+            _token.balanceOf(replacement_),
+            amount_,
+            "Replacement receiver should get the funds."
+        );
+        assertEq(
+            _token.balanceOf(caller_), 0, "Caller should not receive the funds."
+        );
+        assertEq(
+            queue.unclaimable(
+                address(paymentClient), address(_token), caller_
+            ),
+            0,
+            "Caller's unclaimable balance should be cleared."
+        );
+    }
+
+    /* Test testClaimPreviouslyUnclaimableToTreasury_ReleasesEscrowedFundsWithoutSelfApproval()
+        └── Given an escrowed unclaimable balance held by the module
+            └── When an operator sweeps it to the failed-orders treasury (no self-allowance)
+                ├── Then the sweep should succeed using safeTransfer.
+                └── Then the treasury should receive the full amount.
+    */
+    function testClaimPreviouslyUnclaimableToTreasury_ReleasesEscrowedFundsWithoutSelfApproval(
+    ) public {
+        address recipient_ = makeAddr("recipient");
+        uint96 amount_ = 100;
+
+        // Escrow the funds in the module; again no `queue -> queue` approval.
+        _token.mint(address(queue), amount_);
+        queue.exposed_addUnclaimableOrder(
+            helper_createTestPaymentOrder(
+                recipient_, amount_, 1, address(_token)
+            ),
+            address(paymentClient)
+        );
+
+        vm.prank(address(this));
+        queue.claimPreviouslyUnclaimableToTreasury(
+            address(paymentClient), address(_token), recipient_
+        );
+
+        assertEq(
+            _token.balanceOf(queue.getFailedOrdersTreasury()),
+            amount_,
+            "Failed-orders treasury should receive the escrowed tokens."
+        );
+        assertEq(
+            queue.unclaimable(
+                address(paymentClient), address(_token), recipient_
+            ),
+            0,
+            "Unclaimable balance should be cleared."
+        );
+    }
+
     /* Test: Function executePaymentQueue()
         └── Given the number of orders in queue is greater than max orders per execution
             └── When the function executePaymentQueue() is called
@@ -4035,24 +4159,18 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
 
-        // Setup: give tokens to payment client and approve queue to spend them
-        helper_setupPaymentTokenBalanceAndApproval(amount, _token);
-
-        // Transfer tokens to the queue contract first (simulating failed payment flow)
-        vm.prank(address(paymentClient));
-        _token.transfer(address(queue), amount);
-
-        // Queue needs to approve itself to transfer its own tokens
-        vm.prank(address(queue));
-        _token.approve(address(queue), amount);
-
-        // Now add it as unclaimable
+        // The unclaimable balance is keyed on the caller. The internal call is
+        // made by this test contract (the exposed mock returns msg.sender from
+        // _msgSender()), so record the balance against address(this).
+        _token.mint(address(queue), amount);
         queue.exposed_addUnclaimableOrder(
-            helper_createTestPaymentOrder(recipient, amount, 1, address(_token)),
+            helper_createTestPaymentOrder(
+                address(this), amount, 1, address(_token)
+            ),
             address(paymentClient)
         );
 
-        // Try to claim
+        // Claim, paying out to a distinct recipient address.
         queue.exposed_claimPreviouslyUnclaimable(
             address(paymentClient), address(_token), recipient
         );


### PR DESCRIPTION
## Summary

Repairs the unclaimable-payment recovery paths in the queue payment processor. When a direct payment to a recipient fails (e.g. the recipient is blacklisted on a blacklistable ERC20), the processor escrows the tokens inside the module and records them under `_unclaimableAmountsForRecipient`. Both routes out of that escrow bucket were broken:

- **Wrong transfer primitive (both recovery paths).** `claimPreviouslyUnclaimable` and `claimPreviouslyUnclaimableToTreasury` released the escrowed tokens with `safeTransferFrom(address(this), dest, amount)`. For a standard ERC20 this spends `allowance[address(this)][address(this)]`, which is never set, so the call reverts. The module already holds the tokens (they were pulled into it on the failed-transfer path), so the correct primitive is `safeTransfer(dest, amount)`.
- **Wrong accounting key (user-claim path).** The public `claimPreviouslyUnclaimable` guarded on the caller's balance (`unclaimable(client, token, _msgSender())`) but the internal `_claimPreviouslyUnclaimable` read and deleted the slot of the passed `receiver_` argument. Claiming to a replacement receiver therefore passed the guard on the caller's slot while paying out from the replacement's empty slot, transferring nothing and leaving the original balance stranded. The internal function now keys on `_msgSender()` and uses the argument purely as the payout destination, matching the canonical `PP_Simple_v2`.

`PP_Queue_ManualExecution_v1` inherits these functions unchanged, so both deployed variants are fixed by this change. `amountPaid` is intentionally not re-called in recovery: the queue already settles client accounting when it escrows the funds, so a second call would double-count.

### Context

Reported privately by an external security researcher. No live funds are at risk today ($0 currently sits in the affected escrow bucket); the defect is latent and only bites once a payment lands in the failed-transfer fallback. The fix was independently verified by an agent review and a Codex second opinion.

### Changes

- `src/modules/paymentProcessor/PP_Queue_v1.sol`: `safeTransferFrom(address(this), ...)` to `safeTransfer(...)` in both recovery paths; key the internal user-claim on `_msgSender()`.
- `test/unit/modules/paymentProcessor/PP_Queue_v1.t.sol`: three regression tests covering both defects (each fails on the pre-fix code), plus an updated internal-claim test that no longer encodes the buggy behavior.

## Deployment Steps
⚠️ Manual deployment steps needed, this is a beacon-backed module upgrade and is not live until the multisig finalizes it on the target network.

This upgrades two separate module beacons: `PP_Queue_v1` and `PP_Queue_ManualExecution_v1`. Run every step once per module (substitute the module name).

* Step 1: Merge to the target branch and build the implementations.
  ```bash
  forge build
  ```
* Step 2: Deploy the new implementation deterministically. On mainnet the script deploys the implementation and then prints the beacon, implementation, version and governor addresses rather than touching the beacon (the beacon set is multisig-gated). Run once for each module, bumping the minor version.
  ```bash
  forge script script/utils/UpgradeModule.s.sol \
    "run(string,uint)" "PP_Queue_v1" 1 \
    --rpc-url "$RPC_URL" --broadcast

  forge script script/utils/UpgradeModule.s.sol \
    "run(string,uint)" "PP_Queue_ManualExecution_v1" 1 \
    --rpc-url "$RPC_URL" --broadcast
  ```
  Record the printed `beacon`, `implementation` and `version` (minor, patch) for each module.
* Step 3: From the community multisig, start the timelocked beacon upgrade on the Governor for each beacon, using the values from Step 2.
  ```
  Governor_v1.upgradeBeaconWithTimelock(
    beacon,            // printed in Step 2
    newImplementation, // printed in Step 2
    newMinorVersion,   // printed in Step 2
    newPatchVersion    // printed in Step 2
  )
  ```
* Step 4: Wait out the Governor timelock period, then from the same multisig finalize the upgrade for each beacon.
  ```
  Governor_v1.triggerUpgradeBeaconWithTimelock(beacon)
  ```
  If an immediate upgrade is required and authorized, the community multisig can instead call `forceUpgradeBeaconAndRestartImplementation(beacon, newImplementation, newMinorVersion, newPatchVersion)`, which skips the timelock.

After both beacons are upgraded, verify each `beacon.implementation()` matches the implementation from Step 2 and `beacon.version()` reports the new minor version.

## Test Plan

### Pre-merge checklist
- [ ] `forge build` succeeds
- [ ] `forge test --match-contract PP_Queue_v1_Test` passes
- [ ] `forge test --match-contract PP_Queue_ManualExecution_v1` passes
- [ ] New regression tests fail on the pre-fix code and pass on the fix

### Post-deployment verification
- On a mainnet fork or testnet, drive a payment into the failed-transfer escrow path and confirm `claimPreviouslyUnclaimable` releases the funds, including to a replacement receiver distinct from the caller.
- Confirm `claimPreviouslyUnclaimableToTreasury` sweeps an escrowed balance to the failed-orders treasury.
- After the multisig upgrade, confirm both beacons report the new implementation and version.
