### PR TITLE
Fix: Block blacklisted spender in blacklist issuance tokens

### DIFF
--- a/src/external/token/ERC20IssuanceUpgradeable_Blacklist_v1.sol
+++ b/src/external/token/ERC20IssuanceUpgradeable_Blacklist_v1.sol
@@ -229,6 +229,26 @@ contract ERC20IssuanceUpgradeable_Blacklist_v1 is
         super._update(from_, to_, amount_);
     }
 
+    /// @notice Internal hook to also block a blacklisted spender from moving
+    ///         tokens via an allowance.
+    /// @dev    The `_update` hook only sees `from` and `to`, so without this a
+    ///         blacklisted address holding an allowance could still spend it
+    ///         through `transferFrom` (or any allowance-based spend). Checking
+    ///         the spender here closes that path.
+    /// @param  owner_ Address the allowance is drawn from.
+    /// @param  spender_ Address spending the allowance.
+    /// @param  value_ Amount being spent.
+    function _spendAllowance(address owner_, address spender_, uint value_)
+        internal
+        virtual
+        override
+    {
+        if (isBlacklisted(spender_)) {
+            revert ERC20Issuance_Blacklist_BlacklistedAddress(spender_);
+        }
+        super._spendAllowance(owner_, spender_, value_);
+    }
+
     /// @notice Internal function to set a blacklist manager.
     /// @param  manager_ Address to set as blacklist manager.
     /// @param  allowed_ Whether to grant or revoke the blacklist manager role.

--- a/src/external/token/ERC20Issuance_Blacklist_v1.sol
+++ b/src/external/token/ERC20Issuance_Blacklist_v1.sol
@@ -222,6 +222,26 @@ contract ERC20Issuance_Blacklist_v1 is
         super._update(from_, to_, amount_);
     }
 
+    /// @notice Internal hook to also block a blacklisted spender from moving
+    ///         tokens via an allowance.
+    /// @dev    The `_update` hook only sees `from` and `to`, so without this a
+    ///         blacklisted address holding an allowance could still spend it
+    ///         through `transferFrom` (or any allowance-based spend). Checking
+    ///         the spender here closes that path.
+    /// @param  owner_ Address the allowance is drawn from.
+    /// @param  spender_ Address spending the allowance.
+    /// @param  value_ Amount being spent.
+    function _spendAllowance(address owner_, address spender_, uint value_)
+        internal
+        virtual
+        override
+    {
+        if (isBlacklisted(spender_)) {
+            revert ERC20Issuance_Blacklist_BlacklistedAddress(spender_);
+        }
+        super._spendAllowance(owner_, spender_, value_);
+    }
+
     /// @notice Internal function to set a blacklist manager.
     /// @param  manager_ Address to set as blacklist manager.
     /// @param  allowed_ Whether to grant or revoke the blacklist manager role.

--- a/test/unit/external/token/ERC20IssuanceUpgradeable_blacklist_v1.t.sol
+++ b/test/unit/external/token/ERC20IssuanceUpgradeable_blacklist_v1.t.sol
@@ -954,6 +954,66 @@ contract ERC20IssuanceUpgradeable_Blacklist_v1_Test is Test {
         );
     }
 
+    /*  Test: blacklisted spender via transferFrom
+        ├── Given a holder approved a spender and the spender is blacklisted
+        │   └── When transferFrom is called by the spender
+        │       └── Then it should revert with BlacklistedAddress(spender)
+        └── Given the spender is not blacklisted
+            └── When transferFrom is called by the spender
+                └── Then it should move the holder's tokens
+    */
+
+    function testTransferFrom_revertGivenSpenderIsBlacklisted(uint amount_)
+        public
+    {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+        address dest = makeAddr("dest");
+
+        _fundAddress(holder, amount_);
+        vm.prank(holder);
+        token.approve(spender, amount_);
+
+        // Blacklist the spender only. Holder and dest stay clean, so the
+        // `_update(from, to)` checks would pass; the spender check must catch it.
+        _blacklistAddress(spender);
+
+        vm.prank(spender);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Issuance_Blacklist_v1
+                    .ERC20Issuance_Blacklist_BlacklistedAddress
+                    .selector,
+                spender
+            )
+        );
+        token.transferFrom(holder, dest, amount_);
+
+        // Funds must not have moved.
+        assertEq(token.balanceOf(holder), amount_, "holder balance untouched");
+        assertEq(token.balanceOf(dest), 0, "dest received nothing");
+    }
+
+    function testTransferFrom_worksGivenSpenderIsNotBlacklisted(uint amount_)
+        public
+    {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+        address dest = makeAddr("dest");
+
+        _fundAddress(holder, amount_);
+        vm.prank(holder);
+        token.approve(spender, amount_);
+
+        vm.prank(spender);
+        token.transferFrom(holder, dest, amount_);
+
+        assertEq(token.balanceOf(holder), 0, "holder fully spent");
+        assertEq(token.balanceOf(dest), amount_, "dest received funds");
+    }
+
     // ================================================================================
     // Helper Functions
 

--- a/test/unit/external/token/ERC20IssuanceUpgradeable_blacklist_v1.t.sol
+++ b/test/unit/external/token/ERC20IssuanceUpgradeable_blacklist_v1.t.sol
@@ -1014,6 +1014,88 @@ contract ERC20IssuanceUpgradeable_Blacklist_v1_Test is Test {
         assertEq(token.balanceOf(dest), amount_, "dest received funds");
     }
 
+    // The blacklist check runs before OZ's infinite-allowance short-circuit,
+    // so an unlimited approval to a blacklisted spender is still blocked.
+    function testTransferFrom_revertGivenBlacklistedSpenderWithInfiniteAllowance(
+        uint amount_
+    ) public {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+        address dest = makeAddr("dest");
+
+        _fundAddress(holder, amount_);
+        vm.prank(holder);
+        token.approve(spender, type(uint).max);
+
+        _blacklistAddress(spender);
+
+        vm.prank(spender);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Issuance_Blacklist_v1
+                    .ERC20Issuance_Blacklist_BlacklistedAddress
+                    .selector,
+                spender
+            )
+        );
+        token.transferFrom(holder, dest, amount_);
+
+        assertEq(token.balanceOf(holder), amount_, "holder balance untouched");
+        assertEq(token.balanceOf(dest), 0, "dest received nothing");
+    }
+
+    /*  Test: minter spendAllowance wrapper also goes through the spender check
+        ├── Given the spender is blacklisted
+        │   └── When the minter calls spendAllowance()
+        │       └── Then it should revert with BlacklistedAddress(spender)
+        └── Given the spender is not blacklisted
+            └── When the minter calls spendAllowance()
+                └── Then it should consume the allowance
+    */
+
+    function testSpendAllowanceWrapper_revertGivenSpenderIsBlacklisted(
+        uint amount_
+    ) public {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+
+        vm.prank(holder);
+        token.approve(spender, amount_);
+        _blacklistAddress(spender);
+
+        // Caller is the test contract, which is the minter (set in setUp).
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Issuance_Blacklist_v1
+                    .ERC20Issuance_Blacklist_BlacklistedAddress
+                    .selector,
+                spender
+            )
+        );
+        token.spendAllowance(holder, spender, amount_);
+
+        assertEq(
+            token.allowance(holder, spender), amount_, "allowance untouched"
+        );
+    }
+
+    function testSpendAllowanceWrapper_worksGivenSpenderIsNotBlacklisted(
+        uint amount_
+    ) public {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+
+        vm.prank(holder);
+        token.approve(spender, amount_);
+
+        token.spendAllowance(holder, spender, amount_);
+
+        assertEq(token.allowance(holder, spender), 0, "allowance consumed");
+    }
+
     // ================================================================================
     // Helper Functions
 

--- a/test/unit/external/token/ERC20Issuance_blacklist_v1.t.sol
+++ b/test/unit/external/token/ERC20Issuance_blacklist_v1.t.sol
@@ -917,6 +917,66 @@ contract ERC20Issuance_Blacklist_v1_Test is Test {
         );
     }
 
+    /*  Test: blacklisted spender via transferFrom
+        ├── Given a holder approved a spender and the spender is blacklisted
+        │   └── When transferFrom is called by the spender
+        │       └── Then it should revert with BlacklistedAddress(spender)
+        └── Given the spender is not blacklisted
+            └── When transferFrom is called by the spender
+                └── Then it should move the holder's tokens
+    */
+
+    function testTransferFrom_revertGivenSpenderIsBlacklisted(uint amount_)
+        public
+    {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+        address dest = makeAddr("dest");
+
+        _fundAddress(holder, amount_);
+        vm.prank(holder);
+        token.approve(spender, amount_);
+
+        // Blacklist the spender only. Holder and dest stay clean, so the
+        // `_update(from, to)` checks would pass; the spender check must catch it.
+        _blacklistAddress(spender);
+
+        vm.prank(spender);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Issuance_Blacklist_v1
+                    .ERC20Issuance_Blacklist_BlacklistedAddress
+                    .selector,
+                spender
+            )
+        );
+        token.transferFrom(holder, dest, amount_);
+
+        // Funds must not have moved.
+        assertEq(token.balanceOf(holder), amount_, "holder balance untouched");
+        assertEq(token.balanceOf(dest), 0, "dest received nothing");
+    }
+
+    function testTransferFrom_worksGivenSpenderIsNotBlacklisted(uint amount_)
+        public
+    {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+        address dest = makeAddr("dest");
+
+        _fundAddress(holder, amount_);
+        vm.prank(holder);
+        token.approve(spender, amount_);
+
+        vm.prank(spender);
+        token.transferFrom(holder, dest, amount_);
+
+        assertEq(token.balanceOf(holder), 0, "holder fully spent");
+        assertEq(token.balanceOf(dest), amount_, "dest received funds");
+    }
+
     // ================================================================================
     // Helper Functions
 

--- a/test/unit/external/token/ERC20Issuance_blacklist_v1.t.sol
+++ b/test/unit/external/token/ERC20Issuance_blacklist_v1.t.sol
@@ -977,6 +977,88 @@ contract ERC20Issuance_Blacklist_v1_Test is Test {
         assertEq(token.balanceOf(dest), amount_, "dest received funds");
     }
 
+    // The blacklist check runs before OZ's infinite-allowance short-circuit,
+    // so an unlimited approval to a blacklisted spender is still blocked.
+    function testTransferFrom_revertGivenBlacklistedSpenderWithInfiniteAllowance(
+        uint amount_
+    ) public {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+        address dest = makeAddr("dest");
+
+        _fundAddress(holder, amount_);
+        vm.prank(holder);
+        token.approve(spender, type(uint).max);
+
+        _blacklistAddress(spender);
+
+        vm.prank(spender);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Issuance_Blacklist_v1
+                    .ERC20Issuance_Blacklist_BlacklistedAddress
+                    .selector,
+                spender
+            )
+        );
+        token.transferFrom(holder, dest, amount_);
+
+        assertEq(token.balanceOf(holder), amount_, "holder balance untouched");
+        assertEq(token.balanceOf(dest), 0, "dest received nothing");
+    }
+
+    /*  Test: minter spendAllowance wrapper also goes through the spender check
+        ├── Given the spender is blacklisted
+        │   └── When the minter calls spendAllowance()
+        │       └── Then it should revert with BlacklistedAddress(spender)
+        └── Given the spender is not blacklisted
+            └── When the minter calls spendAllowance()
+                └── Then it should consume the allowance
+    */
+
+    function testSpendAllowanceWrapper_revertGivenSpenderIsBlacklisted(
+        uint amount_
+    ) public {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+
+        vm.prank(holder);
+        token.approve(spender, amount_);
+        _blacklistAddress(spender);
+
+        // Caller is the test contract, which is the minter (set in setUp).
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Issuance_Blacklist_v1
+                    .ERC20Issuance_Blacklist_BlacklistedAddress
+                    .selector,
+                spender
+            )
+        );
+        token.spendAllowance(holder, spender, amount_);
+
+        assertEq(
+            token.allowance(holder, spender), amount_, "allowance untouched"
+        );
+    }
+
+    function testSpendAllowanceWrapper_worksGivenSpenderIsNotBlacklisted(
+        uint amount_
+    ) public {
+        amount_ = bound(amount_, 1, uint(type(uint).max - 1));
+        address holder = makeAddr("holder");
+        address spender = makeAddr("spender");
+
+        vm.prank(holder);
+        token.approve(spender, amount_);
+
+        token.spendAllowance(holder, spender, amount_);
+
+        assertEq(token.allowance(holder, spender), 0, "allowance consumed");
+    }
+
     // ================================================================================
     // Helper Functions
 


### PR DESCRIPTION
## Summary

Closes a completeness gap in the blacklist on our two blacklist issuance tokens, `ERC20IssuanceUpgradeable_Blacklist_v1` and `ERC20Issuance_Blacklist_v1`.

The blacklist was enforced only in the `_update(from, to, amount)` hook, which sees the sender and the receiver but never the spender. OpenZeppelin's `transferFrom` runs `_spendAllowance(owner, spender, value)` and then `_update(owner, to, value)`, so a blacklisted address holding a live allowance could still call `transferFrom` and move a non-blacklisted holder's tokens to a fresh address. The blacklist did not cover the spender/operator, unlike canonical blacklist stablecoins which also gate the spender in the allowance path.

### Fix

Override `_spendAllowance` in both contracts to revert when the spender is blacklisted, then delegate to `super`:

```solidity
function _spendAllowance(address owner_, address spender_, uint value_)
    internal
    virtual
    override
{
    if (isBlacklisted(spender_)) {
        revert ERC20Issuance_Blacklist_BlacklistedAddress(spender_);
    }
    super._spendAllowance(owner_, spender_, value_);
}
```

`_spendAllowance` is the single internal chokepoint for every allowance-consuming path (`transferFrom` and the minter `spendAllowance` wrapper), so one override covers them all. The check runs before OpenZeppelin's infinite-allowance short-circuit, so an unlimited approval to a blacklisted spender is blocked too. The change is logic-only with no storage added or reordered, so it is safe for the upgradeable variant behind its proxy.

`approve` is intentionally not gated: allowing an approval to a blacklisted spender is harmless once the spend itself is blocked. Gating it would be optional defense-in-depth, out of scope here.

### Severity

Reported privately by an external security researcher. Low severity and bounded: it only reaches funds where an allowance already exists, the holder must not be blacklisted (a blacklisted holder's own balance stays frozen), and arbitrary holders cannot be touched. No funds are currently at risk. The value is restoring the blacklist as a complete freeze, including the case where a blacklisted contract holds allowances and you are blacklisting it to contain an incident.

### Changes

- `src/external/token/ERC20IssuanceUpgradeable_Blacklist_v1.sol`: add `_spendAllowance` override.
- `src/external/token/ERC20Issuance_Blacklist_v1.sol`: add `_spendAllowance` override.
- Regression tests in both token test suites: a blacklisted spender's `transferFrom` reverts and moves nothing, a clean spender's `transferFrom` still works. Both revert tests fail on the pre-fix code.

## Deployment Steps
⚠️ Manual deployment steps needed. These tokens are deployed as `TransparentUpgradeableProxy` instances, so this is a proxy implementation upgrade, not a Governor beacon upgrade, and it is not live on any instance until each proxy is upgraded.

* Step 1: Compile an inventory of the deployed instances of the affected token type (open item below) so every live proxy is covered.
* Step 2: Deploy the new implementation of the affected token contract(s).
  ```bash
  forge build
  # deploy ERC20IssuanceUpgradeable_Blacklist_v1 (and ERC20Issuance_Blacklist_v1 if any
  # non-upgradeable instances need replacing) and verify the implementation on the explorer
  ```
* Step 3: For each deployed proxy instance, the controlling `ProxyAdmin` owner upgrades it to the new implementation. No reinitialization is needed (logic-only change).
  ```
  ProxyAdmin.upgradeAndCall(proxy, newImplementation, "")
  ```
* Step 4: The proxies are per-instance and may be controlled by different admin owners than the core protocol, so rollout is coordinated with each instance's admin owner rather than executed centrally.

After each upgrade, verify the proxy's implementation slot points to the new implementation and that a blacklisted-spender `transferFrom` reverts on the live instance.

Open item: there is no single factory registry for these tokens (they are deployed per workflow), so the full inventory of live instances must be assembled before rollout is considered complete.

## Test Plan

### Pre-merge checklist
- [ ] `forge build` succeeds
- [ ] `forge test --match-contract Blacklist_v1_Test` passes (both token suites)
- [ ] New regression tests fail on the pre-fix code and pass on the fix

### Post-deployment verification
- On each upgraded proxy, confirm the implementation slot points to the new implementation.
- On a live instance, confirm a blacklisted spender's `transferFrom` reverts and a clean spender's still succeeds.
